### PR TITLE
single bar

### DIFF
--- a/fixtures/single-bar.js
+++ b/fixtures/single-bar.js
@@ -1,0 +1,24 @@
+const singleBarChartSpec = {
+    "title": {
+        "text": "single bar",
+    },
+    "mark": { "type": "bar", "tooltip": true },
+    "data": {
+        "values": [
+            { "group": "a", "label": "x", "value": 100 },
+            { "group": "b", "label": "y", "value": 200 },
+            { "group": "c", "label": "x", "value": 300 },
+            { "group": "d", "label": "w", "value": 400 },
+        ]
+    },
+    "encoding": {
+        "y": {
+            "type": "quantitative",
+            "field": "value",
+            "axis": { "title": null }
+        },
+        "color": { "field": "group", "type": "nominal", "legend": { "title": null } }
+    }
+};
+
+export { singleBarChartSpec }

--- a/source/accessors.js
+++ b/source/accessors.js
@@ -38,11 +38,15 @@ const _createAccessors = (s, type = null) => {
     const lane = (d) => d.data.key;
 
     if (layoutDirection(s) === 'horizontal') {
-      accessors.y = lane;
       accessors.x = start;
+      if (feature(s).hasEncodingY()) {
+        accessors.y = lane;
+      }
     } else if (layoutDirection(s) === 'vertical') {
-      accessors.y = start;
-      accessors.x = lane;
+      accessors.x = start;
+      if (feature(s).hasEncodingY()) {
+        accessors.y = lane;
+      }
     }
 
     accessors.start = (d) => (d[1] ? d : [d[0], d[0]]);

--- a/source/axes.js
+++ b/source/axes.js
@@ -177,7 +177,11 @@ const x = (s, dimensions) => {
             ? scales.y.range().pop()
             : scales.y.range()[0];
       } else {
-        yOffset = 0;
+        if (feature(s).isBar() && !feature(s).hasEncodingY()) {
+          yOffset = barWidth(s, dimensions)
+        } else {
+          yOffset = 0;
+        }
       }
 
       return `translate(${xOffset},${yOffset})`;

--- a/source/axes.js
+++ b/source/axes.js
@@ -264,7 +264,11 @@ const y = (s, dimensions) => {
         .select('.y .axis')
         .selectAll('.tick')
         .select('line')
-        .attr('x1', scales.x.range()[1] + barOffset);
+        .attr('x1', () => {
+          if (feature(s).hasEncodingX()) {
+            return scales.x.range()[1] + barOffset;
+          }
+        });
     }
   };
 };

--- a/source/marks.js
+++ b/source/marks.js
@@ -219,25 +219,24 @@ const barMark = (s, dimensions) => {
  * @returns {string} transform
  */
 const barMarksTransform = (s, dimensions) => {
-  const translate = [0, 0];
-  let offsetChannel;
-  let index;
+  let x = 0;
+  let y = 0;
 
-  if (encodingType(s, 'y') === 'quantitative' && feature(s).hasEncodingX()) {
-    offsetChannel = 'x';
-    index = 0;
-  } else if (encodingType(s, 'x') === 'quantitative' && feature(s).hasEncodingY()) {
-    offsetChannel = 'y';
-    index = 1;
+  if (encodingType(s, 'y') === 'quantitative') {
+    if (feature(s).hasEncodingX()) {
+      if (isDiscrete(s, 'x')) {
+        x = barWidth(s, dimensions) * 0.5;
+      }
+    }
+  } else if (encodingType(s, 'x') === 'quantitative') {
+    if (feature(s).hasEncodingY()) {
+      if (isDiscrete(s, 'y')) {
+        y = barWidth(s, dimensions) * 0.5;
+      }
+    }
   }
 
-  const offset = isDiscrete(s, offsetChannel) ? barWidth(s, dimensions) * 0.5 : 0;
-
-  if (typeof index === 'number') {
-    translate[index] = offset;
-  }
-
-  return `translate(${translate.join(',')})`;
+  return `translate(${x},${y})`;
 };
 
 /**

--- a/source/marks.js
+++ b/source/marks.js
@@ -83,19 +83,19 @@ const _barWidth = (s, dimensions) => {
   const stacked = markData(s);
   const type = encodingType(s, channel);
   const temporal = type === 'temporal';
-  // this check is logically the same as parseScales()[channel].domain()
-  // but writing it that way would be circular
-  const domain = s.encoding[channel].scale?.domain?.map(parseTime);
-  const extent = d3.extent(stacked.flat(), (d) => parseTime(d.data.key));
-  const endpoints = domain || extent;
-  const periods = d3[timePeriod(s, channel)].count(endpoints[0], endpoints[1]);
-  const customDomain = s.encoding[channel].scale?.domain?.length;
+  const customDomain = s.encoding[channel]?.scale?.domain?.length;
 
   let count;
 
   if (customDomain) {
     count = customDomain;
   } else if (temporal) {
+    // this check is logically the same as parseScales()[channel].domain()
+    // but writing it that way would be circular
+    const domain = s.encoding[channel].scale?.domain?.map(parseTime);
+    const extent = d3.extent(stacked.flat(), (d) => parseTime(d.data.key));
+    const endpoints = domain || extent;
+    const periods = d3[timePeriod(s, channel)].count(endpoints[0], endpoints[1]);
     count = periods;
   } else {
     count = d3.max(stacked, (d) => d.length);

--- a/source/marks.js
+++ b/source/marks.js
@@ -199,8 +199,8 @@ const barMark = (s, dimensions) => {
       .attr('aria-roledescription', 'data point')
       .attr('tabindex', -1)
       .attr('class', 'block mark')
-      .attr('y', y)
-      .attr('x', x)
+      .attr('y', feature(s).hasEncodingY() ? y : 0)
+      .attr('x', feature(s).hasEncodingX() ? x : 0)
       .attr('aria-label', (d) => {
         return markDescription(s)(d);
       })

--- a/source/marks.js
+++ b/source/marks.js
@@ -4,7 +4,6 @@ import { BAR_WIDTH_MINIMUM } from './config.js';
 import { createAccessors } from './accessors.js';
 import {
   createEncoders,
-  encodingChannelCovariate,
   encodingChannelQuantitative,
   encodingType,
   encodingValue,
@@ -79,7 +78,7 @@ const markDescription = memoize(_markDescription);
  * @returns {number} bar width
  */
 const _barWidth = (s, dimensions) => {
-  const channel = encodingChannelCovariate(s);
+  const channel = ['x', 'y'].find((channel => channel !== encodingChannelQuantitative(s)));
   const barWidthMaximum = dimensions[channel] / 3;
   const stacked = markData(s);
   const type = encodingType(s, channel);

--- a/source/marks.js
+++ b/source/marks.js
@@ -150,9 +150,9 @@ const markInteractionSelector = (_s) => {
  * @param {object} s Vega Lite specification
  */
 const layoutDirection = (s) => {
-  if (s.encoding.x.type === 'quantitative') {
+  if (s.encoding.x?.type === 'quantitative') {
     return 'horizontal';
-  } else if (s.encoding.y.type === 'quantitative') {
+  } else if (s.encoding.y?.type === 'quantitative') {
     return 'vertical';
   }
 };

--- a/source/marks.js
+++ b/source/marks.js
@@ -224,17 +224,19 @@ const barMarksTransform = (s, dimensions) => {
   let offsetChannel;
   let index;
 
-  if (encodingType(s, 'y') === 'quantitative') {
+  if (encodingType(s, 'y') === 'quantitative' && feature(s).hasEncodingX()) {
     offsetChannel = 'x';
     index = 0;
-  } else if (encodingType(s, 'x') === 'quantitative') {
+  } else if (encodingType(s, 'x') === 'quantitative' && feature(s).hasEncodingY()) {
     offsetChannel = 'y';
     index = 1;
   }
 
   const offset = isDiscrete(s, offsetChannel) ? barWidth(s, dimensions) * 0.5 : 0;
 
-  translate[index] = offset;
+  if (typeof index === 'number') {
+    translate[index] = offset;
+  }
 
   return `translate(${translate.join(',')})`;
 };

--- a/tests/index.html
+++ b/tests/index.html
@@ -42,6 +42,7 @@
     <script src="./integration/line-test.js" type="module"></script>
     <script src="./integration/pivot-test.js" type="module"></script>
     <script src="./integration/rules-test.js" type="module"></script>
+    <script src="./integration/single-bar-test.js" type="module"></script>
     <script src="./integration/sort-test.js" type="module"></script>
     <script src="./integration/stacked-area-test.js" type="module"></script>
     <script src="./integration/stacked-bar-test.js" type="module"></script>

--- a/tests/integration/single-bar-test.js
+++ b/tests/integration/single-bar-test.js
@@ -1,0 +1,30 @@
+import qunit from 'qunit';
+import { render, testSelector } from '../test-helpers.js';
+import { specificationFixture } from '../test-helpers.js';
+
+const { module, test } = qunit;
+
+module('integration > single bar', function () {
+    test('renders a stacked single bar', async function (assert) {
+        const spec = specificationFixture('singleBar');
+        const element = render(spec);
+
+        const mark = testSelector('mark');
+
+        assert.ok(element.querySelector(mark));
+        assert.ok(element.querySelector(mark).tagName, 'rect');
+
+        const nodes = [...element.querySelectorAll(mark)];
+        const nodeHasPositiveHeight = (node) => Number(node.getAttribute('height')) >= 0;
+        const nodeHasZeroHeight = (node) => Number(node.getAttribute('height')) === 0;
+        const nodesHavePositiveHeights = nodes.every(nodeHasPositiveHeight);
+        const nodesHaveZeroHeights = nodes.every(nodeHasZeroHeight);
+
+        assert.ok(
+            nodesHavePositiveHeights,
+            'all mark rects have positive numbers as height attributes',
+        );
+        assert.ok(!nodesHaveZeroHeights, 'some mark rects have nonzero height attributes');
+    });
+
+});

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -7,7 +7,7 @@ import { rulesSpec } from '../fixtures/rules.js';
 import { scatterPlotSpec } from '../fixtures/scatter-plot.js';
 import { stackedBarChartSpec } from '../fixtures/stacked-bar.js';
 import { temporalBarChartSpec } from '../fixtures/temporal-bar.js';
-
+import { singleBarChartSpec } from '../fixtures/single-bar.js';
 import { select } from 'd3';
 import { chart } from '../source/chart.js';
 
@@ -67,6 +67,8 @@ export function specificationFixture(type) {
     spec = stackedBarChartSpec;
   } else if (type === 'stackedArea') {
     spec = stackedAreaChartSpec;
+  } else if (type === 'singleBar') {
+    spec = singleBarChartSpec;
   } else if (type === 'circular') {
     spec = circularChartSpec;
   } else if (type === 'line') {


### PR DESCRIPTION
Add conditional checks around uses of the `x` and `y` encodings so they can be used independently to render a [single bar](https://vega.github.io/vega-lite/docs/bar.html#single-bar-chart) without also needing a second dimension like a timestamp or category.