### PR TITLE
horizontal bar charts and flexible bidirectional encodings

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -1,5 +1,5 @@
 import { barDirection } from './marks.js';
-import { encodingField, encodingFieldQuantitative, encodingValue } from './encodings.js';
+import { encodingChannelQuantitative, encodingField, encodingValue } from './encodings.js';
 import { feature } from './feature.js';
 import { mark } from './helpers.js';
 import { memoize } from './memoize.js';
@@ -53,7 +53,7 @@ const _createAccessors = (s, type = null) => {
   }
 
   if (key === 'arc') {
-    accessors.theta = (d) => encodingValue(s, encodingFieldQuantitative(s))(d);
+    accessors.theta = (d) => encodingValue(s, encodingChannelQuantitative(s))(d);
     accessors.color = (d) => d.data.key;
   }
 

--- a/source/accessors.js
+++ b/source/accessors.js
@@ -1,3 +1,4 @@
+import { barDirection } from './marks.js';
 import { encodingField, encodingFieldQuantitative, encodingValue } from './encodings.js';
 import { feature } from './feature.js';
 import { mark } from './helpers.js';
@@ -33,8 +34,17 @@ const _createAccessors = (s, type = null) => {
   }
 
   if (key === 'bar') {
-    accessors.y = (d) => d[0];
-    accessors.x = (d) => d.data.key;
+    const start = (d) => d[0];
+    const lane = (d) => d.data.key;
+
+    if (barDirection(s) === 'horizontal') {
+      accessors.y = lane;
+      accessors.x = start;
+    } else if (barDirection(s) === 'vertical') {
+      accessors.y = start;
+      accessors.x = lane;
+    }
+
     accessors.barStart = (d) => (d[1] ? d : [d[0], d[0]]);
 
     accessors.barLength = (d) => {

--- a/source/axes.js
+++ b/source/axes.js
@@ -3,7 +3,7 @@ import * as d3 from 'd3';
 import { axisTickLabelText, rotation } from './text.js';
 import { barWidth } from './marks.js';
 import { degrees, isDiscrete, noop, overlap } from './helpers.js';
-import { encodingType } from './encodings.js';
+import { encodingField, encodingChannelQuantitative, encodingType } from './encodings.js';
 import { feature } from './feature.js';
 import { layerMatch } from './views.js';
 import { parseScales } from './scales.js';

--- a/source/axes.js
+++ b/source/axes.js
@@ -3,7 +3,7 @@ import * as d3 from 'd3';
 import { axisTickLabelText, rotation } from './text.js';
 import { barWidth } from './marks.js';
 import { degrees, isDiscrete, noop, overlap } from './helpers.js';
-import { encodingField, encodingChannelQuantitative, encodingType } from './encodings.js';
+import { encodingChannelQuantitative, encodingType } from './encodings.js';
 import { feature } from './feature.js';
 import { layerMatch } from './views.js';
 import { parseScales } from './scales.js';
@@ -252,7 +252,7 @@ const y = (s, dimensions) => {
     }
 
     // extend y axis ticks across the whole chart
-    if (feature(s).isBar() || feature(s).isLine()) {
+    if ((feature(s).isBar() || feature(s).isLine()) && encodingChannelQuantitative(s) === 'y') {
       selection
         .select('.y .axis')
         .selectAll('.tick')

--- a/source/axes.js
+++ b/source/axes.js
@@ -172,7 +172,10 @@ const x = (s, dimensions) => {
       let yOffset;
 
       if (scales.y) {
-        yOffset = isDiscrete(s, 'y') ? scales.y.range().pop() : scales.y.range()[0];
+        yOffset =
+          isDiscrete(s, 'y') || encodingType(s, 'y') === 'temporal'
+            ? scales.y.range().pop()
+            : scales.y.range()[0];
       } else {
         yOffset = 0;
       }

--- a/source/data.js
+++ b/source/data.js
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 
+import { barDirection } from './marks.js';
 import { encodingField, encodingType, encodingValue } from './encodings.js';
 import { feature } from './feature.js';
 import { identity, missingSeries, values } from './helpers.js';
@@ -208,12 +209,13 @@ const transplantStackedBarMetadata = (aggregated, raw, s) => {
 const stackValue = (d, key) => d[key]?.value || 0;
 
 const _stackedBarData = (s) => {
-  const summed = groupAndSumByProperties(
-    values(s),
-    encodingField(s, 'x'),
-    encodingField(s, 'color'),
-    encodingField(s, 'y'),
-  );
+  const dimensions = ['x', 'y'];
+
+  if (barDirection(s) === 'horizontal') {
+    dimensions.reverse();
+  }
+
+  const summed = groupAndSumByProperties(values(s), encodingField(s, dimensions[0]), encodingField(s, 'color'), encodingField(s, dimensions[1]));
   const stacker = d3.stack().keys(stackKeys).value(stackValue);
   const stacked = stacker(summed);
 

--- a/source/data.js
+++ b/source/data.js
@@ -82,7 +82,7 @@ const stackKeys = (data) => {
  * @param {object} s Vega Lite specification
  * @returns {array} values summed across time period
  */
-const sumByPeriod = (s) => {
+const sumByCovariates = (s) => {
   const x = encodingField(s, 'x');
   const y = encodingField(s, 'y');
   const color = encodingField(s, 'color');
@@ -408,4 +408,4 @@ const data = (s) => {
   }
 };
 
-export { data, pointData, sumByPeriod, transplantFields };
+export { data, pointData, sumByCovariates, transplantFields };

--- a/source/data.js
+++ b/source/data.js
@@ -83,12 +83,16 @@ const stackKeys = (data) => {
  * @returns {array} values summed across time period
  */
 const sumByPeriod = (s) => {
-  const summedByGroup = groupAndSumByProperties(
-    s.data.values,
-    encodingField(s, 'x'),
-    encodingField(s, 'color'),
-    encodingField(s, 'y'),
-  );
+  const x = encodingField(s, 'x');
+  const y = encodingField(s, 'y');
+  const color = encodingField(s, 'color');
+
+  // determine relevance of x and y to the arguments based on encoding
+  const vertical = encodingType(s, 'y') === 'quantitative';
+  const independent = vertical ? x : y;
+  const covariate = vertical ? y : x;
+
+  const summedByGroup = groupAndSumByProperties(values(s), independent, color, covariate);
   const keys = stackKeys(summedByGroup);
   const summedByPeriod = summedByGroup.map((item) => {
     return d3.sum(keys.map((key) => item[key]?.value || 0));

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -53,7 +53,7 @@ const encodingValue = (s, channel) => {
  * @param {object} s Vega Lite specification
  * @returns {string} visual encoding channel
  */
-const encodingFieldQuantitative = (s) => {
+const encodingChannelQuantitative = (s) => {
   const test = (channel, definition) => definition.type === 'quantitative';
 
   return encodingTest(s, test);
@@ -66,7 +66,7 @@ const encodingFieldQuantitative = (s) => {
  * @returns {function(object)}
  */
 const encodingValueQuantitative = (s) => {
-  return encodingValue(s, encodingFieldQuantitative(s));
+  return encodingValue(s, encodingChannelQuantitative(s));
 };
 
 /**
@@ -101,7 +101,7 @@ const encodingTest = memoize(_encodingTest);
  * @param {object} s Vega Lite specification
  * @returns {string} visual encoding channel
  */
-const encodingFieldCovariate = (s) => {
+const encodingChannelCovariate = (s) => {
   if ((feature(s).isCircular() || feature(s).isLinear()) && feature(s).hasColor()) {
     return 'color';
   } else if (feature(s).isCartesian()) {
@@ -180,8 +180,8 @@ export {
   encodingField,
   encodingValue,
   encodingType,
-  encodingFieldQuantitative,
-  encodingFieldCovariate,
+  encodingChannelQuantitative,
+  encodingChannelCovariate,
   createEncoders,
   encodingValueQuantitative,
 };

--- a/source/marks.js
+++ b/source/marks.js
@@ -4,7 +4,7 @@ import { BAR_WIDTH_MINIMUM } from './config.js';
 import { createAccessors } from './accessors.js';
 import {
   createEncoders,
-  encodingFieldCovariate,
+  encodingChannelCovariate,
   encodingType,
   encodingValue,
   encodingValueQuantitative,
@@ -78,7 +78,7 @@ const markDescription = memoize(_markDescription);
  * @returns {number} bar width
  */
 const _barWidth = (s, dimensions) => {
-  const channel = encodingFieldCovariate(s);
+  const channel = encodingChannelCovariate(s);
   const barWidthMaximum = dimensions[channel] / 3;
   const stacked = markData(s);
   const type = encodingType(s, channel);

--- a/source/marks.js
+++ b/source/marks.js
@@ -166,12 +166,13 @@ const barDirection = (s) => {
  */
 const barEncoders = (s, dimensions) => {
   const encoders = createEncoders(s, dimensions, createAccessors(s, 'bar'));
+  const barLaneChannel = barDirection(s) === 'vertical' ? 'x' : 'y';
 
   return {
     width: () => barWidth(s, dimensions),
     length: encoders.barLength,
     start: encoders.barStart,
-    lane: encoders.x,
+    lane: encoders[barLaneChannel],
   };
 };
 

--- a/source/marks.js
+++ b/source/marks.js
@@ -146,15 +146,31 @@ const markInteractionSelector = (_s) => {
 };
 
 /**
+ * shuffle around bar mark encoders to
+ * facilitate bidirectional layout
+ * @param {object} s Vega Lite specification
+ * @param {object} dimensions chart dimensions
+ * @returns {object} bar encoder methods
+ */
+const barEncoders = (s, dimensions) => {
+  const encoders = createEncoders(s, dimensions, createAccessors(s, 'bar'));
+
+  return {
+    width: () => barWidth(s, dimensions),
+    length: encoders.barLength,
+    start: encoders.barStart,
+    lane: encoders.x,
+  };
+};
+
+/**
  * render a single bar chart mark
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
  * @returns {function} single mark renderer
  */
 const barMark = (s, dimensions) => {
-  const encoders = createEncoders(s, dimensions, createAccessors(s, 'bar'));
-  const width = barWidth(s, dimensions);
-
+  const { width, length, start, lane } = barEncoders(s, dimensions);
   const markRenderer = (selection) => {
     const rect = selection.append(markSelector(s));
 
@@ -163,12 +179,12 @@ const barMark = (s, dimensions) => {
       .attr('aria-roledescription', 'data point')
       .attr('tabindex', -1)
       .attr('class', 'block mark')
-      .attr('y', encoders.barStart)
-      .attr('x', encoders.x)
+      .attr('y', start)
+      .attr('x', lane)
       .attr('aria-label', (d) => {
         return markDescription(s)(d);
       })
-      .attr('height', encoders.barLength)
+      .attr('height', length)
       .attr('width', width)
       .call(tooltips(s));
   };

--- a/source/marks.js
+++ b/source/marks.js
@@ -166,13 +166,18 @@ const barDirection = (s) => {
  */
 const barEncoders = (s, dimensions) => {
   const encoders = createEncoders(s, dimensions, createAccessors(s, 'bar'));
-  const barLaneChannel = barDirection(s) === 'vertical' ? 'x' : 'y';
+  const vertical = barDirection(s) === 'vertical';
+  const barLaneChannel = vertical ? 'x' : 'y';
+  const lane = encoders[barLaneChannel];
+  const start = encoders.barStart;
+  const length = encoders.barLength;
+  const width = () => barWidth(s, dimensions);
 
   return {
-    width: () => barWidth(s, dimensions),
-    length: encoders.barLength,
-    start: encoders.barStart,
-    lane: encoders[barLaneChannel],
+    x: vertical ? lane : start,
+    y: vertical ? start : lane,
+    height: vertical ? length : width,
+    width: vertical ? width : length,
   };
 };
 
@@ -183,7 +188,8 @@ const barEncoders = (s, dimensions) => {
  * @returns {function} single mark renderer
  */
 const barMark = (s, dimensions) => {
-  const { width, length, start, lane } = barEncoders(s, dimensions);
+  const { x, y, height, width } = barEncoders(s, dimensions);
+
   const markRenderer = (selection) => {
     const rect = selection.append(markSelector(s));
 
@@ -192,12 +198,12 @@ const barMark = (s, dimensions) => {
       .attr('aria-roledescription', 'data point')
       .attr('tabindex', -1)
       .attr('class', 'block mark')
-      .attr('y', start)
-      .attr('x', lane)
+      .attr('y', y)
+      .attr('x', x)
       .attr('aria-label', (d) => {
         return markDescription(s)(d);
       })
-      .attr('height', length)
+      .attr('height', height)
       .attr('width', width)
       .call(tooltips(s));
   };

--- a/source/marks.js
+++ b/source/marks.js
@@ -177,6 +177,32 @@ const barMark = (s, dimensions) => {
 };
 
 /**
+ * lane transform for all bar marks
+ * @param {*} s
+ * @param {*} dimensions
+ * @returns {string} transform
+ */
+const barMarksTransform = (s, dimensions) => {
+  const translate = [0, 0];
+  let offsetChannel;
+  let index;
+
+  if (encodingType(s, 'y') === 'quantitative') {
+    offsetChannel = 'x';
+    index = 0;
+  } else if (encodingType(s, 'x') === 'quantitative') {
+    offsetChannel = 'y';
+    index = 1;
+  }
+
+  const offset = isDiscrete(s, offsetChannel) ? barWidth(s, dimensions) * 0.5 : 0;
+
+  translate[index] = offset;
+
+  return `translate(${translate.join(',')})`;
+};
+
+/**
  * render bar chart marks
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
@@ -188,11 +214,7 @@ const barMarks = (s, dimensions) => {
     const marks = selection
       .append('g')
       .attr('class', 'marks')
-      .attr('transform', () => {
-        const x = isDiscrete(s, 'x') ? barWidth(s, dimensions) * 0.5 : 0;
-
-        return `translate(${x},0)`;
-      });
+      .attr('transform', barMarksTransform(s, dimensions));
 
     const series = marks
       .selectAll('g')

--- a/source/marks.js
+++ b/source/marks.js
@@ -146,6 +146,18 @@ const markInteractionSelector = (_s) => {
 };
 
 /**
+ * determine which way bars are oriented
+ * @param {object} s Vega Lite specification
+ */
+const barDirection = (s) => {
+  if (s.encoding.x.type === 'quantitative') {
+    return 'horizontal';
+  } else if (s.encoding.y.type === 'quantitative') {
+    return 'vertical';
+  }
+};
+
+/**
  * shuffle around bar mark encoders to
  * facilitate bidirectional layout
  * @param {object} s Vega Lite specification

--- a/source/marks.js
+++ b/source/marks.js
@@ -10,7 +10,7 @@ import {
   encodingValueQuantitative,
 } from './encodings.js';
 import { data, pointData } from './data.js';
-import { datum, key, missingSeries, values } from './helpers.js';
+import { datum, isDiscrete, key, missingSeries, values } from './helpers.js';
 import { feature } from './feature.js';
 import { memoize } from './memoize.js';
 import { parseScales } from './scales.js';
@@ -184,14 +184,12 @@ const barMark = (s, dimensions) => {
  */
 const barMarks = (s, dimensions) => {
   const encoders = createEncoders(s, dimensions, createAccessors(s, 'series'));
-  const type = encodingType(s, encodingFieldCovariate(s));
   const renderer = (selection) => {
     const marks = selection
       .append('g')
       .attr('class', 'marks')
       .attr('transform', () => {
-        const categorical = ['nominal', 'ordinal'].includes(type);
-        const x = categorical ? barWidth(s, dimensions) * 0.5 : 0;
+        const x = isDiscrete(s, 'x') ? barWidth(s, dimensions) * 0.5 : 0;
 
         return `translate(${x},0)`;
       });

--- a/source/marks.js
+++ b/source/marks.js
@@ -617,4 +617,4 @@ const marks = (s, dimensions) => {
   }
 };
 
-export { marks, radius, barWidth, markSelector, markInteractionSelector, category };
+export { marks, radius, barWidth, barDirection, markSelector, markInteractionSelector, category };

--- a/source/position.js
+++ b/source/position.js
@@ -54,8 +54,8 @@ const tickMargin = (s, dimensions) => {
  */
 const titleMargin = (s) => {
   return {
-    bottom: feature(s).hasAxisTitleX() ? GRID * 4 : 0,
-    left: feature(s).hasAxisTitleY() ? GRID * 4 : 0,
+    bottom: feature(s).hasAxisTitleX() ? GRID * 5 : 0,
+    left: feature(s).hasAxisTitleY() ? GRID * 5 : 0,
   };
 };
 

--- a/source/position.js
+++ b/source/position.js
@@ -5,7 +5,8 @@ import { memoize } from './memoize.js';
 import { polarToCartesian } from './helpers.js';
 import { radius } from './marks.js';
 
-const MARGIN_MAXIMUM = 180 + GRID * 5;
+const TITLE_MARGIN = GRID * 5;
+const MARGIN_MAXIMUM = 180 + TITLE_MARGIN;
 
 const axes = { x: 'bottom', y: 'left' };
 
@@ -54,8 +55,8 @@ const tickMargin = (s, dimensions) => {
  */
 const titleMargin = (s) => {
   return {
-    bottom: feature(s).hasAxisTitleX() ? GRID * 5 : 0,
-    left: feature(s).hasAxisTitleY() ? GRID * 5 : 0,
+    bottom: feature(s).hasAxisTitleX() ? TITLE_MARGIN : 0,
+    left: feature(s).hasAxisTitleY() ? TITLE_MARGIN : 0,
   };
 };
 

--- a/source/position.js
+++ b/source/position.js
@@ -5,7 +5,7 @@ import { memoize } from './memoize.js';
 import { polarToCartesian } from './helpers.js';
 import { radius } from './marks.js';
 
-const MARGIN_MAXIMUM = 120;
+const MARGIN_MAXIMUM = 180 + GRID * 5;
 
 const axes = { x: 'bottom', y: 'left' };
 

--- a/source/scales.js
+++ b/source/scales.js
@@ -95,10 +95,9 @@ const channelRoot = (s, channel) => {
  * @returns {number[]} domain
  */
 const domain = (s, channel) => {
+  const type = encodingType(s, channel);
   const domains = {
     x: (values) => {
-      const type = encodingType(s, channel);
-
       if (type === 'temporal') {
         const date = (d) => parseTime(encodingValue(s, channel)(d));
 
@@ -110,7 +109,6 @@ const domain = (s, channel) => {
       }
     },
     y: (values) => {
-      const type = encodingType(s, channel);
       let yMin;
       let yMax;
 

--- a/source/scales.js
+++ b/source/scales.js
@@ -97,51 +97,49 @@ const channelRoot = (s, channel) => {
 const domainBaseValues = (s, channel) => {
   const type = encodingType(s, channel);
 
-  if (channel === 'x') {
-    if (type === 'temporal') {
-      const date = (d) => parseTime(encodingValue(s, channel)(d));
+  if (type === 'temporal') {
+    const date = (d) => parseTime(encodingValue(s, channel)(d));
 
-      return d3.extent(values(s), date);
-    } else if (type === 'nominal' || type === 'ordinal') {
-      return [...new Set(values(s).map((item) => encodingValue(s, channel)(item)))];
-    } else if (type === 'quantitative') {
+    return d3.extent(values(s), date);
+  } else if (type === 'nominal' || type === 'ordinal') {
+    return [...new Set(values(s).map((item) => encodingValue(s, channel)(item)))];
+  } else if (type === 'quantitative') {
+    if (channel === 'x') {
       return d3.extent(values(s), (item) => encodingValue(s, channel)(item));
     }
-  }
 
-  if (channel === 'y') {
-    let yMin;
-    let yMax;
+    if (channel === 'y') {
+      let yMin;
+      let yMax;
 
-    if (type === 'nominal') {
-      return [...new Set(values(s).map((item) => encodingValue(s, channel)(item)))];
-    } else if (feature(s).isBar()) {
-      yMin = 0;
-      yMax = d3.max(sumByPeriod(s));
-    } else if (feature(s).isLine()) {
-      const daily = data(s)
-        .map((item) => item.values)
-        .flat();
-      const y = encodingValue(s, channel);
-      const nonzero = s.encoding.y.scale?.zero === false;
-      const min = d3.min(daily, y);
-      const positive = typeof min === 'number' && min > 0;
+      if (feature(s).isBar()) {
+        yMin = 0;
+        yMax = d3.max(sumByPeriod(s));
+      } else if (feature(s).isLine()) {
+        const daily = data(s)
+          .map((item) => item.values)
+          .flat();
+        const y = encodingValue(s, channel);
+        const nonzero = s.encoding.y.scale?.zero === false;
+        const min = d3.min(daily, y);
+        const positive = typeof min === 'number' && min > 0;
 
-      if (nonzero && positive) {
-        yMin = min;
-      } else if (!positive) {
-        yMin = min;
+        if (nonzero && positive) {
+          yMin = min;
+        } else if (!positive) {
+          yMin = min;
+        } else {
+          yMin = 0;
+        }
+
+        yMax = d3.max(daily, y);
       } else {
         yMin = 0;
+        yMax = d3.max(values(s), encodingValue(s, channel));
       }
 
-      yMax = d3.max(daily, y);
-    } else {
-      yMin = 0;
-      yMax = d3.max(values(s), encodingValue(s, channel));
+      return [yMin, yMax];
     }
-
-    return [yMin, yMax];
   }
 
   if (channel === 'theta') {

--- a/source/scales.js
+++ b/source/scales.js
@@ -126,11 +126,11 @@ const domainBaseValues = (s, channel) => {
         yMin = 0;
         yMax = d3.max(sumByPeriod(s));
       } else if (feature(s).isLine()) {
-        const daily = data(s)
+        const byPeriod = data(s)
           .map((item) => item.values)
           .flat();
         const nonzero = s.encoding.y.scale?.zero === false;
-        const min = d3.min(daily, encodingValue(s, channel));
+        const min = d3.min(byPeriod, encodingValue(s, channel));
         const positive = typeof min === 'number' && min > 0;
 
         if (nonzero && positive) {
@@ -141,7 +141,7 @@ const domainBaseValues = (s, channel) => {
           yMin = 0;
         }
 
-        yMax = d3.max(daily, encodingValue(s, channel));
+        yMax = d3.max(byPeriod, encodingValue(s, channel));
       } else {
         yMin = 0;
         yMax = d3.max(values(s), encodingValue(s, channel));

--- a/source/scales.js
+++ b/source/scales.js
@@ -321,11 +321,19 @@ const extendScales = (s, dimensions, scales) => {
         return 0;
       }
 
-      return dimensions[channel] - extendedScales[channel](d);
+      if (channel === 'y') {
+        return dimensions[channel] - extendedScales[channel](d);
+      } else if (channel === 'x') {
+        return extendedScales[channel](d);
+      }
     };
 
     extendedScales.barStart = (d) => {
-      return extendedScales[channel](d[0]) - extendedScales.barLength(d[1] - d[0]);
+      if (channel === 'y') {
+        return extendedScales[channel](d[0]) - extendedScales.barLength(d[1] - d[0]);
+      } else if (channel === 'x') {
+        return extendedScales[channel](d[0]);
+      }
     };
   }
 

--- a/source/scales.js
+++ b/source/scales.js
@@ -104,6 +104,10 @@ const domainBaseValues = (s, channel) => {
   } else if (type === 'nominal' || type === 'ordinal') {
     return [...new Set(values(s).map((item) => encodingValue(s, channel)(item)))];
   } else if (type === 'quantitative') {
+    if (channel === 'theta') {
+      return [0, 360];
+    }
+
     if (channel === 'x') {
       return d3.extent(values(s), (item) => encodingValue(s, channel)(item));
     }
@@ -140,10 +144,6 @@ const domainBaseValues = (s, channel) => {
 
       return [yMin, yMax];
     }
-  }
-
-  if (channel === 'theta') {
-    return [0, 360];
   }
 
   if (channel === 'color') {

--- a/source/scales.js
+++ b/source/scales.js
@@ -174,30 +174,32 @@ const domain = (s, channel) => {
 /**
  * compute scale range
  * @param {object} s Vega Lite specification
- * @param {string} channel encoding parameter
+ * @param {string} dimensions chart dimensions
+ * @param {string} _channel visual encoding
  * @returns {number[]} range
  */
-const range = (s, dimensions, channel) => {
+const range = (s, dimensions, _channel) => {
+  const channel = channelRoot(s, _channel);
   const ranges = {
     x: () => {
       const rangeDeltas = () => {
-        if (feature(s).isBar() && encodingType(s, 'x') === 'temporal') {
-          return { x: barWidth(s, dimensions) };
+        if (feature(s).isBar() && encodingType(s, channel) === 'temporal') {
+          return { [channel]: barWidth(s, dimensions) };
         } else {
-          return { x: 0 };
+          return { [channel]: 0 };
         }
       };
 
-      return [0, dimensions.x - rangeDeltas().x];
+      return [0, dimensions[channel] - rangeDeltas()[channel]];
     },
     y: () => {
       if (isDiscrete(s, channel)) {
         const count = domain(s, channel).length;
-        const interval = dimensions.y / count;
+        const interval = dimensions[channel] / count;
 
         return Array.from({ length: count }).map((item, index) => index * interval);
       } else {
-        return [dimensions.y, 0];
+        return [dimensions[channel], 0];
       }
     },
     color: () => {
@@ -211,13 +213,13 @@ const range = (s, dimensions, channel) => {
 
       return (
         s.encoding.color?.scale?.range ||
-        colors((customDomain(s, 'color') || colorRangeProcessor(s)).length)
+        colors((customDomain(s, channel) || colorRangeProcessor(s)).length)
       );
     },
     theta: () => [0, Math.PI * 2],
   };
 
-  return ranges[channelRoot(s, channel)]();
+  return ranges[channel]();
 };
 
 /**

--- a/source/scales.js
+++ b/source/scales.js
@@ -103,7 +103,7 @@ const domainBaseValues = (s, channel) => {
 
       return d3.extent(values(s), date);
     } else if (type === 'nominal' || type === 'ordinal') {
-      return values(s).map((item) => encodingValue(s, channel)(item));
+      return [...new Set(values(s).map((item) => encodingValue(s, channel)(item)))];
     } else if (type === 'quantitative') {
       return d3.extent(values(s), (item) => encodingValue(s, channel)(item));
     }

--- a/source/scales.js
+++ b/source/scales.js
@@ -2,7 +2,7 @@ import * as d3 from 'd3';
 import { barWidth } from './marks.js';
 import { data, sumByCovariates } from './data.js';
 import { defaultColor } from './config.js';
-import { encodingFieldQuantitative, encodingType, encodingValue } from './encodings.js';
+import { encodingChannelQuantitative, encodingType, encodingValue } from './encodings.js';
 import { feature } from './feature.js';
 import { identity, isDiscrete, values } from './helpers.js';
 import { memoize } from './memoize.js';
@@ -311,7 +311,7 @@ const extendScales = (s, dimensions, scales) => {
   const extensions = detectScaleExtensions(s);
 
   if (extensions.includes('length')) {
-    const channel = encodingFieldQuantitative(s);
+    const channel = encodingChannelQuantitative(s);
 
     extendedScales.barLength = (d) => {
       if (extendedScales[channel].domain().every((endpoint) => endpoint === 0)) {

--- a/source/scales.js
+++ b/source/scales.js
@@ -183,33 +183,27 @@ const domain = (s, channel) => {
 const range = (s, dimensions, _channel) => {
   const channel = channelRoot(s, _channel);
   const cartesian = () => {
-    const x = () => {
-      const rangeDeltas = () => {
-        if (feature(s).isBar() && encodingType(s, channel) === 'temporal') {
-          return { [channel]: barWidth(s, dimensions) };
-        } else {
-          return { [channel]: 0 };
-        }
-      };
+    let result;
 
-      return [0, dimensions[channel] - rangeDeltas()[channel]];
-    };
-    const y = () => {
-      if (isDiscrete(s, channel)) {
-        const count = domain(s, channel).length;
-        const interval = dimensions[channel] / count;
+    if (isDiscrete(s, channel) && scaleType(s, channel) !== 'scaleBand') {
+      const count = domain(s, channel).length;
+      const interval = dimensions[channel] / count;
 
-        return Array.from({ length: count }).map((item, index) => index * interval);
-      } else {
-        return [dimensions[channel], 0];
-      }
-    };
+      const positions = Array.from({ length: count }).map((item, index) => index * interval);
 
-    if (channel === 'x') {
-      return x();
-    } else if (channel === 'y') {
-      return y();
+      result = positions;
+    } else {
+      const temporalBar = feature(s).isBar() && encodingType(s, channel) === 'temporal';
+      const offset = temporalBar ? barWidth(s, dimensions) : 0;
+
+      result = [0, dimensions[channel] - offset];
     }
+
+    if (channel === 'y' && encodingType(s, channel) === 'quantitative') {
+      result.reverse();
+    }
+
+    return result;
   };
   const ranges = {
     x: cartesian,

--- a/source/scales.js
+++ b/source/scales.js
@@ -97,6 +97,12 @@ const channelRoot = (s, channel) => {
 const domainBaseValues = (s, channel) => {
   const type = encodingType(s, channel);
 
+  if (channel === 'color') {
+    const colors = Array.from(new Set(values(s).map(encodingValue(s, 'color'))));
+
+    return colors;
+  }
+
   if (type === 'temporal') {
     const date = (d) => parseTime(encodingValue(s, channel)(d));
 
@@ -144,12 +150,6 @@ const domainBaseValues = (s, channel) => {
 
       return [yMin, yMax];
     }
-  }
-
-  if (channel === 'color') {
-    const colors = Array.from(new Set(values(s).map(encodingValue(s, 'color'))));
-
-    return colors;
   }
 };
 

--- a/source/scales.js
+++ b/source/scales.js
@@ -114,41 +114,37 @@ const domainBaseValues = (s, channel) => {
       return [0, 360];
     }
 
-    if (channel === 'x') {
-      return d3.extent(values(s), (item) => encodingValue(s, channel)(item));
-    }
+    let min;
+    let max;
 
-    if (channel === 'y') {
-      let min;
-      let max;
+    if (feature(s).isBar()) {
+      min = 0;
+      max = d3.max(sumByCovariates(s));
+    } else if (feature(s).isLine()) {
+      const byPeriod = data(s)
+        .map((item) => item.values)
+        .flat();
+      const nonzero = s.encoding.y.scale?.zero === false;
+      const periodMin = d3.min(byPeriod, encodingValue(s, channel));
+      const positive = typeof periodMin === 'number' && periodMin > 0;
 
-      if (feature(s).isBar()) {
-        min = 0;
-        max = d3.max(sumByCovariates(s));
-      } else if (feature(s).isLine()) {
-        const byPeriod = data(s)
-          .map((item) => item.values)
-          .flat();
-        const nonzero = s.encoding.y.scale?.zero === false;
-        const periodMin = d3.min(byPeriod, encodingValue(s, channel));
-        const positive = typeof periodMin === 'number' && periodMin > 0;
-
-        if (nonzero && positive) {
-          min = periodMin;
-        } else if (!positive) {
-          min = periodMin;
-        } else {
-          min = 0;
-        }
-
-        max = d3.max(byPeriod, encodingValue(s, channel));
+      if (nonzero && positive) {
+        min = periodMin;
+      } else if (!positive) {
+        min = periodMin;
       } else {
         min = 0;
-        max = d3.max(values(s), encodingValue(s, channel));
       }
 
-      return [min, max];
+      max = d3.max(byPeriod, encodingValue(s, channel));
+    } else {
+      min = 0;
+      max = d3.max(values(s), encodingValue(s, channel));
     }
+
+    return [min, max];
+  } else {
+    return d3.extent(values(s), (item) => encodingValue(s, channel)(item));
   }
 };
 

--- a/source/scales.js
+++ b/source/scales.js
@@ -119,35 +119,35 @@ const domainBaseValues = (s, channel) => {
     }
 
     if (channel === 'y') {
-      let yMin;
-      let yMax;
+      let min;
+      let max;
 
       if (feature(s).isBar()) {
-        yMin = 0;
-        yMax = d3.max(sumByPeriod(s));
+        min = 0;
+        max = d3.max(sumByPeriod(s));
       } else if (feature(s).isLine()) {
         const byPeriod = data(s)
           .map((item) => item.values)
           .flat();
         const nonzero = s.encoding.y.scale?.zero === false;
-        const min = d3.min(byPeriod, encodingValue(s, channel));
-        const positive = typeof min === 'number' && min > 0;
+        const periodMin = d3.min(byPeriod, encodingValue(s, channel));
+        const positive = typeof periodMin === 'number' && periodMin > 0;
 
         if (nonzero && positive) {
-          yMin = min;
+          min = periodMin;
         } else if (!positive) {
-          yMin = min;
+          min = periodMin;
         } else {
-          yMin = 0;
+          min = 0;
         }
 
-        yMax = d3.max(byPeriod, encodingValue(s, channel));
+        max = d3.max(byPeriod, encodingValue(s, channel));
       } else {
-        yMin = 0;
-        yMax = d3.max(values(s), encodingValue(s, channel));
+        min = 0;
+        max = d3.max(values(s), encodingValue(s, channel));
       }
 
-      return [yMin, yMax];
+      return [min, max];
     }
   }
 };

--- a/source/scales.js
+++ b/source/scales.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 
 import { barWidth } from './marks.js';
-import { data, sumByPeriod } from './data.js';
+import { data, sumByCovariates } from './data.js';
 import { defaultColor } from './config.js';
 import { encodingFieldQuantitative, encodingType, encodingValue } from './encodings.js';
 import { feature } from './feature.js';
@@ -124,7 +124,7 @@ const domainBaseValues = (s, channel) => {
 
       if (feature(s).isBar()) {
         min = 0;
-        max = d3.max(sumByPeriod(s));
+        max = d3.max(sumByCovariates(s));
       } else if (feature(s).isLine()) {
         const byPeriod = data(s)
           .map((item) => item.values)

--- a/source/scales.js
+++ b/source/scales.js
@@ -97,25 +97,25 @@ const channelRoot = (s, channel) => {
 const domain = (s, channel) => {
   const domains = {
     x: (values) => {
-      const type = encodingType(s, 'x');
+      const type = encodingType(s, channel);
 
       if (type === 'temporal') {
-        const date = (d) => parseTime(encodingValue(s, 'x')(d));
+        const date = (d) => parseTime(encodingValue(s, channel)(d));
 
         return d3.extent(values, date);
       } else if (type === 'nominal' || type === 'ordinal') {
-        return values.map((item) => encodingValue(s, 'x')(item));
+        return values.map((item) => encodingValue(s, channel)(item));
       } else if (type === 'quantitative') {
-        return d3.extent(values, (item) => encodingValue(s, 'x')(item));
+        return d3.extent(values, (item) => encodingValue(s, channel)(item));
       }
     },
     y: (values) => {
-      const type = encodingType(s, 'y');
+      const type = encodingType(s, channel);
       let yMin;
       let yMax;
 
       if (type === 'nominal') {
-        return [...new Set(values.map((item) => encodingValue(s, 'y')(item)))];
+        return [...new Set(values.map((item) => encodingValue(s, channel)(item)))];
       } else if (feature(s).isBar()) {
         yMin = 0;
         yMax = d3.max(sumByPeriod(s));
@@ -123,7 +123,7 @@ const domain = (s, channel) => {
         const daily = data(s)
           .map((item) => item.values)
           .flat();
-        const y = encodingValue(s, 'y');
+        const y = encodingValue(s, channel);
         const nonzero = s.encoding.y.scale?.zero === false;
         const min = d3.min(daily, y);
         const positive = typeof min === 'number' && min > 0;
@@ -139,7 +139,7 @@ const domain = (s, channel) => {
         yMax = d3.max(daily, y);
       } else {
         yMin = 0;
-        yMax = d3.max(values, encodingValue(s, 'y'));
+        yMax = d3.max(values, encodingValue(s, channel));
       }
 
       return [yMin, yMax];

--- a/source/scales.js
+++ b/source/scales.js
@@ -40,7 +40,10 @@ const scaleType = (s, channel) => {
   const key = encodingType(s, channel);
 
   if (typeof key === 'string') {
-    const method = channel === 'x' && ['nominal', 'ordinal'].includes(key) ? 'Band' : methods[key];
+    const method =
+      ['x', 'y'].includes(channelRoot(s, channel)) && isDiscrete(s, channel)
+        ? 'Band'
+        : methods[key];
 
     return `scale${method}`;
   } else if (typeof key === 'undefined') {

--- a/source/scales.js
+++ b/source/scales.js
@@ -191,9 +191,7 @@ const range = (s, dimensions, channel) => {
       return [0, dimensions.x - rangeDeltas().x];
     },
     y: () => {
-      const type = encodingType(s, 'y');
-
-      if (['nominal', 'ordinal'].includes(type)) {
+      if (isDiscrete(s, channel)) {
         const count = domain(s, channel).length;
         const interval = dimensions.y / count;
 

--- a/source/scales.js
+++ b/source/scales.js
@@ -129,9 +129,8 @@ const domainBaseValues = (s, channel) => {
         const daily = data(s)
           .map((item) => item.values)
           .flat();
-        const y = encodingValue(s, channel);
         const nonzero = s.encoding.y.scale?.zero === false;
-        const min = d3.min(daily, y);
+        const min = d3.min(daily, encodingValue(s, channel));
         const positive = typeof min === 'number' && min > 0;
 
         if (nonzero && positive) {
@@ -142,7 +141,7 @@ const domainBaseValues = (s, channel) => {
           yMin = 0;
         }
 
-        yMax = d3.max(daily, y);
+        yMax = d3.max(daily, encodingValue(s, channel));
       } else {
         yMin = 0;
         yMax = d3.max(values(s), encodingValue(s, channel));

--- a/tests/integration/stacked-bar-test.js
+++ b/tests/integration/stacked-bar-test.js
@@ -5,7 +5,7 @@ import { specificationFixture } from '../test-helpers.js';
 const { module, test } = qunit;
 
 module('integration > stacked-bar', function () {
-  test('renders a stacked bar chart', async function (assert) {
+  test('renders a vertical stacked bar chart', async function (assert) {
     const spec = specificationFixture('stackedBar');
     const element = render(spec);
 
@@ -25,5 +25,31 @@ module('integration > stacked-bar', function () {
       'all mark rects have positive numbers as height attributes',
     );
     assert.ok(!nodesHaveZeroHeights, 'some mark rects have nonzero height attributes');
+  });
+
+  test('renders a horizontal stacked bar chart', async function (assert) {
+    const spec = specificationFixture('stackedBar');
+
+    const { x, y } = spec.encoding;
+
+    // invert the encodings
+    spec.encoding.x = y;
+    spec.encoding.y = x;
+
+    const element = render(spec);
+
+    const mark = testSelector('mark');
+
+    assert.ok(element.querySelector(mark));
+    assert.equal(element.querySelector(mark).tagName, 'rect');
+
+    const nodes = [...element.querySelectorAll(mark)];
+    const nodeHasPositiveWidth = (node) => Number(node.getAttribute('width')) >= 0;
+    const nodeHasZeroWidth = (node) => Number(node.getAttribute('width')) === 0;
+    const nodesHavePositiveWidths = nodes.every(nodeHasPositiveWidth);
+    const nodesHaveZeroWidths = nodes.every(nodeHasZeroWidth);
+
+    assert.ok(nodesHavePositiveWidths, 'all mark rects have positive numbers as width attributes');
+    assert.ok(!nodesHaveZeroWidths, 'some mark rects have nonzero width attributes');
   });
 });

--- a/tests/integration/stacked-bar-test.js
+++ b/tests/integration/stacked-bar-test.js
@@ -14,14 +14,16 @@ module('integration > stacked-bar', function () {
     assert.ok(element.querySelector(mark));
     assert.ok(element.querySelector(mark).tagName, 'rect');
 
+    const nodes = [...element.querySelectorAll(mark)];
     const nodeHasPositiveHeight = (node) => Number(node.getAttribute('height')) >= 0;
-    const nodesHavePositiveHeights = [...element.querySelectorAll(mark)].every(
-      nodeHasPositiveHeight,
-    );
+    const nodeHasZeroHeight = (node) => Number(node.getAttribute('height')) === 0;
+    const nodesHavePositiveHeights = nodes.every(nodeHasPositiveHeight);
+    const nodesHaveZeroHeights = nodes.every(nodeHasZeroHeight);
 
     assert.ok(
       nodesHavePositiveHeights,
       'all mark rects have positive numbers as height attributes',
     );
+    assert.ok(!nodesHaveZeroHeights, 'some mark rects have nonzero height attributes');
   });
 });

--- a/tests/unit/encodings-test.js
+++ b/tests/unit/encodings-test.js
@@ -1,8 +1,8 @@
 import {
   createEncoders,
   encodingField,
-  encodingFieldCovariate,
-  encodingFieldQuantitative,
+  encodingChannelCovariate,
+  encodingChannelQuantitative,
   encodingType,
   encodingValue,
 } from '../../source/encodings.js';
@@ -60,17 +60,17 @@ module('unit > encoders', () => {
       encoding: { x: { type: 'quantitative' }, y: { type: 'quantitative' } },
     };
 
-    assert.equal(encodingFieldCovariate(ordinal), 'x');
-    assert.equal(encodingFieldCovariate(nominal), 'x');
-    assert.equal(encodingFieldCovariate(temporal), 'x');
-    assert.throws(() => encodingFieldCovariate(doubleNominal));
-    assert.throws(() => encodingFieldCovariate(doubleQuantitative));
+    assert.equal(encodingChannelCovariate(ordinal), 'x');
+    assert.equal(encodingChannelCovariate(nominal), 'x');
+    assert.equal(encodingChannelCovariate(temporal), 'x');
+    assert.throws(() => encodingChannelCovariate(doubleNominal));
+    assert.throws(() => encodingChannelCovariate(doubleQuantitative));    
   });
 
   test('identifies quantitative encoding channels', (assert) => {
     const s = { encoding: { x: { type: 'nominal' }, y: { type: 'quantitative' } } };
 
-    assert.equal(encodingFieldQuantitative(s), 'y');
+    assert.equal(encodingChannelQuantitative(s), 'y');
   });
 
   test('detects encoding types', (assert) => {


### PR DESCRIPTION
Allow more flexible use of `specification.encoding` which more readily allows inverting `x` and `y` instead of hard-coding assumptions about how those channels are most likely to be used.

For example, the following specification now renders as expected:

```json
{
  "title": {
    "text": "horizontal bar chart demonstration"
  },
  "data": {
    "values": [
      {
        "group": "a",
        "value": 10
      },
      {
        "group": "b",
        "value": 20
      },
      {
        "group": "c",
        "value": 40
      },
      {
        "group": "d",
        "value": 30
      },
      {
        "group": "e",
        "value": 35
      },
      {
        "group": "f",
        "value": 15
      },
      {
        "group": "g",
        "value": 17
      }
    ]
  },
  "encoding": {
    "y": {
      "field": "group",
      "type": "nominal"
    },
    "x": {
      "field": "value",
      "type": "quantitative"
    }
  },
  "mark": {
    "type": "bar"
  }
}
```