### PR TITLE
custom domain temporal bar width fix

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -83,16 +83,16 @@ const _barWidth = (s, dimensions) => {
   const stacked = markData(s);
   const type = encodingType(s, channel);
   const temporal = type === 'temporal';
-  const customDomain = s.encoding[channel]?.scale?.domain?.length;
+  const customDomain = s.encoding[channel]?.scale?.domain;
 
   let count;
 
-  if (customDomain) {
-    count = customDomain;
+  if (customDomain && !temporal) {
+    count = customDomain.length;
   } else if (temporal) {
     // this check is logically the same as parseScales()[channel].domain()
     // but writing it that way would be circular
-    const domain = s.encoding[channel].scale?.domain?.map(parseTime);
+    const domain = customDomain?.map(parseTime);
     const extent = d3.extent(stacked.flat(), (d) => parseTime(d.data.key));
     const endpoints = domain || extent;
     const periods = d3[timePeriod(s, channel)].count(endpoints[0], endpoints[1]);

--- a/tests/unit/marks-test.js
+++ b/tests/unit/marks-test.js
@@ -7,7 +7,7 @@ const { module, test } = qunit;
 module('unit > marks', () => {
   module('bar width', () => {
 
-    const dimensions = { x: 100, y: 100 };
+    const dimensions = { x: 1000, y: 1000 };
 
     test('return value', (assert) => {
       const specification = specificationFixture('stackedBar');
@@ -63,6 +63,15 @@ module('unit > marks', () => {
         barWidth(specification, dimensions) <= dimensions.x / 3,
         'gap left between two categorical bars',
       );
+    });
+
+    test('iterates through temporal periods for custom domains', (assert) => {
+      const standardSpec = specificationFixture('stackedBar');
+      const customSpec = specificationFixture('stackedBar');
+      const standardWidth = barWidth(standardSpec, dimensions);
+      customSpec.encoding.x.scale = {domain: ['2020-04-20', '2020-07-01']};
+      const customWidth = barWidth(customSpec, dimensions);
+      assert.ok(standardWidth > customWidth);
     });
 
   });


### PR DESCRIPTION
Always count the time intervals in order to determine the bar width for temporal encodings, including when using a custom domain.