### PR TITLE
type checking fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint-git": "commitlint -- --to=HEAD",
     "lint-js": "eslint source tests",
     "test": "qunit tests/*",
-    "types": "tsc --noEmit --allowJs --checkJs ./source/chart.js"
+    "types": "tsc --noEmit --allowJs --checkJs --target ES2022 ./source/chart.js"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint-git": "commitlint -- --to=HEAD",
     "lint-js": "eslint source tests",
     "test": "qunit tests/*",
-    "types": "tsc --noEmit --allowJs --checkJs --target ES2022 ./source/chart.js"
+    "types": "tsc --noEmit --allowJs --checkJs --moduleResolution node --target ES2022 ./source/chart.js"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.2",

--- a/source/data.js
+++ b/source/data.js
@@ -387,7 +387,7 @@ const pointData = identity;
 
 /**
  * wrapper function around data preprocessing functionality
- * @param {s} s Vega Lite specification
+ * @param {object} s Vega Lite specification
  * @returns {array} sorted and aggregated data
  */
 const data = (s) => {

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -149,6 +149,11 @@ const interactions = (_s) => {
           d3.select(target).raise();
           d3.select(target).attr('data-highlight', true);
 
+          // the .focus() method is not officially supported on SVG
+          // elements per the formal specification, but informally
+          // it works
+
+          // @ts-ignore
           active.focus();
         });
 

--- a/source/marks.js
+++ b/source/marks.js
@@ -29,7 +29,7 @@ const markData = (s) => {
   if (series) {
     return data(s).map((item) => item.sort(sortMarkData(s)));
   } else {
-    return data(s).sort(sortMarkData(s));
+    return data(s).sort((a, b) => sortMarkData(s)(a, b));
   }
 };
 

--- a/source/position.js
+++ b/source/position.js
@@ -50,7 +50,6 @@ const tickMargin = (s, dimensions) => {
 /**
  * compute margin for a Cartesian chart
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
  * @returns {object} D3 margin convention object
  */
 const titleMargin = (s) => {

--- a/source/sort.js
+++ b/source/sort.js
@@ -172,7 +172,7 @@ const sortMarkData = (s) => {
   const channel = Object.entries(s.encoding).find(([, channel]) => channel.sort)?.[0];
 
   if (!channel) {
-    return sortNone;
+    return sortNone();
   } else {
     const raw = values(s);
     const order = raw.map(encodingValue(s, channel)).sort(sorter(s, channel));
@@ -223,7 +223,7 @@ const selectComparator = (s, channel) => {
   } else if (isDescending(s, channel)) {
     return descending;
   } else {
-    return sortNone;
+    return sortNone();
   }
 };
 
@@ -315,7 +315,7 @@ const sortByArray = (s, channel) => {
  * null sort comparator
  * @returns {function} noop sort comparator function
  */
-const sortNone = () => 0;
+const sortNone = () => () => 0;
 
 /**
  * create sort comparator function
@@ -334,7 +334,7 @@ const _sorter = (s, channel) => {
     } else if (selectSorter(s, channel) === 'natural') {
       return sortNatural(s, channel);
     } else if (selectSorter(s, channel) === 'none') {
-      return sortNone;
+      return sortNone();
     }
   } catch (error) {
     const sort = s.encoding[channel]?.sort;

--- a/source/sort.js
+++ b/source/sort.js
@@ -244,7 +244,7 @@ const sortNatural = (s, channel) => {
 /**
  * field sort comparator
  * @param {object} s Vega Lite specification
- * @param {string} field encoding channel
+ * @param {string} channel encoding channel
  * @returns {function} field sort comparator function
  */
 const sortByField = (s, channel) => {
@@ -294,7 +294,7 @@ const sortByChannel = (s, channel) => {
 /**
  * array sort comparator
  * @param {object} s Vega Lite specification
- * @param {string} field encoding channel
+ * @param {string} channel encoding channel
  * @returns {function} array sort comparator function
  */
 const sortByArray = (s, channel) => {

--- a/source/sort.js
+++ b/source/sort.js
@@ -166,7 +166,7 @@ const valuesToSort = (s, channel) => {
  * @param {object} s Vega Lite specification
  * @returns {function} sort comparator function
  */
-const sortMarkData = (s) => {
+const _sortMarkData = (s) => {
   // just select the first matching encoding because
   // multidimensional sort doesn't work at the mark level
   const channel = Object.entries(s.encoding).find(([, channel]) => channel.sort)?.[0];
@@ -183,6 +183,7 @@ const sortMarkData = (s) => {
     };
   }
 };
+const sortMarkData = memoize(_sortMarkData);
 
 /**
  * select sort comparator function

--- a/source/text.js
+++ b/source/text.js
@@ -148,7 +148,7 @@ const truncate = memoize(_truncate);
  * @param {'x'|'y'} channel axis dimension
  * @param {string} textContent text to process
  * @param {array} [styles] styles to incorporate when measuring text width
- * @returns {function} text processing function
+ * @returns {string} text processing function
  */
 const _axisTickLabelTextContent = (s, channel, textContent, styles) => {
   let text = textContent;


### PR DESCRIPTION
Various fixes to satisfy TypeScript. There's still one error due to the missing `matchAll` regex implementation.