### PR TITLE
unknown encoding type errors

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -37,18 +37,16 @@ const scaleType = (s, channel) => {
     quantitative: 'Linear',
     ordinal: 'Ordinal',
   };
-  const key = encodingType(s, channel);
 
-  if (typeof key === 'string') {
+  if (methods[encodingType(s, channel)]) {
     const method =
       ['x', 'y'].includes(channelRoot(s, channel)) && isDiscrete(s, channel)
         ? 'Band'
-        : methods[key];
-
+        : methods[encodingType(s, channel)];
     return `scale${method}`;
-  } else if (typeof key === 'undefined') {
+  } else {
     throw new Error(
-      `could not determine scale method for ${channel} channel because encoding type is undefined`,
+      `could not determine scale method for ${channel} channel because encoding type is ${encodingType(s, channel)}`,
     );
   }
 };

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -271,4 +271,30 @@ module('unit > scales', (hooks) => {
       assert.equal(typeof date, 'string');
     });
   });
+
+  test('throws errors for unknown encoding types', (assert) => {
+    const s = {
+      data: {
+        values: [
+          { group: 'a', value: 0 },
+          { group: 'b', value: 10 },
+          { group: 'c', value: 100 },
+        ],
+      },
+      mark: {
+        type: 'arc'
+      },
+      encoding: {
+        theta: {
+          type: 'unknown encoding type',
+          field: 'value',
+        },
+        color: {
+          type: 'nominal',
+          field: 'group',
+        }
+      },
+    };
+    assert.throws(() => parseScales(s));
+  });
 });


### PR DESCRIPTION
Make `scaleType()` stricter so it throws errors for any _unrecognized_ encoding type instead of only for an _undefined_ encoding type.