### PR TITLE
restrict single series key rewriting

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -225,21 +225,28 @@ const _stackData = (s) => {
   const summed = groupAndSumByProperties(values(s), encodingField(s, dimensions[0]), encodingField(s, 'color'), encodingField(s, dimensions[1]));
   const stacker = d3.stack().keys(stackKeys).value(stackValue);
   const stacked = stacker(summed);
+  const single = stacked.length === 1;
 
-  // mutate instead of map in order to preserve
-  // hidden keys attached to the stack layout
-  stacked.forEach((series) => {
-    if (stacked.length === 1) {
-      series.key = missingSeries();
-      series.forEach((item) => {
-        if (item.data.undefined) {
-          item.data[missingSeries()] = item.data.undefined;
-          delete item.data.undefined;
-        }
-      });
-    }
-  });
+  // this needs to test for the field instead of
+  // the encoding as with feature(s).hasColor()
+  // in order to account for value encodings
+  const seriesEncoding = encodingField(s, 'color');
 
+  const sanitize = single && !seriesEncoding;
+
+  if (sanitize) {
+    // mutate instead of map in order to preserve
+    // hidden keys attached to the stack layout
+    stacked.forEach((series) => {
+        series.key = missingSeries();
+        series.forEach((item) => {
+          if (item.data.undefined) {
+            item.data[missingSeries()] = item.data.undefined;
+            delete item.data.undefined;
+          }
+        });
+    });
+  }
   const sorted = sort(stacked);
 
   return transplantStackedBarMetadata(sorted, values(s), s);

--- a/tests/unit/data-test.js
+++ b/tests/unit/data-test.js
@@ -33,6 +33,32 @@ module('unit > data', () => {
     );
   });
 
+  test('compiles single-series data using a placeholder encoding key when a series encoding is not present', (assert) => {
+    const barData = data(specificationFixture('categoricalBar'));
+
+    assert.ok(Array.isArray(barData), 'data function returns an array');
+    assert.equal(barData.length, 1, 'single series');
+    assert.equal(barData[0].key, '_', 'series key is an underscore');
+  });
+
+  test('compiles single-series data using the original encoding key when a series encoding is present', (assert) => {
+    const specification = specificationFixture('categoricalBar');
+    const field = 'a';
+    const value = 'b';
+    specification.data.values = specification.data.values.map((item) => {
+      item[field] = value;
+      return item;
+    })
+    specification.encoding.color = {
+      field,
+      type: 'nominal'
+    };
+    const barData = data(specification);
+    assert.ok(Array.isArray(barData), 'data function returns an array');
+    assert.equal(barData.length, 1, 'single series');
+    assert.equal(barData[0].key, value, 'series key is the encoding field');
+  });
+
   test('computes circular chart data', (assert) => {
     const segments = data(specificationFixture('circular'));
     const keys = segments.every((item) => typeof item.key === 'string');


### PR DESCRIPTION
Narrows the conditions under which the key of a single series is assumed to be in error and is consequently overwritten with a deliberate placeholder. This better handles cases with sparse data where the input only contains one series but multiple possible series values are enumerated by the range.