### PR TITLE
add matchAll shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typescript": "^4.7.3"
   },
   "dependencies": {
-    "d3": "^7.4.4"
+    "d3": "^7.4.4",
+    "string.prototype.matchall": "^4.0.7"
   }
 }

--- a/source/time.js
+++ b/source/time.js
@@ -1,6 +1,7 @@
 import * as d3 from 'd3';
 import { encodingValue } from './encodings.js';
 import { memoize } from './memoize.js';
+import matchAll from 'string.prototype.matchall';
 
 const UTC = 'utc';
 const TIME = 'time';
@@ -104,7 +105,7 @@ const findTimePeriod = new RegExp(`(?:${TIME}|${UTC})(\\w+)`, 'gi');
  * @returns {string} camelcased time specifier string
  */
 const camelCaseTimePeriod = (timeSpecifier) => {
-  let matches = matchAll(findTimePeriod, timeSpecifier);
+  let matches = [...matchAll(timeSpecifier, findTimePeriod)];
 
   if (!matches.length) {
     return timeSpecifier;


### PR DESCRIPTION
Adds a third-party dependency which provides a working shim for the `String.prototype.matchAll()` method. (This can probably be removed eventually.)