### PR TITLE
primary layer view helper

### DIFF
--- a/source/position.js
+++ b/source/position.js
@@ -4,11 +4,34 @@ import { longestAxisTickLabelTextWidth, rotation } from './text.js';
 import { memoize } from './memoize.js';
 import { polarToCartesian } from './helpers.js';
 import { radius } from './marks.js';
+import { layerMatch } from './views.js';
 
 const TITLE_MARGIN = GRID * 5;
 const MARGIN_MAXIMUM = 180 + TITLE_MARGIN;
 
 const axes = { x: 'bottom', y: 'left' };
+
+/**
+ * test whether a specification has all the
+ * encodings necessary for a successful two
+ * dimensional layout
+ * @param {object} s Vega Lite specification
+ * @returns {boolean}
+ */
+const twoDimensional = (s) => {
+  return s.encoding.x && s.encoding.y || s.encoding.theta;
+};
+
+/**
+ * test whether a specification has all the
+ * encodings necessary for a successful two
+ * dimensional layout
+ * @param {object} s Vega Lite specification
+ * @returns {boolean}
+ */
+const oneDimensional = (s) => {
+  return s.encoding.x && !s.encoding.y || !s.encoding.x && s.encoding.y;
+};
 
 /**
  * compute margin for a circular chart
@@ -89,7 +112,8 @@ const marginCartesian = (s, dimensions) => {
   };
 };
 
-const _margin = (s, dimensions) => {
+const _margin = (_s, dimensions) => {
+  const s = _s.layer ? layerMatch(_s, twoDimensional) || layerMatch(_s, oneDimensional) : _s;
   if (feature(s).isCircular()) {
     return marginCircular();
   } else {

--- a/source/position.js
+++ b/source/position.js
@@ -4,34 +4,12 @@ import { longestAxisTickLabelTextWidth, rotation } from './text.js';
 import { memoize } from './memoize.js';
 import { polarToCartesian } from './helpers.js';
 import { radius } from './marks.js';
-import { layerMatch } from './views.js';
+import { layerPrimary } from './views.js';
 
 const TITLE_MARGIN = GRID * 5;
 const MARGIN_MAXIMUM = 180 + TITLE_MARGIN;
 
 const axes = { x: 'bottom', y: 'left' };
-
-/**
- * test whether a specification has all the
- * encodings necessary for a successful two
- * dimensional layout
- * @param {object} s Vega Lite specification
- * @returns {boolean}
- */
-const twoDimensional = (s) => {
-  return s.encoding.x && s.encoding.y || s.encoding.theta;
-};
-
-/**
- * test whether a specification has all the
- * encodings necessary for a successful two
- * dimensional layout
- * @param {object} s Vega Lite specification
- * @returns {boolean}
- */
-const oneDimensional = (s) => {
-  return s.encoding.x && !s.encoding.y || !s.encoding.x && s.encoding.y;
-};
 
 /**
  * compute margin for a circular chart
@@ -112,12 +90,11 @@ const marginCartesian = (s, dimensions) => {
   };
 };
 
-const _margin = (_s, dimensions) => {
-  const s = _s.layer ? layerMatch(_s, twoDimensional) || layerMatch(_s, oneDimensional) : _s;
+const _margin = (s, dimensions) => {
   if (feature(s).isCircular()) {
     return marginCircular();
   } else {
-    return marginCartesian(s, dimensions);
+    return marginCartesian(layerPrimary(s), dimensions);
   }
 };
 

--- a/source/views.js
+++ b/source/views.js
@@ -148,7 +148,12 @@ const oneDimensional = (s) => {
  * @param {object} s Vega Lite specification
  * @returns {object} layer specification
  */
-const layerPrimary = (s) => s.layer ? layerMatch(s, twoDimensional) || layerMatch(s, oneDimensional) : s;
+const layerPrimary = (s) => {
+  if (!s.layer) {
+    return s;
+  }
+  layerMatch(s, twoDimensional) || layerMatch(s, oneDimensional) || s;
+};
 
 /**
  * find the DOM element corresponding to a layer

--- a/source/views.js
+++ b/source/views.js
@@ -127,7 +127,7 @@ const layerMatch = (s, test) => {
  * @returns {boolean}
  */
 const twoDimensional = (s) => {
-  return s.encoding.x && s.encoding.y || s.encoding.theta;
+  return s.encoding.x && s.encoding.y || s.encoding.theta && s.encoding.color;
 };
 
 /**

--- a/source/views.js
+++ b/source/views.js
@@ -119,6 +119,36 @@ const layerMatch = (s, test) => {
     }
   }
 };
+/**
+ * test whether a specification has all the
+ * encodings necessary for a successful two
+ * dimensional layout
+ * @param {object} s Vega Lite specification
+ * @returns {boolean}
+ */
+const twoDimensional = (s) => {
+  return s.encoding.x && s.encoding.y || s.encoding.theta;
+};
+
+/**
+ * test whether a specification has all the
+ * encodings necessary for a successful two
+ * dimensional layout
+ * @param {object} s Vega Lite specification
+ * @returns {boolean}
+ */
+const oneDimensional = (s) => {
+  return s.encoding.x && !s.encoding.y || !s.encoding.x && s.encoding.y;
+};
+
+/**
+ * select the layer that is likely to be the most important
+ * for global functionality like axes and margins across the
+ * entire chart
+ * @param {object} s Vega Lite specification
+ * @returns {object} layer specification
+ */
+const layerPrimary = (s) => s.layer ? layerMatch(s, twoDimensional) || layerMatch(s, oneDimensional) : s;
 
 /**
  * find the DOM element corresponding to a layer
@@ -258,4 +288,4 @@ const layerTestRecursive = (s, test) => {
   return test(s) || layerTest(s, test);
 };
 
-export { layer, layerMatch, layerNode, layerTestRecursive };
+export { layer, layerMatch, layerPrimary, layerNode, layerTestRecursive };

--- a/source/views.js
+++ b/source/views.js
@@ -134,9 +134,11 @@ const layerPrimary = (s) => {
   const heuristics = [
     // explicit axis configuration
     (s) => s.encoding.x?.axis || s.encoding.y?.axis,
-    // two dimensions
-    (s) => s.encoding.x && s.encoding.y || s.encoding.theta && s.encoding.color,
-    // one dimension
+    // radial
+    (s) => s.encoding.theta && s.encoding.color,
+    // cartesian
+    (s) => s.encoding.x && s.encoding.y,
+    // linear
     (s) => s.encoding.x && !s.encoding.y || !s.encoding.x && s.encoding.y,
     // add a wrapper to require encoding
   ].map((heuristic) => (s) => s.encoding && heuristic(s));

--- a/tests/unit/views-test.js
+++ b/tests/unit/views-test.js
@@ -1,95 +1,97 @@
 import {
   layerMatch,
-  layerNode,
+  layerNode
 } from '../../source/views.js';
 import qunit from 'qunit';
 
 const { module, test } = qunit;
 
 module('unit > views', () => {
-  const specifications = {
-    data: { values: [1, 2, 3, 5, 6] },
-    layer: [
-      {
-        mark: { type: 'rule' },
-        encoding: { y: { datum: 10 } },
-      },
-      {
-        mark: { type: 'bar' },
-        encoding: { y: { scale: { domain: [0, 100] }, type: 'quantitative' } },
-      },
-    ],
-  };
-  const ruleTest = (s) => s.mark.type === 'rule';
-  const barTest = (s) => s.mark.type === 'bar';
-
-  test('resolves missing domains', (assert) => {
-    const s = layerMatch(specifications, (s) => s.mark.type === 'rule');
-
-    assert.deepEqual(s.encoding.y.scale.domain, specifications.layer[1].encoding.y.scale.domain);
-  });
-  test('resolves missing encoding types', (assert) => {
-    const s = layerMatch(specifications, (s) => s.mark.type === 'rule');
-
-    assert.equal(s.encoding.y.type, 'quantitative');
-  });
-  test('appends data to layer specifications', (assert) => {
-    assert.equal(typeof layerMatch(specifications, barTest).data.values.length, 'number');
-  });
-
-  test('appends encoding to layer specifications', (assert) => {
-    const encodingResolveTestSpecification = {
-      data: { values: [{}] },
-      encoding: {
-        x: {
-          field: 'a',
-          type: 'quantitative',
+  module('layers', () => {
+    const specifications = {
+      data: { values: [1, 2, 3, 5, 6] },
+      layer: [
+        {
+          mark: { type: 'rule' },
+          encoding: { y: { datum: 10 } },
         },
-        y: {
-          field: 'b',
-          type: 'quantitative',
+        {
+          mark: { type: 'bar' },
+          encoding: { y: { scale: { domain: [0, 100] }, type: 'quantitative' } },
         },
-      },
-      layer: [{ mark: { type: 'point' } }, { mark: { type: 'text' } }],
+      ],
     };
-    const pointTest = (s) => s.mark.type === 'point';
-    const layer = layerMatch(encodingResolveTestSpecification, pointTest);
-
-    assert.equal(layer.encoding.x.field, 'a');
-    assert.equal(layer.encoding.y.field, 'b');
-  });
-
-  test('matches nested layers', (assert) => {
-    assert.equal(typeof layerMatch(specifications, ruleTest).encoding.y.datum, 'number');
-    assert.equal(layerMatch(specifications, barTest).encoding.y.type, 'quantitative');
-  });
-
-  test('finds layer nodes', (assert) => {
-    const markup = `
-      <svg>
-        <g class="layer" data-test-selector="a">
-          <g class="marks">
-            <line>
-          </g>
-        </g>
-        <g class="layer" data-test-selector="b">
-          <g class="marks">
-            <rect>
-          </g>
-        </g>
-      </svg>
-    `;
-    const wrapper = document.createElement('div');
-
-    wrapper.innerHTML = markup;
-
     const ruleTest = (s) => s.mark.type === 'rule';
     const barTest = (s) => s.mark.type === 'bar';
 
-    const ruleSpec = layerMatch(specifications, ruleTest);
-    const barSpec = layerMatch(specifications, barTest);
+    test('resolves missing domains', (assert) => {
+      const s = layerMatch(specifications, (s) => s.mark.type === 'rule');
 
-    assert.equal(layerNode(ruleSpec, wrapper).getAttribute('data-test-selector'), 'a');
-    assert.equal(layerNode(barSpec, wrapper).getAttribute('data-test-selector'), 'b');
+      assert.deepEqual(s.encoding.y.scale.domain, specifications.layer[1].encoding.y.scale.domain);
+    });
+    test('resolves missing encoding types', (assert) => {
+      const s = layerMatch(specifications, (s) => s.mark.type === 'rule');
+
+      assert.equal(s.encoding.y.type, 'quantitative');
+    });
+    test('appends data to layer specifications', (assert) => {
+      assert.equal(typeof layerMatch(specifications, barTest).data.values.length, 'number');
+    });
+
+    test('appends encoding to layer specifications', (assert) => {
+      const encodingResolveTestSpecification = {
+        data: { values: [{}] },
+        encoding: {
+          x: {
+            field: 'a',
+            type: 'quantitative',
+          },
+          y: {
+            field: 'b',
+            type: 'quantitative',
+          },
+        },
+        layer: [{ mark: { type: 'point' } }, { mark: { type: 'text' } }],
+      };
+      const pointTest = (s) => s.mark.type === 'point';
+      const layer = layerMatch(encodingResolveTestSpecification, pointTest);
+
+      assert.equal(layer.encoding.x.field, 'a');
+      assert.equal(layer.encoding.y.field, 'b');
+    });
+
+    test('matches nested layers', (assert) => {
+      assert.equal(typeof layerMatch(specifications, ruleTest).encoding.y.datum, 'number');
+      assert.equal(layerMatch(specifications, barTest).encoding.y.type, 'quantitative');
+    });
+
+    test('finds layer nodes', (assert) => {
+      const markup = `
+        <svg>
+          <g class="layer" data-test-selector="a">
+            <g class="marks">
+              <line>
+            </g>
+          </g>
+          <g class="layer" data-test-selector="b">
+            <g class="marks">
+              <rect>
+            </g>
+          </g>
+        </svg>
+      `;
+      const wrapper = document.createElement('div');
+
+      wrapper.innerHTML = markup;
+
+      const ruleTest = (s) => s.mark.type === 'rule';
+      const barTest = (s) => s.mark.type === 'bar';
+
+      const ruleSpec = layerMatch(specifications, ruleTest);
+      const barSpec = layerMatch(specifications, barTest);
+
+      assert.equal(layerNode(ruleSpec, wrapper).getAttribute('data-test-selector'), 'a');
+      assert.equal(layerNode(barSpec, wrapper).getAttribute('data-test-selector'), 'b');
+    });
   });
 });

--- a/tests/unit/views-test.js
+++ b/tests/unit/views-test.js
@@ -1,6 +1,7 @@
 import {
   layerMatch,
-  layerNode
+  layerNode,
+  layerPrimary
 } from '../../source/views.js';
 import qunit from 'qunit';
 
@@ -92,6 +93,189 @@ module('unit > views', () => {
 
       assert.equal(layerNode(ruleSpec, wrapper).getAttribute('data-test-selector'), 'a');
       assert.equal(layerNode(barSpec, wrapper).getAttribute('data-test-selector'), 'b');
+    });
+    module('primary', () => {
+      test('circular', (assert) => {
+        const specification = {
+          data: {values: [
+            { group: 'a', value: 1 },
+            { group: 'b', value: 2 },
+            { group: 'c', value: 3 },
+          ]},
+          layer: [
+            {
+              mark: {
+                type: "text",
+                text: "this is a text layer"
+              }
+            },
+            {
+              mark: {
+                type: "arc",
+                innerRadius: 50,
+              },
+              encoding: {
+                theta: {
+                  field: "value",
+                  type: "quantitative"
+                },
+                color: {
+                  field: "group",
+                  type: "nominal"
+                }
+              }
+            }
+          ]
+        };
+        assert.equal(layerPrimary(specification).mark.type, 'arc', 'selects arcs from donut chart with text layer');
+      });
+      test('cartesian', (assert) => {
+        const specification = {
+          data: {
+            values: [
+              { date: "2015", value: 1 },
+              { date: "2016", value: 2 },
+              { date: "2017", value: 3 },
+              { date: "2018", value: 4 },
+              { date: "2019", value: 4 },
+              { date: "2020", value: 7 },
+              { date: "2021", value: 10 },
+              { date: "2022", value: 4 },
+            ]
+          },
+          layer: [
+            {
+              mark: {
+                type: "rule"
+              },
+              encoding: {
+                y: {
+                  datum: 5,
+                  type: 'quantitative'
+                }
+              }
+            },
+            {
+              mark: {
+                type: "line",
+              },
+              encoding: {
+                theta: {
+                  field: "value",
+                  type: "quantitative"
+                },
+                color: {
+                  field: "date",
+                  type: "temporal"
+                }
+              }
+            }
+          ]
+        };
+        assert.equal(layerPrimary(specification).mark.type, 'line', 'selects line from line chart with rule layer');
+      });      
+      test('linear', (assert) => {
+        const specification = {
+          data: {
+            values: [
+              { group: "a", value: 21 },
+              { group: "a", value: 44 },
+              { group: "b", value: 57 },
+              { group: "a", value: 82 },
+              { group: "a", value: 23 },
+              { group: "b", value: 10 },
+              { group: "b", value: 30 },
+              { group: "a", value: 57 },
+            ]
+          },
+          layer: [
+            {
+              mark: {
+                type: "text",
+                text: 'text annotation'
+              },
+              encoding: {
+                x: {
+                  datum: 20,
+                  type: 'quantitative'
+                }
+              }
+            },
+            {
+              mark: {
+                type: "point",
+              },
+              encoding: {
+                x: {
+                  field: "value",
+                  type: "quantitative"
+                },
+                color: {
+                  field: "group",
+                  type: "nominal"
+                }
+              }
+            }
+          ]
+        };
+        assert.equal(layerPrimary(specification).mark.type, 'point', 'selects points from linear chart with text layer');
+      });
+      test('multiple graphical layers', (assert) => {
+        const specification = {
+          data: {
+            values: [
+              { date: "2020", value: 14, otherValue: 66 },
+              { date: "2021", value: 45, otherValue: 65 },
+              { date: "2022", value: 22, otherValue: 66 },
+              { date: "2023", value: 22, otherValue: 64 },
+              { date: "2024", value: 23, otherValue: 62 },
+              { date: "2025", value: 24, otherValue: 55 },
+              { date: "2026", value: 26, otherValue: 57 },
+              { date: "2027", value: 11, otherValue: 53 },
+              { date: "2028", value: 24, otherValue: 44 },
+            ]
+          },
+          layer: [
+            {
+              mark: {
+                type: "line",
+              },
+              encoding: {
+                x: {
+                  field: 'date',
+                  type: 'temporal'
+                },
+                y: {
+                  field: 'value',
+                  type: 'quantitative'
+                }
+              }
+            },
+            {
+              mark: {
+                type: "bar",
+              },
+              encoding: {
+                x: {
+                  field: "date",
+                  type: "temporal",
+                  axis: {
+                    title: 'date'
+                  },
+                },
+                y: {
+                  field: "otherValue",
+                  type: "quantitative",
+                  axis: {
+                    title: 'other value'
+                  },
+                },
+              }
+            }
+          ]
+        };
+        assert.equal(layerPrimary(specification).mark.type, 'bar', 'selects layers with explicit axis configuration from charts with multiple graphical layers');
+      });
     });
   });
 });


### PR DESCRIPTION
Charts with multiple layers still have some of the same concerns as single-layer charts, such as calculating margins. This can't work with the root level specification, which is missing the configuration information that has been moved into the individual layers. One way to solve this problem, I hope, is by introducing a centralized set of heuristics that will resolve to the "primary" layer which should be used for those purposes.