### PR TITLE
lint git commits

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,12 @@
+const config = {
+    extends: ['@commitlint/config-conventional'],
+    "rules": {
+        'body-case': [0],
+        'body-max-line-length': [0],
+        'footer-empty': [0],
+        'references-empty': [0],
+        'signed-off-by': [0],
+    },
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
     ".": "./source/chart.js"
   },
   "scripts": {
-    "build": "esbuild --bundle --format=esm --outfile=build/charts.js source/chart.js"
+    "build": "esbuild --bundle --format=esm --outfile=build/charts.js source/chart.js",
+    "lint-git": "commitlint -- --to=HEAD"
   },
   "devDependencies": {
+    "@commitlint/cli": "^17.0.2",
+    "@commitlint/config-conventional": "^17.0.2",
     "esbuild": "^0.14.43"
   },
   "dependencies": {


### PR DESCRIPTION
Start linting the git history right away in order to keep all future development clean.