### PR TITLE
improve memoization of higher-order functions

### DIFF
--- a/source/memoize.js
+++ b/source/memoize.js
@@ -10,11 +10,17 @@ const argumentKey = (arg) => {
 
   if (type === 'undefined' || arg === null) {
     key = `${arg}`;
+  } else if (type === 'function') {
+    key = 'function';
+  } else if (type === 'object') {
+    key = 'object';
   } else {
     key = arg.toString();
   }
 
-  if (key !== '[object Object]') {
+  const primitive = type !== 'object' && type !== 'function';
+
+  if (primitive) {
     return key;
   }
 

--- a/tests/unit/memoize-test.js
+++ b/tests/unit/memoize-test.js
@@ -28,4 +28,41 @@ module('unit > memoize', () => {
     assert.notEqual(memoized(1, 2), memoized(2, 3));
     assert.equal(memoized(2, 3), memoized(2, 3));
   });
+
+  test('memoizes functions with enclosing scopes', (assert) => {
+    let a, b, c;
+
+    // create scopes with anonymous functions
+
+    (() => {
+      const value = 'apple'
+      a = () => value;
+    })();
+    
+    (() => {
+      const value = 'banana';
+      b = () => value;
+    })();
+
+    (() => {
+      const value = 'cherry';
+      c = () => value;
+    })();
+
+    const _eat = (fn) => {
+      return `delicious ${fn()}`;
+    }
+
+    const eat = memoize(_eat);
+
+    assert.equal(a(), 'apple');
+    assert.equal(b(), 'banana');
+    assert.equal(c(), 'cherry');
+
+    assert.equal(eat(a), 'delicious apple');
+    assert.equal(eat(b), 'delicious banana');
+    assert.equal(eat(c), 'delicious cherry');
+
+  });
+
 });


### PR DESCRIPTION
Cleans up memoization and corrects an error in which functions supplied as arguments were memoized according to the string resulting from `Function.prototype.toString()` instead of as memory references which also capture the surrounding closures.