### PR TITLE
add styles export

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,18 @@ select('div').call(renderer);
 
 You'll probably want to load the included stylesheet? Feel free to use your own alternative if you want, though.
 
+You can load it directly:
+
 ```html
 <head>
     <link rel="stylesheet" href="./source/index.css" />
 </head>
+```
+
+Or import with a packager or build tool:
+
+```javascript
+import "bisonica/styles.css";
 ```
 
 # Why?

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "exports": {
-    ".": "./source/chart.js"
+    ".": "./source/chart.js",
+    "./styles.css": "./source/index.css"
   },
   "scripts": {
     "build": "esbuild --bundle --format=esm --outfile=build/charts.js source/chart.js",


### PR DESCRIPTION
Add an alias for the CSS to `package.json` to make it easier to import with build tooling.