### PR TITLE
range helper for bar chart temporal scales

### DIFF
--- a/source/feature.js
+++ b/source/feature.js
@@ -56,6 +56,8 @@ const _feature = (s) => {
 
   tests.hasAxis = (s) => tests.hasEncodingX(s) || tests.hasEncodingY(s);
 
+  tests.isTemporalBar = (s) => tests.isBar(s) && isTemporal;
+
   const layerTests = {};
 
   Object.entries(tests).forEach(([key, test]) => {

--- a/source/scales.js
+++ b/source/scales.js
@@ -198,8 +198,7 @@ const range = (s, dimensions, _channel) => {
 
       result = positions;
     } else {
-      const temporalBar = feature(s).isBar() && encodingType(s, channel) === 'temporal';
-      const offset = temporalBar ? barWidth(s, dimensions) : 0;
+      const offset = feature(s).isTemporalBar() ? barWidth(s, dimensions) : 0;
 
       result = [0, dimensions[channel] - offset];
     }

--- a/source/scales.js
+++ b/source/scales.js
@@ -197,7 +197,9 @@ const range = (s, dimensions, _channel) => {
 
       result = positions;
     } else {
-      result = [0, feature(s).isTemporalBar() ? temporalBarDimensions(s, dimensions)[channel] : dimensions[channel]];
+      const start = 0;
+      const end = feature(s).isTemporalBar() ? temporalBarDimensions(s, dimensions)[channel] : dimensions[channel];
+      result = [start, end];
     }
 
     if (channel === 'y' && encodingType(s, channel) === 'quantitative') {

--- a/source/scales.js
+++ b/source/scales.js
@@ -1,12 +1,11 @@
 import * as d3 from 'd3';
-import { barWidth } from './marks.js';
 import { data, sumByCovariates } from './data.js';
 import { defaultColor } from './config.js';
 import { encodingChannelQuantitative, encodingType, encodingValue } from './encodings.js';
 import { feature } from './feature.js';
 import { identity, isDiscrete, values } from './helpers.js';
 import { memoize } from './memoize.js';
-import { parseTime } from './time.js';
+import { parseTime, temporalBarDimensions } from './time.js';
 import { sorter } from './sort.js';
 
 /**
@@ -198,9 +197,7 @@ const range = (s, dimensions, _channel) => {
 
       result = positions;
     } else {
-      const offset = feature(s).isTemporalBar() ? barWidth(s, dimensions) : 0;
-
-      result = [0, dimensions[channel] - offset];
+      result = [0, feature(s).isTemporalBar() ? temporalBarDimensions(s, dimensions)[channel] : dimensions[channel]];
     }
 
     if (channel === 'y' && encodingType(s, channel) === 'quantitative') {

--- a/source/time.js
+++ b/source/time.js
@@ -1,6 +1,9 @@
 import * as d3 from 'd3';
-import { encodingValue } from './encodings.js';
+import { encodingChannelQuantitative, encodingValue } from './encodings.js';
 import { memoize } from './memoize.js';
+import { feature } from './feature.js';
+import { barWidth } from './marks.js';
+
 import matchAll from 'string.prototype.matchall';
 
 const UTC = 'utc';
@@ -178,4 +181,20 @@ const _getTimeFormatter = (s, channel) => {
 };
 const getTimeFormatter = memoize(_getTimeFormatter);
 
-export { getTimeParser, parseTime, timePeriod, getTimeFormatter, timeMethod };
+/**
+ * alter dimensions object to subtract the bar width
+ * for a temporal bar chart
+ * @param {object} s Vega Lite specification
+ * @param {object} dimensions chart dimensions
+ * @returns {object} chart dimensions with bar width offset
+ */
+const temporalBarDimensions = (s, dimensions) => {
+  const offset = feature(s).isTemporalBar() ? barWidth(s, dimensions) : 0;
+  const channel = ['x', 'y'].find(channel => channel !== encodingChannelQuantitative(s));
+  return {
+    ...dimensions,
+    [channel]: dimensions[channel] - offset
+  };
+};
+
+export { getTimeParser, parseTime, timePeriod, getTimeFormatter, timeMethod, temporalBarDimensions };

--- a/source/views.js
+++ b/source/views.js
@@ -2,7 +2,7 @@ import * as d3 from 'd3';
 import { feature } from './feature.js';
 
 import { mark, noop, values } from './helpers.js';
-import { markSelector, marks } from './marks.js';
+import { markSelector, marks, barWidth } from './marks.js';
 import { parseScales } from './scales.js';
 
 /**
@@ -296,10 +296,16 @@ const layer = (s, dimensions) => {
   return (selection) => {
     s.layer.forEach((_, index) => {
       try {
+        const layer = layerSpecification(s, index);
+        const barLayer = layerSpecification(s, s.layer.findIndex((layer) => feature(layer).isBar()))
+        const offset = feature(s).isBar() &&
+        !feature(layer).isBar()
+        ? barWidth(barLayer, dimensions)
+        : 0;
         selection
           .append('g')
           .classed('layer', true)
-          .call(marks(layerSpecification(s, index), dimensions));
+          .call(marks(layer, { y: dimensions.y, x: dimensions.x - offset}));
       } catch (error) {
         const markName = mark(layerSpecification(s, index));
 

--- a/source/views.js
+++ b/source/views.js
@@ -2,8 +2,9 @@ import * as d3 from 'd3';
 import { feature } from './feature.js';
 
 import { mark, noop, values } from './helpers.js';
-import { markSelector, marks, barWidth } from './marks.js';
+import { markSelector, marks } from './marks.js';
 import { parseScales } from './scales.js';
+import { temporalBarDimensions } from './time.js';
 
 /**
  * determine whether encoding types can be shared
@@ -298,12 +299,11 @@ const layer = (s, dimensions) => {
       try {
         const layer = layerSpecification(s, index);
         const barLayer = layerSpecification(s, s.layer.findIndex((layer) => feature(layer).isBar()))
-        const change = feature(s).isTemporalBar() && !feature(layer).isTemporalBar()
-        const offset = change ? barWidth(barLayer, dimensions) : 0;
+        const changeDimensions = feature(s).isTemporalBar() && !feature(layer).isTemporalBar()
         selection
           .append('g')
           .classed('layer', true)
-          .call(marks(layer, { y: dimensions.y, x: dimensions.x - offset}));
+          .call(marks(layer, changeDimensions ? temporalBarDimensions(barLayer, dimensions) : dimensions));
       } catch (error) {
         const markName = mark(layerSpecification(s, index));
 

--- a/source/views.js
+++ b/source/views.js
@@ -298,10 +298,8 @@ const layer = (s, dimensions) => {
       try {
         const layer = layerSpecification(s, index);
         const barLayer = layerSpecification(s, s.layer.findIndex((layer) => feature(layer).isBar()))
-        const offset = feature(s).isBar() &&
-        !feature(layer).isBar()
-        ? barWidth(barLayer, dimensions)
-        : 0;
+        const change = feature(s).isTemporalBar() && !feature(layer).isTemporalBar()
+        const offset = change ? barWidth(barLayer, dimensions) : 0;
         selection
           .append('g')
           .classed('layer', true)


### PR DESCRIPTION
Time series bar charts are common, but d3 doesn't really provide an appropriate scale type for this – [band scales](https://github.com/d3/d3-scale#band-scales) handle bars and [time scales](https://github.com/d3/d3-scale#time-scales) handle dates, but there's no scale type which can do both at the same time.

Instead, there are two common solutions:

1. manually compute the bar width and then apply it as an offset to the scale
2. convert the date objects to strings and then plot them with an ordinal scale, equivalent to Vega Lite's [scale casting](https://vega.github.io/vega-lite-v3/docs/type.html#cast-timeunit)

This pull request further refines the first approach. In the context of a reusable library, it's much cleaner to constrain that mutation inside a centralized function rather than changing dimensions on the fly when setting the scale range. The adjustment needs to be made both when rendering temporal bar charts as well as with other layers which sit on top of temporal bar charts and thus need to use synchronized positions along the time scale.