### PR TITLE
collect all legend colors across layers

### DIFF
--- a/source/legend.js
+++ b/source/legend.js
@@ -4,7 +4,7 @@ import { dispatchers } from './interactions.js';
 import { encodingField } from './encodings.js';
 import { feature } from './feature.js';
 import { key, noop } from './helpers.js';
-import { layerMatch } from './views.js';
+import { layerPrimary } from './views.js';
 import { parseScales } from './scales.js';
 
 /**
@@ -45,13 +45,11 @@ const isOverflown = ({ clientWidth, clientHeight, scrollWidth, scrollHeight }) =
  * @returns {function} renderer
  */
 const color = (_s) => {
-  const test = (s) => s.encoding.color;
-  let s = layerMatch(_s, test);
+  let s = _s.layer ? layerPrimary(_s) : _s;
 
   const renderer = (selection) => {
     try {
       const { color } = parseScales(s);
-
       const dispatcher = dispatchers.get(selection.node());
 
       if (feature(s).hasLegendTitle()) {

--- a/source/views.js
+++ b/source/views.js
@@ -1,4 +1,5 @@
 import * as d3 from 'd3';
+import { feature } from './feature.js';
 
 import { mark, noop, values } from './helpers.js';
 import { markSelector, marks } from './marks.js';
@@ -73,7 +74,7 @@ const unionDomains = (s, channel) => {
     .map((item) => (typeof item.domain === 'function' ? item.domain() : null))
     .flat();
 
-  const getType = (s) => s.encoding?.[channel].type;
+  const getType = (s) => s.encoding?.[channel]?.type;
 
   const type = getType(s) || getType(s.layer.find(getType));
 
@@ -146,6 +147,15 @@ const layerPrimary = (s) => {
   for (const heuristic of heuristics) {
     let match = layerMatch(s, heuristic);
     if (typeof match === 'object') {
+      if (feature(s).hasColor() && !match.encoding.color?.scale?.domain) {
+        if (!match.encoding.color) {
+          match.encoding.color = {};
+        }
+        if (!match.encoding.color.scale) {
+          match.encoding.color.scale = {};
+        }
+        match.encoding.color.scale = { domain: unionDomains(s, 'color') };
+      }
       return match;
     }
   }

--- a/tests/unit/views-test.js
+++ b/tests/unit/views-test.js
@@ -4,6 +4,7 @@ import {
   layerPrimary
 } from '../../source/views.js';
 import qunit from 'qunit';
+import { parseScales } from '../../source/scales.js';
 
 const { module, test } = qunit;
 
@@ -219,6 +220,213 @@ module('unit > views', () => {
           ]
         };
         assert.equal(layerPrimary(specification).mark.type, 'point', 'selects points from linear chart with text layer');
+      });
+      test('unions color domain', (assert) => {
+        const specification = {
+          "title": { "text": "layer color legend test specification" },
+          "data": {
+            "values": [
+              {
+                "a": "2016",
+                "b": 10,
+                "c": "_",
+                "d": 10,
+                "e": ">"
+              },
+              {
+                "a": "2017",
+                "b": 20,
+                "c": "_",
+                "d": 10,
+                "e": "<"
+              },
+              {
+                "a": "2018",
+                "b": 10,
+                "c": "_",
+                "d": 20,
+                "e": ">"
+              },
+              {
+                "a": "2019",
+                "b": 40,
+                "c": "_",
+                "d": 10,
+                "e": ">"
+              },
+              {
+                "a": "2020",
+                "b": 60,
+                "c": "_",
+                "d": 20,
+                "e": ">"
+              },
+              {
+                "a": "2021",
+                "b": 80,
+                "c": "_",
+                "d": 30,
+                "e": "<"
+              },
+              {
+                "a": "2022",
+                "b": 40,
+                "c": "_",
+                "d": 40,
+                "e": "<"
+              },
+              {
+                "a": "2016",
+                "b": 50,
+                "c": "•",
+                "d": 30,
+                "e": ">"
+              },
+              {
+                "a": "2017",
+                "b": 60,
+                "c": "•",
+                "d": 30,
+                "e": "<"
+              },
+              {
+                "a": "2018",
+                "b": 50,
+                "c": "•",
+                "d": 30,
+                "e": ">"
+              },
+              {
+                "a": "2019",
+                "b": 30,
+                "c": "•",
+                "d": 40,
+                "e": ">"
+              },
+              {
+                "a": "2020",
+                "b": 10,
+                "c": "•",
+                "d": 60,
+                "e": "<"
+              },
+              {
+                "a": "2021",
+                "b": 10,
+                "c": "•",
+                "d": 60,
+                "e": ">"
+              },
+              {
+                "a": "2022",
+                "b": 20,
+                "c": "•",
+                "d": 30,
+                "e": ">"
+              },
+              {
+                "a": "2016",
+                "b": 70,
+                "c": "+",
+                "d": 50,
+                "e": "<"
+              },
+              {
+                "a": "2017",
+                "b": 50,
+                "c": "+",
+                "d": 20,
+                "e": "<"
+              },
+              {
+                "a": "2018",
+                "b": 40,
+                "c": "+",
+                "d": 10,
+                "e": ">"
+              },
+              {
+                "a": "2019",
+                "b": 60,
+                "c": "+",
+                "d": 50,
+                "e": ">"
+              },
+              {
+                "a": "2020",
+                "b": 30,
+                "c": "+",
+                "d": 20,
+                "e": "<"
+              },
+              {
+                "a": "2021",
+                "b": 10,
+                "c": "+",
+                "d": 20,
+                "e": ">"
+              },
+              {
+                "a": "2022",
+                "b": 20,
+                "c": "+",
+                "d": 50,
+                "e": ">"
+              }
+            ]
+          },
+          "layer": [
+            {
+              "mark": {
+                "type": "line"
+              },
+              "encoding": {
+                "x": {
+                  "field": "a",
+                  "type": "temporal"
+                },
+                "y": {
+                  "field": "b",
+                  "type": "quantitative"
+                },
+                "color": {
+                  "field": "e",
+                  "type": "nominal"
+                }
+              }
+            },
+            {
+              "mark": {
+                "type": "bar"
+              },
+              "encoding": {
+                "x": {
+                  "field": "a",
+                  "type": "temporal"
+                },
+                "y": {
+                  "field": "d",
+                  "type": "quantitative"
+                },
+                "color": {
+                  "field": "c",
+                  "type": "nominal"
+                }
+              }
+            }
+          ]
+        };
+        const domain = parseScales(layerPrimary(specification)).color.domain();
+        assert.equal(domain.length, 5)
+
+        const layers = [0, 1]
+        const fields = layers.map((index) => specification.layer[index].encoding.color.field)
+        const values = fields.map((field) => specification.data.values.map((item) => item[field])).flat()
+        const unique = [...new Set(values)]
+
+        unique.forEach((value) => {
+          assert.ok(domain.includes(value))
+        });
       });
       test('multiple graphical layers', (assert) => {
         const specification = {


### PR DESCRIPTION
Legends should be able to explain every color used in the chart, which means they need to collect all the colors used across all the layers in a single color scale.