### PR TITLE
text mark link fix

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -665,7 +665,7 @@ const textMarks = (s, dimensions) => {
     const dy = text.node().getBoundingClientRect().height * 0.25;
 
     text.attr('transform', `translate(0,${dy})`);
-    text.classed('link', encodingValue(s, 'href'));
+    text.classed('link', s.encoding && encodingValue(s, 'href'));
 
   };
 };


### PR DESCRIPTION
Fixes a bug introduced by pull request #31 which could cause mark rendering to fail when text content is set using a property on the mark object and consequently there is no encoding object at all.