### PR TITLE
extensions

### DIFF
--- a/source/extensions.js
+++ b/source/extensions.js
@@ -1,8 +1,6 @@
 const extension = (s, key) => {
     if (s.usermeta?.[key]) {
         return s.usermeta[key];
-    } else {
-        throw new Error(`${key} is missing from specification.usermeta`);
     }
 };
 

--- a/source/extensions.js
+++ b/source/extensions.js
@@ -1,0 +1,9 @@
+const extension = (s, key) => {
+    if (s.usermeta?.[key]) {
+        return s.usermeta[key];
+    } else {
+        throw new Error(`${key} is missing from specification.usermeta`);
+    }
+};
+
+export { extension };

--- a/source/init.js
+++ b/source/init.js
@@ -1,5 +1,6 @@
 import { WRAPPER_CLASS } from './config.js';
 import { feature } from './feature.js';
+import { extension } from './extensions.js';
 
 /**
  * prepare the DOM of a specified element for rendering a chart
@@ -43,7 +44,7 @@ const init = (s, dimensions) => {
       }
     }
 
-    const id = s.usermeta?.id;
+    const id = extension(s, 'id');
 
     if (id) {
       svg.attr('aria-labelledby', `title-${id}`);


### PR DESCRIPTION
Vega Lite provides the [`usermeta`](https://vega.github.io/vega-lite/docs/spec.html#top-level) property as a way to add arbitrary additional information in a structured fashion.

> Optional metadata that will be passed to Vega. This object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.

This adds an internal helper function called `extension()` which can look up values from that property, which presumably will always be a hashmap. Currently this is only used for the `id`, but will likely be necessary for additional functionality in the future, such as [sonification](https://github.com/vijithassar/bisonica/issues/63).

`extension(s, 'id')` is equivalent to `specification.usermeta.id`; the main benefit of this is simply that now it's retrieved through a function which can perform additional shenanigans while constraining, instead of simply reading a property which would be more likely to leak strange behaviors out to the caller.