### PR TITLE
union ranges

### DIFF
--- a/source/views.js
+++ b/source/views.js
@@ -171,7 +171,12 @@ const layerPrimary = (s) => {
         if (!match.encoding.color.scale) {
           match.encoding.color.scale = {};
         }
-        match.encoding.color.scale = { domain: unionDomains(s, 'color') };
+        const domain = unionDomains(s, 'color');
+        const range = unionRanges(s, 'color');
+        match.encoding.color.scale = { domain }
+        if (range.length === domain.length) {
+          match.encoding.color.scale.range = range;
+        }
       }
       return match;
     }

--- a/source/views.js
+++ b/source/views.js
@@ -34,12 +34,13 @@ const emptyData = (data) => {
 };
 
 /**
- * compute a unified data domain across all layers
+ * compute a unified set of scale values across all layers
  * @param {object} s Vega Lite specification
  * @param {string} channel visual encoding
- * @returns {array} unified domain
+ * @param {'domain'|'range'} valueType value type
+ * @returns {array} unified set of scale values
  */
-const unionDomains = (s, channel) => {
+const unionScaleValues = (s, channel, valueType) => {
   const layers = s.layer;
   const layersWithData = layers
     .map((layer) => {
@@ -70,8 +71,8 @@ const unionDomains = (s, channel) => {
     })
     .filter((item) => !!item);
 
-  const domains = scales
-    .map((item) => (typeof item.domain === 'function' ? item.domain() : null))
+  const scaleValues = scales
+    .map((item) => (typeof item[valueType] === 'function' ? item[valueType]() : null))
     .flat();
 
   const getType = (s) => s.encoding?.[channel]?.type;
@@ -79,11 +80,27 @@ const unionDomains = (s, channel) => {
   const type = getType(s) || getType(s.layer.find(getType));
 
   if (type === 'quantitative' || type === 'temporal' || !type) {
-    return d3.extent(domains);
+    return d3.extent(scaleValues);
   } else if (type === 'nominal' || type === 'ordinal') {
-    return [...new Set(domains).values()];
+    return [...new Set(scaleValues).values()];
   }
 };
+
+/**
+ * compute a unified data domain across all layers
+ * @param {object} s Vega Lite specification
+ * @param {string} channel visual encoding
+ * @returns {array} unified domain
+ */
+const unionDomains = (s, channel) => unionScaleValues(s, channel, 'domain');
+
+/**
+ * compute a unified data range across all layers
+ * @param {object} s Vega Lite specification
+ * @param {string} channel visual encoding
+ * @returns {array} unified range
+ */
+const unionRanges = (s, channel) => unionScaleValues(s, channel, 'range');
 
 /**
  * test all layers with a predicate function

--- a/tests/unit/views-test.js
+++ b/tests/unit/views-test.js
@@ -428,6 +428,226 @@ module('unit > views', () => {
           assert.ok(domain.includes(value))
         });
       });
+
+      test('unions color range', (assert) => {
+        const specification = {
+          "title": { "text": "layer color legend test specification" },
+          "data": {
+            "values": [
+              {
+                "a": "2016",
+                "b": 10,
+                "c": "_",
+                "d": 10,
+                "e": ">"
+              },
+              {
+                "a": "2017",
+                "b": 20,
+                "c": "_",
+                "d": 10,
+                "e": "<"
+              },
+              {
+                "a": "2018",
+                "b": 10,
+                "c": "_",
+                "d": 20,
+                "e": ">"
+              },
+              {
+                "a": "2019",
+                "b": 40,
+                "c": "_",
+                "d": 10,
+                "e": ">"
+              },
+              {
+                "a": "2020",
+                "b": 60,
+                "c": "_",
+                "d": 20,
+                "e": ">"
+              },
+              {
+                "a": "2021",
+                "b": 80,
+                "c": "_",
+                "d": 30,
+                "e": "<"
+              },
+              {
+                "a": "2022",
+                "b": 40,
+                "c": "_",
+                "d": 40,
+                "e": "<"
+              },
+              {
+                "a": "2016",
+                "b": 50,
+                "c": "•",
+                "d": 30,
+                "e": ">"
+              },
+              {
+                "a": "2017",
+                "b": 60,
+                "c": "•",
+                "d": 30,
+                "e": "<"
+              },
+              {
+                "a": "2018",
+                "b": 50,
+                "c": "•",
+                "d": 30,
+                "e": ">"
+              },
+              {
+                "a": "2019",
+                "b": 30,
+                "c": "•",
+                "d": 40,
+                "e": ">"
+              },
+              {
+                "a": "2020",
+                "b": 10,
+                "c": "•",
+                "d": 60,
+                "e": "<"
+              },
+              {
+                "a": "2021",
+                "b": 10,
+                "c": "•",
+                "d": 60,
+                "e": ">"
+              },
+              {
+                "a": "2022",
+                "b": 20,
+                "c": "•",
+                "d": 30,
+                "e": ">"
+              },
+              {
+                "a": "2016",
+                "b": 70,
+                "c": "+",
+                "d": 50,
+                "e": "<"
+              },
+              {
+                "a": "2017",
+                "b": 50,
+                "c": "+",
+                "d": 20,
+                "e": "<"
+              },
+              {
+                "a": "2018",
+                "b": 40,
+                "c": "+",
+                "d": 10,
+                "e": ">"
+              },
+              {
+                "a": "2019",
+                "b": 60,
+                "c": "+",
+                "d": 50,
+                "e": ">"
+              },
+              {
+                "a": "2020",
+                "b": 30,
+                "c": "+",
+                "d": 20,
+                "e": "<"
+              },
+              {
+                "a": "2021",
+                "b": 10,
+                "c": "+",
+                "d": 20,
+                "e": ">"
+              },
+              {
+                "a": "2022",
+                "b": 20,
+                "c": "+",
+                "d": 50,
+                "e": ">"
+              }
+            ]
+          },
+          "layer": [
+            {
+              "mark": {
+                "type": "line"
+              },
+              "encoding": {
+                "x": {
+                  "field": "a",
+                  "type": "temporal"
+                },
+                "y": {
+                  "field": "b",
+                  "type": "quantitative"
+                },
+                "color": {
+                  "field": "e",
+                  "type": "nominal",
+                  "scale": {
+                    "range": [
+                      "red", 
+                      "orange"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "mark": {
+                "type": "bar"
+              },
+              "encoding": {
+                "x": {
+                  "field": "a",
+                  "type": "temporal"
+                },
+                "y": {
+                  "field": "d",
+                  "type": "quantitative"
+                },
+                "color": {
+                  "field": "c",
+                  "type": "nominal",
+                  "scale": {
+                    "range": [
+                      "yellow",
+                      "green",
+                      "blue"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        };
+        const range = parseScales(layerPrimary(specification)).color.range();
+        assert.equal(range.length, 5)
+
+        const layers = [0, 1]
+        const values = layers.map((index) => specification.layer[index].encoding.color.scale.range).flat()
+
+        values.forEach((value) => {
+          assert.ok(range.includes(value))
+        });
+      });
+
       test('multiple graphical layers', (assert) => {
         const specification = {
           data: {


### PR DESCRIPTION
Generalize the`unionDomains()` function into something that can be used for either domains or ranges, then use it to compute a unified set of colors for the `layerPrimary()` function introduced in pull request #36.