### PR TITLE
symmetric log scales

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -46,7 +46,14 @@ const scaleType = (s, channel) => {
       quantitative: 'scaleLinear',
       ordinal: 'scaleOrdinal',
     }
-    method = methods[encodingType(s, channel)]
+    if(
+      s.encoding[channel].scale?.type === 'symlog' &&
+      encodingType(s, channel) === 'quantitative'
+    ) {
+      method = 'scaleSymlog';
+    } else {
+      method = methods[encodingType(s, channel)];
+    }
   }
   if (typeof d3[method] === 'function') {
     return method;

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -297,4 +297,38 @@ module('unit > scales', (hooks) => {
     };
     assert.throws(() => parseScales(s));
   });
+
+  test('generates symmetric log scales', (assert) => {
+    const spec = {
+      data: {
+        values: [
+          { value: 10000, label: '2020-01-01' },
+          { value: 200, label: '2020-01-02' },
+          { value: 300, label: '2020-01-03' },
+          { value: 400, label: '2020-01-04' },
+          { value: 500, label: '2020-01-05' },
+        ],
+      },
+      mark: 'line',
+      encoding: {
+        y: {
+          field: 'value',
+          type: 'quantitative',
+          scale: { type: 'symlog' },
+        },
+      },
+    };
+
+    assert.strictEqual(
+      parseScales(spec, dimensions).y(100).toFixed(4),
+      '50.5953',
+      'should generate symmetric log scales',
+    );
+    assert.strictEqual(
+      parseScales(spec, dimensions).y(0).toFixed(4),
+      '100.0000',
+      'symmetric log scales should handle zero',
+    );
+  });
+
 });


### PR DESCRIPTION
Adds support for [symlog scales](https://vega.github.io/vega-lite/docs/scale.html#symlog). (Thanks, @husseinqudsi!)