### PR TITLE
clean up bar width tests

### DIFF
--- a/tests/unit/marks-test.js
+++ b/tests/unit/marks-test.js
@@ -10,38 +10,42 @@ const set = () => null
 module('unit > marks', () => {
   module('bar width', () => {
 
-    const stackedBarChartSpec = specificationFixture('stackedBar');
-    const categoricalBarChartSpec = specificationFixture('categoricalBar');
-
     const dimensions = { x: 100, y: 100 };
 
-    const dates = new Set(stackedBarChartSpec.data.values.map((item) => item.label)).size;
-
-    const categories = categoricalBarChartSpec.data.values.map((item) => item.label).length;
-
     test('return value', (assert) => {
+      const specification = specificationFixture('stackedBar');
+
       assert.equal(
-        typeof barWidth(stackedBarChartSpec, dimensions),
+        typeof barWidth(specification, dimensions),
         'number',
         'bar width is a number',
       );
     });
 
     test('temporal encoding', (assert) => {
+      const specification = specificationFixture('stackedBar');
+      const dates = new Set(specification.data.values.map((item) => item.label)).size;
+
       assert.ok(
-        barWidth(stackedBarChartSpec, dimensions) <= dimensions.x / dates,
+        barWidth(specification, dimensions) <= dimensions.x / dates,
         'time series bar width sized according to number of timestamps',
       );
     });
 
     test('nominal encoding', (assert) => {
+      const specification = specificationFixture('categoricalBar');
+      const categories = specification.data.values.map((item) => item.label).length;
+
       assert.ok(
-        barWidth(categoricalBarChartSpec, dimensions) <= dimensions.x / categories,
+        barWidth(specification, dimensions) <= dimensions.x / categories,
         'time series bar width sized according to number of categories',
       );
     });
 
     test('mutation', (assert) => {
+      const stackedBarChartSpec = specificationFixture('stackedBar');
+      const categoricalBarChartSpec = specificationFixture('categoricalBar');
+
       const twoBarsTimeSeries = [
         { label: '2020-01-01', value: 10, group: 'a' },
         { label: '2020-01-01', value: 20, group: 'b' },

--- a/tests/unit/marks-test.js
+++ b/tests/unit/marks-test.js
@@ -8,7 +8,7 @@ const { module, test } = qunit;
 const set = () => null
 
 module('unit > marks', () => {
-  test('bar width', (assert) => {
+  module('bar width', () => {
 
     const stackedBarChartSpec = specificationFixture('stackedBar');
     const categoricalBarChartSpec = specificationFixture('categoricalBar');
@@ -19,46 +19,55 @@ module('unit > marks', () => {
 
     const categories = categoricalBarChartSpec.data.values.map((item) => item.label).length;
 
-    assert.equal(
-      typeof barWidth(stackedBarChartSpec, dimensions),
-      'number',
-      'bar width is a number',
-    );
+    test('return value', (assert) => {
+      assert.equal(
+        typeof barWidth(stackedBarChartSpec, dimensions),
+        'number',
+        'bar width is a number',
+      );
+    });
 
-    assert.ok(
-      barWidth(stackedBarChartSpec, dimensions) <= dimensions.x / dates,
-      'time series bar width sized according to number of timestamps',
-    );
+    test('temporal encoding', (assert) => {
+      assert.ok(
+        barWidth(stackedBarChartSpec, dimensions) <= dimensions.x / dates,
+        'time series bar width sized according to number of timestamps',
+      );
+    });
 
-    assert.ok(
-      barWidth(categoricalBarChartSpec, dimensions) <= dimensions.x / categories,
-      'time series bar width sized according to number of categories',
-    );
+    test('nominal encoding', (assert) => {
+      assert.ok(
+        barWidth(categoricalBarChartSpec, dimensions) <= dimensions.x / categories,
+        'time series bar width sized according to number of categories',
+      );
+    });
 
-    const twoBarsTimeSeries = [
-      { label: '2020-01-01', value: 10, group: 'a' },
-      { label: '2020-01-01', value: 20, group: 'b' },
-      { label: '2020-01-02', value: 30, group: 'a' },
-      { label: '2020-01-02', value: 40, group: 'b' },
-    ];
+    test('mutation', (assert) => {
+      const twoBarsTimeSeries = [
+        { label: '2020-01-01', value: 10, group: 'a' },
+        { label: '2020-01-01', value: 20, group: 'b' },
+        { label: '2020-01-02', value: 30, group: 'a' },
+        { label: '2020-01-02', value: 40, group: 'b' },
+      ];
 
-    const twoBarsCategorical = [
-      { group: 'a', value: 10 },
-      { group: 'b', value: 20 },
-    ];
+      const twoBarsCategorical = [
+        { group: 'a', value: 10 },
+        { group: 'b', value: 20 },
+      ];
 
-    set(stackedBarChartSpec.data, 'values', twoBarsTimeSeries);
+      set(stackedBarChartSpec.data, 'values', twoBarsTimeSeries);
 
-    set(categoricalBarChartSpec.data, 'values', twoBarsCategorical);
+      set(categoricalBarChartSpec.data, 'values', twoBarsCategorical);
 
-    assert.ok(
-      barWidth(stackedBarChartSpec, dimensions) <= dimensions.x / 3,
-      'gap left between two time series bars',
-    );
+      assert.ok(
+        barWidth(stackedBarChartSpec, dimensions) <= dimensions.x / 3,
+        'gap left between two time series bars',
+      );
 
-    assert.ok(
-      barWidth(categoricalBarChartSpec, dimensions) <= dimensions.x / 3,
-      'gap left between two categorical bars',
-    );
+      assert.ok(
+        barWidth(categoricalBarChartSpec, dimensions) <= dimensions.x / 3,
+        'gap left between two categorical bars',
+      );
+    });
+
   });
 });

--- a/tests/unit/marks-test.js
+++ b/tests/unit/marks-test.js
@@ -1,9 +1,8 @@
 import { barWidth } from '../../source/marks.js';
-import { categoricalBarChartSpec } from '../../fixtures/categorical-bar.js';
 import { encodingField } from '../../source/encodings.js';
 import qunit from 'qunit';
 // import { set } from '@ember/object';
-import { stackedBarChartSpec } from '../../fixtures/stacked-bar.js';
+import { specificationFixture } from '../test-helpers.js';
 
 const { module, test } = qunit;
 
@@ -11,6 +10,10 @@ const set = () => null
 
 module('unit > marks', () => {
   test('bar width', (assert) => {
+
+    const stackedBarChartSpec = specificationFixture('stackedBar');
+    const categoricalBarChartSpec = specificationFixture('categoricalBar');
+
     const dimensions = { x: 100, y: 100 };
 
     const dates = new Set(

--- a/tests/unit/marks-test.js
+++ b/tests/unit/marks-test.js
@@ -1,5 +1,4 @@
 import { barWidth } from '../../source/marks.js';
-import { encodingField } from '../../source/encodings.js';
 import qunit from 'qunit';
 // import { set } from '@ember/object';
 import { specificationFixture } from '../test-helpers.js';
@@ -16,13 +15,9 @@ module('unit > marks', () => {
 
     const dimensions = { x: 100, y: 100 };
 
-    const dates = new Set(
-      stackedBarChartSpec.data.values.map((item) => item[encodingField(stackedBarChartSpec, 'x')]),
-    ).size;
+    const dates = new Set(stackedBarChartSpec.data.values.map((item) => item.label)).size;
 
-    const categories = categoricalBarChartSpec.data.values.map(
-      (item) => item[encodingField(categoricalBarChartSpec, 'x')],
-    ).length;
+    const categories = categoricalBarChartSpec.data.values.map((item) => item.label).length;
 
     assert.equal(
       typeof barWidth(stackedBarChartSpec, dimensions),

--- a/tests/unit/marks-test.js
+++ b/tests/unit/marks-test.js
@@ -39,31 +39,26 @@ module('unit > marks', () => {
       );
     });
 
-    test('mutation', (assert) => {
-      const stackedBarChartSpec = specificationFixture('stackedBar');
-      const categoricalBarChartSpec = specificationFixture('categoricalBar');
-
-      const twoBarsTimeSeries = [
+    test('temporal gap', (assert) => {
+      const specification = specificationFixture('stackedBar');
+      specification.data.values = [
         { label: '2020-01-01', value: 10, group: 'a' },
         { label: '2020-01-01', value: 20, group: 'b' },
         { label: '2020-01-02', value: 30, group: 'a' },
         { label: '2020-01-02', value: 40, group: 'b' },
       ];
+      assert.ok(
+        barWidth(specification, dimensions) <= dimensions.x / 3,
+        'gap left between two time series bars',
+      );
+    });
 
-      const twoBarsCategorical = [
+    test('nominal gap', (assert) => {
+      const categoricalBarChartSpec = specificationFixture('categoricalBar');
+      categoricalBarChartSpec.data.values = [
         { group: 'a', value: 10 },
         { group: 'b', value: 20 },
       ];
-
-      set(stackedBarChartSpec.data, 'values', twoBarsTimeSeries);
-
-      set(categoricalBarChartSpec.data, 'values', twoBarsCategorical);
-
-      assert.ok(
-        barWidth(stackedBarChartSpec, dimensions) <= dimensions.x / 3,
-        'gap left between two time series bars',
-      );
-
       assert.ok(
         barWidth(categoricalBarChartSpec, dimensions) <= dimensions.x / 3,
         'gap left between two categorical bars',

--- a/tests/unit/marks-test.js
+++ b/tests/unit/marks-test.js
@@ -1,11 +1,8 @@
 import { barWidth } from '../../source/marks.js';
 import qunit from 'qunit';
-// import { set } from '@ember/object';
 import { specificationFixture } from '../test-helpers.js';
 
 const { module, test } = qunit;
-
-const set = () => null
 
 module('unit > marks', () => {
   module('bar width', () => {


### PR DESCRIPTION
Some of these were in a broken state as a result of refactoring for open source, and they also needed to be reorganized.