### PR TITLE
decrease version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bisonica",
-  "version": "0.9.5",
+  "version": "0.1.0",
   "type": "module",
   "exports": {
     ".": "./source/chart.js"


### PR DESCRIPTION
There are some mistakes in the interpretation of the Vega Lite specification that I'd hoped to immediately correct, which is why I set the version number to almost-but-not-quite 1.0. Now it looks like other things may take priority first, so let's back this down. We'll get there when we get there.