### PR TITLE
default argument for scale dimensions

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -41,7 +41,7 @@ const ticks = (s, channel) => {
     }
   }
 
-  const scales = parseScales(s, { x: 0, y: 0 });
+  const scales = parseScales(s);
 
   const hasSingleValue = scales[channel].domain()[0] === scales[channel].domain()[1];
 

--- a/source/legend.js
+++ b/source/legend.js
@@ -50,7 +50,7 @@ const color = (_s) => {
 
   const renderer = (selection) => {
     try {
-      const { color } = parseScales(s, { x: 0, y: 0 });
+      const { color } = parseScales(s);
 
       const dispatcher = dispatchers.get(selection.node());
 

--- a/source/marks.js
+++ b/source/marks.js
@@ -376,7 +376,7 @@ const circularMarks = (s, dimensions) => {
   const outerRadius = radius(dimensions);
   const innerRadiusRatio = s.mark?.innerRadius ? s.mark.innerRadius / 100 : 0;
   const innerRadius = outerRadius * innerRadiusRatio;
-  const { color } = parseScales(s, { x: 0, y: 0 });
+  const { color } = parseScales(s);
   const sort = (a, b) => color.domain().indexOf(a.group) - color.domain().indexOf(b.group);
   const layout = d3.pie().value(encodingValueQuantitative(s)).sort(sort);
   const encoders = createEncoders(s, dimensions, createAccessors(s));

--- a/source/scales.js
+++ b/source/scales.js
@@ -319,7 +319,7 @@ const extendScales = (s, dimensions, scales) => {
   return extendedScales;
 };
 
-const _parseScales = (s, dimensions) => {
+const _parseScales = (s, dimensions = { x: 0, y: 0 }) => {
   const core = coreScales(s, dimensions);
   const extended = extendScales(s, dimensions, core);
 
@@ -329,7 +329,7 @@ const _parseScales = (s, dimensions) => {
 /**
  * generate all scale functions necessary to render a s
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {object} [dimensions] chart dimensions
  * @returns {object} hash of all necessary d3 scale functions
  */
 const parseScales = memoize(_parseScales);

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -61,7 +61,7 @@ function tooltipEvent(s, node, interaction) {
     const detail = { datum, node, interaction, content: tooltipContentData(s)(datum) };
 
     if (feature(s).isMulticolor()) {
-      detail.color = parseScales(s, { x: 0, y: 0 }).color(category.get(datum));
+      detail.color = parseScales(s).color(category.get(datum));
     }
 
     const customEvent = new CustomEvent('tooltip', {

--- a/source/views.js
+++ b/source/views.js
@@ -65,7 +65,7 @@ const unionDomains = (s, channel) => {
         }
       }
 
-      return parseScales(layer, { x: 0, y: 0 })[channel];
+      return parseScales(layer)[channel];
     })
     .filter((item) => !!item);
 

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -179,7 +179,7 @@ module('unit > scales', (hooks) => {
         },
       },
     };
-    const { x, y, color } = parseScales(s, { x: 0, y: 0 });
+    const { x, y, color } = parseScales(s);
 
     assert.equal(x.domain()[0].getTime(), parseTime(s.encoding.x.scale.domain[0]).getTime());
     assert.equal(x.domain()[1].getTime(), parseTime(s.encoding.x.scale.domain[1]).getTime());
@@ -204,7 +204,7 @@ module('unit > scales', (hooks) => {
         },
       },
     };
-    const { color } = parseScales(s, { x: 0, y: 0 });
+    const { color } = parseScales(s);
 
     assert.equal(color.range().length, domain.length);
   });
@@ -217,7 +217,7 @@ module('unit > scales', (hooks) => {
         },
       },
     };
-    const { size } = parseScales(s, { x: 0, y: 0 });
+    const { size } = parseScales(s);
 
     assert.equal(typeof size, 'function');
     assert.equal(size(), s.encoding.size.value);
@@ -239,7 +239,7 @@ module('unit > scales', (hooks) => {
         },
       },
     };
-    const { x } = parseScales(s, { x: 0, y: 0 });
+    const { x } = parseScales(s);
 
     assert.equal(typeof x, 'function');
     x.domain().forEach((date) => {
@@ -264,7 +264,7 @@ module('unit > scales', (hooks) => {
         },
       },
     };
-    const { x } = parseScales(s, { x: 0, y: 0 });
+    const { x } = parseScales(s);
 
     assert.equal(typeof x, 'function');
     x.domain().forEach((date) => {


### PR DESCRIPTION
Objects are memoized by reference, so setting a dimensions object as an optional default argument instead of having the callers supply an equivalent object will more effectively tap into memoization and reuse the result of `parseScales()`.