### PR TITLE
dynamic channel lookup for tooltip values

### DIFF
--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -115,8 +115,8 @@ const _getTooltipField = (s, type) => {
 
   accessors = createAccessors(s);
 
-  // report length instead of start position as tooltip value for bars
-  if (feature(s).isBar()) {
+  // report length instead of start position as tooltip value for stacks
+  if (feature(s).isBar() || feature(s).isArea()) {
     accessors[encodingChannelQuantitative(s)] = accessors.length;
   }
 

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -2,7 +2,7 @@ import * as d3 from 'd3';
 
 import { category } from './marks.js';
 import { createAccessors } from './accessors.js';
-import { encodingField, encodingType, encodingValue } from './encodings.js';
+import { encodingChannelQuantitative, encodingField, encodingType, encodingValue } from './encodings.js';
 import { feature } from './feature.js';
 import { getTimeFormatter } from './time.js';
 import { memoize } from './memoize.js';
@@ -115,9 +115,9 @@ const _getTooltipField = (s, type) => {
 
   accessors = createAccessors(s);
 
-  // report height instead of y position as tooltip value
+  // report length instead of start position as tooltip value for bars
   if (feature(s).isBar()) {
-    accessors.y = accessors.length;
+    accessors[encodingChannelQuantitative(s)] = accessors.length;
   }
 
   let key;

--- a/tests/unit/tooltip-test.js
+++ b/tests/unit/tooltip-test.js
@@ -1,5 +1,6 @@
 import qunit from 'qunit';
 import { tooltipContent } from '../../source/tooltips.js';
+import { data } from '../../source/data.js';
 
 const { module, test } = qunit;
 
@@ -109,4 +110,37 @@ module('unit > tooltips', () => {
 
     assert.equal(text, 'tooltip value is: 1');
   });
+  test('handles bidirectional cartesian encodings', (assert) => {
+    const length = {field: 'a', type: 'quantitative'};
+    const category = {field: 'b', type: 'nominal'};
+    const values = [
+      { a: 10, b: '_'},
+      { a: 20, b: '•' },
+      { a: 30, b: '+' }
+    ];
+    const mark = {type: 'bar', tooltip: true};
+    const horizontal = {
+      data: {values},
+      mark,
+      encoding: {
+        x: length,
+        y: category
+      }
+    };
+    const vertical = {
+      data: {values},
+      mark,
+      encoding: {
+        y: length,
+        x: category
+      }
+    };
+
+    const datum = (s) => data(s)[0][2];
+    const text = (s) => tooltipContent(s)(datum(s));
+
+    assert.equal(text(horizontal), 'a: 30; b: +');
+    assert.equal(text(vertical), 'a: 30; b: +');
+
+  })
 });


### PR DESCRIPTION
Substitute a dynamic call to `encodingChannelQuantitative()` for the hard-coded `y` in the tooltip data lookup function so tooltips will work properly when the bar chart layout is horizontal.