### PR TITLE
faster tests

### DIFF
--- a/tests/integration/aria-test.js
+++ b/tests/integration/aria-test.js
@@ -5,7 +5,7 @@ const { module, test } = qunit;
 
 module('integration > aria', function () {
 
-  test('aria-label matches tooltip by default', async function (assert) {
+  test('aria-label matches tooltip by default', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.usermeta = { tooltipHandler: false };
@@ -20,7 +20,7 @@ module('integration > aria', function () {
     assert.ok(match);
   });
 
-  test('aria-label matches tooltip when tooltip channel is specified', async function (assert) {
+  test('aria-label matches tooltip when tooltip channel is specified', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.usermeta = { tooltipHandler: false };
@@ -38,7 +38,7 @@ module('integration > aria', function () {
     assert.ok(match);
   });
 
-  test('aria-label can be set with description field', async function (assert) {
+  test('aria-label can be set with description field', (assert) => {
     const spec = specificationFixture('stackedBar');
     const element = render(spec);
 
@@ -48,7 +48,7 @@ module('integration > aria', function () {
 
   });
 
-  test('aria-label can be set to a calculate transform field', async function (assert) {
+  test('aria-label can be set to a calculate transform field', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.transform = [{ calculate: "'START:' + datum.value + ':END'", as: 'test' }];
@@ -59,7 +59,7 @@ module('integration > aria', function () {
     assert.ok(element.querySelector(testSelector('mark')).getAttribute('aria-label').match(/^START.*END$/));
   });
 
-  test('aria-label can diverge from tooltip', async function (assert) {
+  test('aria-label can diverge from tooltip', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.usermeta = { tooltipHandler: false };
@@ -81,7 +81,7 @@ module('integration > aria', function () {
     assert.notOk(match);
   });
 
-  test('every bar chart mark has an aria-label attribute by default', async function (assert) {
+  test('every bar chart mark has an aria-label attribute by default', (assert) => {
     const spec = specificationFixture('stackedBar');
     const element = render(spec);
     element.querySelectorAll(testSelector('mark')).forEach((mark => {
@@ -89,7 +89,7 @@ module('integration > aria', function () {
     }));
   });
 
-  test('every circular chart mark has an aria-label attribute by default', async function (assert) {
+  test('every circular chart mark has an aria-label attribute by default', (assert) => {
     const spec = specificationFixture('circular');
     const element = render(spec);
     element.querySelectorAll(testSelector('mark')).forEach((mark) => {
@@ -97,7 +97,7 @@ module('integration > aria', function () {
     });
   });
 
-  test('every line chart point mark has an aria-label attribute by default', async function (assert) {
+  test('every line chart point mark has an aria-label attribute by default', (assert) => {
     const spec = specificationFixture('line');
     const element = render(spec);
     element.querySelectorAll(testSelector('mark')).forEach((mark) => {

--- a/tests/integration/aria-test.js
+++ b/tests/integration/aria-test.js
@@ -6,7 +6,7 @@ const { module, test } = qunit;
 module('integration > aria', function () {
 
   test('aria-label matches tooltip by default', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('circular');
 
     spec.usermeta = { tooltipHandler: false };
 
@@ -21,7 +21,7 @@ module('integration > aria', function () {
   });
 
   test('aria-label matches tooltip when tooltip channel is specified', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('circular');
 
     spec.usermeta = { tooltipHandler: false };
 
@@ -39,7 +39,7 @@ module('integration > aria', function () {
   });
 
   test('aria-label can be set with description field', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('circular');
     const element = render(spec);
 
     [...element.querySelectorAll(testSelector('mark'))].forEach(mark => {
@@ -49,7 +49,7 @@ module('integration > aria', function () {
   });
 
   test('aria-label can be set to a calculate transform field', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('circular');
 
     spec.transform = [{ calculate: "'START:' + datum.value + ':END'", as: 'test' }];
     spec.encoding.description = { field: 'test' };
@@ -60,7 +60,7 @@ module('integration > aria', function () {
   });
 
   test('aria-label can diverge from tooltip', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('circular');
 
     spec.usermeta = { tooltipHandler: false };
 
@@ -82,7 +82,7 @@ module('integration > aria', function () {
   });
 
   test('every bar chart mark has an aria-label attribute by default', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('categoricalBar');
     const element = render(spec);
     element.querySelectorAll(testSelector('mark')).forEach((mark => {
       assert.ok(mark.getAttribute('aria-label'));

--- a/tests/integration/axes-test.js
+++ b/tests/integration/axes-test.js
@@ -4,7 +4,7 @@ import { render, testSelector, specificationFixture } from '../test-helpers.js';
 const { module, test } = qunit;
 
 module('integration > axes', function () {
-  test('renders a chart with axes', async function (assert) {
+  test('renders a chart with axes', (assert) => {
     const spec = specificationFixture('stackedBar');
     const element = render(spec);
 
@@ -15,7 +15,7 @@ module('integration > axes', function () {
     assert.ok(element.querySelector(testSelector('tick')));
   });
 
-  test('renders a chart with custom axis titles', async function (assert) {
+  test('renders a chart with custom axis titles', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.encoding.x.axis = { title: 'a' };
@@ -25,7 +25,7 @@ module('integration > axes', function () {
     assert.equal(element.querySelector(testSelector('axes-y-title')).textContent, spec.encoding.y.axis.title);
   });
 
-  test('renders a chart without y-axis tick labels', async function (assert) {
+  test('renders a chart without y-axis tick labels', (assert) => {
     let spec, element;
 
     spec = specificationFixture('stackedBar');
@@ -48,7 +48,7 @@ module('integration > axes', function () {
     assert.ok(!tickLabelTexts.some((el) => el.textContent.length));
   });
 
-  test('renders a chart with custom axis tick intervals', async function (assert) {
+  test('renders a chart with custom axis tick intervals', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     const dates = spec.data.values.map((item) => new Date(item.label));
@@ -73,7 +73,7 @@ module('integration > axes', function () {
     assert.ok(weekly.length < differenceDays);
   });
 
-  test('renders a chart with custom axis tick steps', async function (assert) {
+  test('renders a chart with custom axis tick steps', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     const dates = spec.data.values.map((item) => new Date(item.label));
@@ -89,7 +89,7 @@ module('integration > axes', function () {
     assert.ok(ticks.length < differenceDays);
   });
 
-  test('renders a chart without axes', async function (assert) {
+  test('renders a chart without axes', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.encoding.x.axis = { title: null };
@@ -101,7 +101,7 @@ module('integration > axes', function () {
     selectors.forEach((selector) => assert.notOk(element.querySelector(selector)));
   });
 
-  test('renders a chart with truncated axis labels', async function (assert) {
+  test('renders a chart with truncated axis labels', (assert) => {
     const max = 20;
     const spec = specificationFixture('categoricalBar');
 

--- a/tests/integration/axes-test.js
+++ b/tests/integration/axes-test.js
@@ -1,11 +1,12 @@
 import qunit from 'qunit';
 import { render, testSelector, specificationFixture } from '../test-helpers.js';
+import * as d3 from 'd3';
 
 const { module, test } = qunit;
 
 module('integration > axes', function () {
   test('renders a chart with axes', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('line');
     const element = render(spec);
 
     const single = [testSelector('axes'), testSelector('axes-x'), testSelector('axes-y')];
@@ -16,7 +17,7 @@ module('integration > axes', function () {
   });
 
   test('renders a chart with custom axis titles', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('line');
 
     spec.encoding.x.axis = { title: 'a' };
     spec.encoding.y.axis = { title: 'b' };
@@ -28,7 +29,7 @@ module('integration > axes', function () {
   test('renders a chart without y-axis tick labels', (assert) => {
     let spec, element;
 
-    spec = specificationFixture('stackedBar');
+    spec = specificationFixture('line');
 
     element = render(spec);
 
@@ -38,9 +39,9 @@ module('integration > axes', function () {
 
     assert.ok(tickLabelTexts.every((el) => el.textContent.length));
 
-    spec = specificationFixture('stackedBar');
+    spec = specificationFixture('line');
 
-    spec.encoding.y.axis.labels = false;
+    spec.encoding.y.axis = {labels: false};
 
     element = render(spec);
     tickLabelTexts = [...element.querySelectorAll(`${testSelector('axes-y')} .tick text`)];
@@ -49,32 +50,32 @@ module('integration > axes', function () {
   });
 
   test('renders a chart with custom axis tick intervals', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const monthly = specificationFixture('temporalBar');
+    const biannual = specificationFixture('temporalBar'); 
 
-    const dates = spec.data.values.map((item) => new Date(item.label));
-    const differenceMilliseconds = Math.abs(Math.min(...dates) - Math.max(...dates));
-    const differenceDays = Math.floor(differenceMilliseconds / (24 * 60 * 60 * 1000));
+    const endpoints = d3.extent(monthly.data.values, (d) => +d.date);
+    const years = endpoints[1] - endpoints[0];
 
-    spec.encoding.x.axis = { tickCount: { interval: 'utchour' } };
+    monthly.encoding.x.axis = { tickCount: { interval: 'utcmonth' } };
 
     let element;
 
-    element = render(spec);
+    element = render(monthly);
 
-    const hourly = element.querySelectorAll(`${testSelector('axes-x')} .tick`);
+    const monthlyTicks = element.querySelectorAll(`${testSelector('axes-x')} .tick`);
 
-    assert.ok(hourly.length > differenceDays);
+    assert.ok(monthlyTicks.length > years);
 
-    spec.encoding.x.axis = { tickCount: { interval: 'utcweek' } };
-    element = render(spec);
+    biannual.encoding.x.axis = { tickCount: { interval: 'utcyear', step: 2 } };
+    element = render(biannual);
 
-    const weekly = element.querySelectorAll(`${testSelector('axes-x')} .tick`);
+    const biannualTicks = element.querySelectorAll(`${testSelector('axes-x')} .tick`);
 
-    assert.ok(weekly.length < differenceDays);
+    assert.ok(biannualTicks.length < years);
   });
 
   test('renders a chart with custom axis tick steps', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('line');
 
     const dates = spec.data.values.map((item) => new Date(item.label));
     const differenceMilliseconds = Math.abs(Math.min(...dates) - Math.max(...dates));
@@ -90,7 +91,7 @@ module('integration > axes', function () {
   });
 
   test('renders a chart without axes', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('line');
 
     spec.encoding.x.axis = { title: null };
     spec.encoding.y.axis = { title: null };

--- a/tests/integration/axes-test.js
+++ b/tests/integration/axes-test.js
@@ -27,26 +27,16 @@ module('integration > axes', function () {
   });
 
   test('renders a chart without y-axis tick labels', (assert) => {
-    let spec, element;
 
-    spec = specificationFixture('line');
-
-    element = render(spec);
-
-    let tickLabelTexts;
-
-    tickLabelTexts = [...element.querySelectorAll(`${testSelector('axes-y')} .tick text`)];
-
-    assert.ok(tickLabelTexts.every((el) => el.textContent.length));
-
-    spec = specificationFixture('line');
+    const spec = specificationFixture('line');
 
     spec.encoding.y.axis = {labels: false};
 
-    element = render(spec);
-    tickLabelTexts = [...element.querySelectorAll(`${testSelector('axes-y')} .tick text`)];
+    const element = render(spec);
 
-    assert.ok(!tickLabelTexts.some((el) => el.textContent.length));
+    const tickLabelText = element.querySelector(`${testSelector('axes-y')} .axis`).textContent;
+
+    assert.equal(tickLabelText, '');
   });
 
   test('renders a chart with custom axis tick intervals', (assert) => {

--- a/tests/integration/categorical-bar-test.js
+++ b/tests/integration/categorical-bar-test.js
@@ -10,7 +10,7 @@ const { module, test } = qunit;
 const approximate = (value) => Math.round(value * 100) / 100;
 
 module('integration > categorical-bar', function () {
-  test('renders a categorical bar chart', async function (assert) {
+  test('renders a categorical bar chart', (assert) => {
     const spec = specificationFixture('categoricalBar');
 
     const element = render(spec);
@@ -39,7 +39,7 @@ module('integration > categorical-bar', function () {
     });
   });
 
-  test('handles input data with all zero values', async function (assert) {
+  test('handles input data with all zero values', (assert) => {
     const spec = specificationFixture('categoricalBar');
 
     spec.data.values.forEach((item) => {

--- a/tests/integration/circular-test.js
+++ b/tests/integration/circular-test.js
@@ -73,7 +73,7 @@ const isPie = (marks) => {
 };
 
 module('integration > circular', function () {
-  test('renders a circular chart', async function (assert) {
+  test('renders a circular chart', (assert) => {
     const spec = specificationFixture('circular');
 
     const element = render(spec);
@@ -93,7 +93,7 @@ module('integration > circular', function () {
     assert.ok(mark.length === colors.size, 'every segment is a different color');
   });
 
-  test('renders a pie chart', async function (assert) {
+  test('renders a pie chart', (assert) => {
     const spec = specificationFixture('circular');
 
     spec.mark = 'arc';
@@ -110,7 +110,7 @@ module('integration > circular', function () {
     assert.ok(isPie(marks));
   });
 
-  test.skip('renders a donut chart', async function (assert) {
+  test.skip('renders a donut chart', (assert) => {
     const donutChartSpec = {
       ...specificationFixture('circular'),
       mark: { type: 'arc', innerRadius: 50 },

--- a/tests/integration/legend-test.js
+++ b/tests/integration/legend-test.js
@@ -5,7 +5,7 @@ const { module, test } = qunit;
 
 module('integration > legend', function () {
   test('renders a chart with legend', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('line');
     const element = render(spec);
 
     assert.ok(element.querySelector(testSelector('legend')));

--- a/tests/integration/legend-test.js
+++ b/tests/integration/legend-test.js
@@ -4,20 +4,20 @@ import { render, specificationFixture, testSelector } from '../test-helpers.js';
 const { module, test } = qunit;
 
 module('integration > legend', function () {
-  test('renders a chart with legend', async function (assert) {
+  test('renders a chart with legend', (assert) => {
     const spec = specificationFixture('stackedBar');
     const element = render(spec);
 
     assert.ok(element.querySelector(testSelector('legend')));
   });
 
-  test('renders a chart with legend automatically omitted', async function (assert) {
+  test('renders a chart with legend automatically omitted', (assert) => {
     const spec = specificationFixture('categoricalBar');
     const element = render(spec);
     assert.equal(element.querySelector(testSelector('legend')).textContent, '');
   });
 
-  test('renders a chart with legend explicitly omitted', async function (assert) {
+  test('renders a chart with legend explicitly omitted', (assert) => {
     const spec = specificationFixture('line');
 
     spec.encoding.color.legend = null;
@@ -26,7 +26,7 @@ module('integration > legend', function () {
     assert.equal(element.querySelector(testSelector('legend')).textContent, '');
   });
 
-  test('renders a legend with all categories', async function (assert) {
+  test('renders a legend with all categories', (assert) => {
     const spec = specificationFixture('line');
     const categories = [...new Set(spec.data.values.map((item) => item.group))];
 
@@ -35,13 +35,13 @@ module('integration > legend', function () {
     assert.equal(element.querySelectorAll(testSelector('legend-pair')).length, categories.length)
   });
 
-  test.skip('partitions legend into popup when content overflows', async function (assert) {
+  test.skip('partitions legend into popup when content overflows', (assert) => {
     const spec = specificationFixture('line');
     const element = render(spec);
     assert.ok(element.querySelector(testSelector('legend-items-more')));
   });
 
-  test('renders legend in full when content does not overflow', async function (assert) {
+  test('renders legend in full when content does not overflow', (assert) => {
     const spec = specificationFixture('line');
 
     const ids = new Map();

--- a/tests/integration/line-test.js
+++ b/tests/integration/line-test.js
@@ -7,7 +7,7 @@ const { module, test } = qunit;
 const pointSelector = testSelector('marks-mark-point');
 
 module('integration > line', function () {
-  test('renders a line chart', async function (assert) {
+  test('renders a line chart', (assert) => {
     const spec = specificationFixture('line');
     const element = render(spec);
 
@@ -26,13 +26,13 @@ module('integration > line', function () {
     });
   });
 
-  test('renders a line chart with points', async function (assert) {
+  test('renders a line chart with points', (assert) => {
     const spec = specificationFixture('line');
     const element = render(spec);
     assert.ok(element.querySelector(pointSelector));
   });
 
-  test('renders a line chart without points', async function (assert) {
+  test('renders a line chart without points', (assert) => {
     const spec = specificationFixture('line');
 
     delete spec.mark.point;
@@ -40,7 +40,7 @@ module('integration > line', function () {
     assert.notOk(element.querySelector(pointSelector));
   });
 
-  test('renders a line chart with arbitrary field names', async function (assert) {
+  test('renders a line chart with arbitrary field names', (assert) => {
     const spec = specificationFixture('line');
     const propertyMap = {
       label: '_',

--- a/tests/integration/pivot-test.js
+++ b/tests/integration/pivot-test.js
@@ -14,7 +14,7 @@ module('integration > pivot urls', function () {
 
   const getUrl = (item) => d3.select(item).datum().url;
 
-  test('stacked bar chart pivot links', async function (assert) {
+  test('stacked bar chart pivot links', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.encoding.href = { field: 'url' };
@@ -29,7 +29,7 @@ module('integration > pivot urls', function () {
     assert.notEqual(urls[0], urls[1]);
   });
 
-  test('categorical bar chart pivot links', async function (assert) {
+  test('categorical bar chart pivot links', (assert) => {
     const spec = specificationFixture('categoricalBar');
 
     spec.encoding.href = { field: 'url' };
@@ -44,7 +44,7 @@ module('integration > pivot urls', function () {
     assert.notEqual(urls[0], urls[1]);
   });
 
-  test('line chart pivot links', async function (assert) {
+  test('line chart pivot links', (assert) => {
     const spec = specificationFixture('line');
 
     spec.encoding.href = { field: 'url' };
@@ -71,7 +71,7 @@ module('integration > pivot urls', function () {
     assert.notEqual(urls[0], urls[1]);
   });
 
-  test('circular chart pivot links', async function (assert) {
+  test('circular chart pivot links', (assert) => {
     const spec = specificationFixture('circular');
 
     spec.data.values = [

--- a/tests/integration/rules-test.js
+++ b/tests/integration/rules-test.js
@@ -5,7 +5,7 @@ import { specificationFixture } from '../test-helpers.js';
 const { module, test } = qunit;
 
 module('integration > rules', function () {
-  test('renders rules', async function (assert) {
+  test('renders rules', (assert) => {
     const spec = specificationFixture('rules');
     const element = render(spec);
 

--- a/tests/integration/single-bar-test.js
+++ b/tests/integration/single-bar-test.js
@@ -5,7 +5,7 @@ import { specificationFixture } from '../test-helpers.js';
 const { module, test } = qunit;
 
 module('integration > single bar', function () {
-    test('renders a stacked single bar', async function (assert) {
+    test('renders a stacked single bar', (assert) => {
         const spec = specificationFixture('singleBar');
         const element = render(spec);
 

--- a/tests/integration/sort-test.js
+++ b/tests/integration/sort-test.js
@@ -6,7 +6,7 @@ import { specificationFixture } from '../test-helpers.js';
 const { module, test } = qunit;
 
 module('integration > sort', function () {
-  test('renders marks in ascending order', async function (assert) {
+  test('renders marks in ascending order', (assert) => {
     const spec = specificationFixture('categoricalBar');
 
     spec.encoding.x.sort = 'y';
@@ -21,7 +21,7 @@ module('integration > sort', function () {
 
     assert.deepEqual(values, sorted);
   });
-  test('renders marks in descending order', async function (assert) {
+  test('renders marks in descending order', (assert) => {
     const spec = specificationFixture('categoricalBar');
 
     spec.encoding.x.sort = '-y';

--- a/tests/integration/stacked-area-test.js
+++ b/tests/integration/stacked-area-test.js
@@ -5,7 +5,7 @@ import { specificationFixture } from '../test-helpers.js';
 const { module, test } = qunit;
 
 module('integration > stacked area', function () {
-    test('renders a stacked area chart', async function (assert) {
+    test('renders a stacked area chart', (assert) => {
         const spec = specificationFixture('stackedArea');
         const element = render(spec);
 

--- a/tests/integration/stacked-bar-test.js
+++ b/tests/integration/stacked-bar-test.js
@@ -5,7 +5,7 @@ import { specificationFixture } from '../test-helpers.js';
 const { module, test } = qunit;
 
 module('integration > stacked-bar', function () {
-  test('renders a vertical stacked bar chart', async function (assert) {
+  test('renders a vertical stacked bar chart', (assert) => {
     const spec = specificationFixture('stackedBar');
     const element = render(spec);
 
@@ -27,7 +27,7 @@ module('integration > stacked-bar', function () {
     assert.ok(!nodesHaveZeroHeights, 'some mark rects have nonzero height attributes');
   });
 
-  test('renders a horizontal stacked bar chart', async function (assert) {
+  test('renders a horizontal stacked bar chart', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     const { x, y } = spec.encoding;

--- a/tests/integration/text-test.js
+++ b/tests/integration/text-test.js
@@ -6,7 +6,7 @@ const { module, test } = qunit;
 
 module('integration > text', function () {
 
-  test('renders text marks', async function (assert) {
+  test('renders text marks', (assert) => {
     const spec = {
       $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
       title: {
@@ -34,7 +34,7 @@ module('integration > text', function () {
 
   });
 
-  test('renders text marks with dynamic attributes', async function (assert) {
+  test('renders text marks with dynamic attributes', (assert) => {
     const spec = specificationFixture('scatterPlot');
 
     spec.mark = { type: 'text' };

--- a/tests/integration/time-series-bar-test.js
+++ b/tests/integration/time-series-bar-test.js
@@ -11,7 +11,7 @@ const { module, test } = qunit;
 const approximate = (value) => Math.round(value * 100) / 100;
 
 module('integration > temporal-bar', function () {
-  test('renders a time series bar chart', async function (assert) {
+  test('renders a time series bar chart', (assert) => {
     const spec = specificationFixture('temporalBar');
 
     const element = render(spec);
@@ -40,7 +40,7 @@ module('integration > temporal-bar', function () {
     });
   });
 
-  test('handles input data with all zero values', async function (assert) {
+  test('handles input data with all zero values', (assert) => {
     const spec = specificationFixture('temporalBar');
 
     spec.data.values.forEach((item) => {

--- a/tests/integration/tooltip-test.js
+++ b/tests/integration/tooltip-test.js
@@ -10,7 +10,7 @@ const { module, test } = qunit;
 
 module('integration > tooltips', function () {
 
-  test('renders a chart with SVG title tooltips', async function (assert) {
+  test('renders a chart with SVG title tooltips', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.usermeta = { tooltipHandler: false };
@@ -20,7 +20,7 @@ module('integration > tooltips', function () {
     assert.ok(element.querySelector(testSelector('mark-title')));
   });
 
-  test('renders a chart without SVG title tooltips', async function (assert) {
+  test('renders a chart without SVG title tooltips', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.usermeta = { tooltipHandler: false };
@@ -31,7 +31,7 @@ module('integration > tooltips', function () {
     assert.notOk(element.querySelector(testSelector('mark-title')));
   });
 
-  test('disables SVG title tooltips when a custom tooltip handler is indicated', async function (assert) {
+  test('disables SVG title tooltips when a custom tooltip handler is indicated', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.usermeta = { tooltipHandler: true };
@@ -41,7 +41,7 @@ module('integration > tooltips', function () {
     assert.notOk(element.querySelector(testSelector('mark-title')));
   });
 
-  test.skip('disables tooltips from the encoding hash', async function (assert) {
+  test.skip('disables tooltips from the encoding hash', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.encoding.tooltip = null;
@@ -50,7 +50,7 @@ module('integration > tooltips', function () {
     assert.dom(testSelector('mark-title')).doesNotExist();
   });
 
-  test('renders a chart with encoding values in the SVG title tooltip', async function (assert) {
+  test('renders a chart with encoding values in the SVG title tooltip', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.usermeta = { tooltipHandler: false };
@@ -67,7 +67,7 @@ module('integration > tooltips', function () {
     });
   });
 
-  test('renders a stacked bar chart with SVG title tooltips', async function (assert) {
+  test('renders a stacked bar chart with SVG title tooltips', (assert) => {
     const spec = specificationFixture('stackedBar');
 
     spec.usermeta = { tooltipHandler: false };
@@ -80,7 +80,7 @@ module('integration > tooltips', function () {
 
   });
 
-  test('renders a circular chart with SVG title tooltips', async function (assert) {
+  test('renders a circular chart with SVG title tooltips', (assert) => {
     const spec = specificationFixture('circular');
 
     spec.usermeta = { tooltipHandler: false };
@@ -92,7 +92,7 @@ module('integration > tooltips', function () {
     assert.ok(!element.querySelector(testSelector('mark-title')).textContent.includes('undefined'));
   });
 
-  test('renders a line chart with SVG title tooltips', async function (assert) {
+  test('renders a line chart with SVG title tooltips', (assert) => {
     const spec = specificationFixture('line');
 
     spec.usermeta = { tooltipHandler: false };
@@ -104,7 +104,7 @@ module('integration > tooltips', function () {
     assert.ok(!element.querySelector(testSelector('point-title')).textContent.includes('undefined'));
   });
 
-  test('follows tooltip rendering instructions in charts with nested layers', async function (assert) {
+  test('follows tooltip rendering instructions in charts with nested layers', (assert) => {
     const graphic = specificationFixture('circular');
 
     graphic.mark.innerRadius = 50;
@@ -126,7 +126,7 @@ module('integration > tooltips', function () {
     assert.notOk(element.querySelector(testSelector('mark-title')));
   });
 
-  test('emits a CustomEvent with tooltip details in response to mouseover', async function (assert) {
+  test('emits a CustomEvent with tooltip details in response to mouseover', (assert) => {
     const element = render(specificationFixture('circular'));
 
     const event = new MouseEvent('mouseover', { bubbles: true });

--- a/tests/integration/tooltip-test.js
+++ b/tests/integration/tooltip-test.js
@@ -16,7 +16,7 @@ module('integration > tooltips', function () {
 
     const element = render(spec);
 
-    assert.ok(element.querySelectorAll(testSelector('mark-title').length > 0));
+    assert.ok(element.querySelectorAll(testSelector('mark-title').length > 0), 'mark nodes contain title nodes');
   });
 
   test('renders a chart without SVG title tooltips', (assert) => {
@@ -27,7 +27,7 @@ module('integration > tooltips', function () {
     delete spec.mark.tooltip;
     const element = render(spec);
 
-    assert.notOk(element.querySelectorAll(testSelector('mark-title')).length > 0);
+    assert.equal(element.querySelectorAll(testSelector('mark-title')).length, 0, 'mark nodes do not contain title nodes');
   });
 
   test('disables SVG title tooltips when a custom tooltip handler is indicated', (assert) => {
@@ -37,7 +37,7 @@ module('integration > tooltips', function () {
 
     const element = render(spec);
 
-    assert.notOk(element.querySelectorAll(testSelector('mark-title')).length > 0);
+    assert.equal(element.querySelectorAll(testSelector('mark-title')).length, 0, 'mark nodes do not contain title nodes');
   });
 
   test.skip('disables tooltips from the encoding hash', (assert) => {

--- a/tests/integration/tooltip-test.js
+++ b/tests/integration/tooltip-test.js
@@ -11,38 +11,37 @@ const { module, test } = qunit;
 module('integration > tooltips', function () {
 
   test('renders a chart with SVG title tooltips', (assert) => {
-    const spec = specificationFixture('stackedBar');
-
+    const spec = specificationFixture('line');
     spec.usermeta = { tooltipHandler: false };
 
     const element = render(spec);
 
-    assert.ok(element.querySelector(testSelector('mark-title')));
+    assert.ok(element.querySelectorAll(testSelector('mark-title').length > 0));
   });
 
   test('renders a chart without SVG title tooltips', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('line');
 
     spec.usermeta = { tooltipHandler: false };
 
     delete spec.mark.tooltip;
     const element = render(spec);
 
-    assert.notOk(element.querySelector(testSelector('mark-title')));
+    assert.notOk(element.querySelectorAll(testSelector('mark-title')).length > 0);
   });
 
   test('disables SVG title tooltips when a custom tooltip handler is indicated', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('line');
 
     spec.usermeta = { tooltipHandler: true };
 
     const element = render(spec);
 
-    assert.notOk(element.querySelector(testSelector('mark-title')));
+    assert.notOk(element.querySelectorAll(testSelector('mark-title')).length > 0);
   });
 
   test.skip('disables tooltips from the encoding hash', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('line');
 
     spec.encoding.tooltip = null;
     const element = render(spec); // eslint-disable-line
@@ -51,7 +50,7 @@ module('integration > tooltips', function () {
   });
 
   test('renders a chart with encoding values in the SVG title tooltip', (assert) => {
-    const spec = specificationFixture('stackedBar');
+    const spec = specificationFixture('circular');
 
     spec.usermeta = { tooltipHandler: false };
 

--- a/tests/integration/views-test.js
+++ b/tests/integration/views-test.js
@@ -4,14 +4,14 @@ import { render, specificationFixture, testSelector } from '../test-helpers.js';
 const { module, test } = qunit;
 
 module('integration > views', function () {
-  test('renders a chart without layers', async function (assert) {
+  test('renders a chart without layers', (assert) => {
     const spec = specificationFixture('line');
     const element = render(spec);
 
     assert.notOk(element.querySelector(testSelector('layer')));
   });
 
-  test('renders a chart with one layer', async function (assert) {
+  test('renders a chart with one layer', (assert) => {
     const spec = { ...specificationFixture('line') };
     const lineLayer = {
       mark: spec.mark,
@@ -26,7 +26,7 @@ module('integration > views', function () {
     assert.ok(element.querySelector(testSelector('layer')));
   });
 
-  test('renders a chart with two layers', async function (assert) {
+  test('renders a chart with two layers', (assert) => {
     const spec = { ...specificationFixture('line') };
 
     const lineLayer = {
@@ -49,7 +49,7 @@ module('integration > views', function () {
     assert.equal(element.querySelectorAll(testSelector('layer')).length, 2);
   });
 
-  test('renders a chart with nested layer data', async function (assert) {
+  test('renders a chart with nested layer data', (assert) => {
     const lineChartSpec = specificationFixture('line');
     const layerSpec = JSON.parse(JSON.stringify(lineChartSpec));
     const lineLayer = {

--- a/tests/unit/encodings-test.js
+++ b/tests/unit/encodings-test.js
@@ -9,7 +9,7 @@ import {
 import { dimensions } from './support.js';
 import qunit from 'qunit';
 import { parseTime } from '../../source/time.js';
-import { stackedBarChartSpec } from '../../fixtures/stacked-bar.js';
+import { specificationFixture } from '../test-helpers.js';
 
 const { module, test } = qunit;
 
@@ -20,8 +20,9 @@ module('unit > encoders', () => {
       y: (d) => d.value,
       color: (d) => d.group,
     };
-    const encoders = createEncoders(stackedBarChartSpec, dimensions, accessors);
-    const dataPoint = stackedBarChartSpec.data.values[0];
+    const specification = specificationFixture('line');
+    const encoders = createEncoders(specification, dimensions, accessors);
+    const dataPoint = specification.data.values[0];
 
     assert.equal(typeof encoders, 'object', 'encoders are methods on an object');
     Object.entries(encoders).forEach(([name, encoder]) => {

--- a/tests/unit/marks-test.js
+++ b/tests/unit/marks-test.js
@@ -10,7 +10,7 @@ module('unit > marks', () => {
     const dimensions = { x: 1000, y: 1000 };
 
     test('return value', (assert) => {
-      const specification = specificationFixture('stackedBar');
+      const specification = specificationFixture('categoricalBar');
 
       assert.equal(
         typeof barWidth(specification, dimensions),
@@ -20,7 +20,7 @@ module('unit > marks', () => {
     });
 
     test('temporal encoding', (assert) => {
-      const specification = specificationFixture('stackedBar');
+      const specification = specificationFixture('temporalBar');
       const dates = new Set(specification.data.values.map((item) => item.label)).size;
 
       assert.ok(
@@ -66,10 +66,10 @@ module('unit > marks', () => {
     });
 
     test('iterates through temporal periods for custom domains', (assert) => {
-      const standardSpec = specificationFixture('stackedBar');
-      const customSpec = specificationFixture('stackedBar');
+      const standardSpec = specificationFixture('temporalBar');
+      const customSpec = specificationFixture('temporalBar');
       const standardWidth = barWidth(standardSpec, dimensions);
-      customSpec.encoding.x.scale = {domain: ['2020-04-20', '2020-07-01']};
+      customSpec.encoding.x.scale = {domain: ['2010', '2020']};
       const customWidth = barWidth(customSpec, dimensions);
       assert.ok(standardWidth > customWidth);
     });

--- a/tests/unit/mutation-test.js
+++ b/tests/unit/mutation-test.js
@@ -2,7 +2,7 @@ import { chart } from '../../source/chart.js';
 import { init } from '../../source/init.js';
 import qunit from 'qunit';
 import { select } from 'd3';
-import { stackedBarChartSpec } from '../../fixtures/stacked-bar.js';
+import { specificationFixture } from '../test-helpers.js';
 
 const { module, test } = qunit;
 
@@ -27,7 +27,7 @@ const freeze = (object) => {
 
 module('unit > mutation', () => {
   test('does not mutate specifications', (assert) => {
-    const s = freeze(JSON.parse(JSON.stringify(stackedBarChartSpec)));
+    const s = freeze(JSON.parse(JSON.stringify(specificationFixture('line'))));
     const dimensions = { x: 500, y: 500 };
 
     assert.equal(

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -1,5 +1,4 @@
 import { dimensions } from './support.js';
-import { lineChartSpec } from '../../fixtures/line.js';
 import qunit from 'qunit';
 import { parseScales } from '../../source/scales.js';
 import { parseTime } from '../../source/time.js';
@@ -7,9 +6,10 @@ import { specificationFixture } from '../test-helpers.js';
 
 const { module, test } = qunit;
 
-const stackedBarChartSpec = specificationFixture('stackedBar');
-const ordinalSpec = specificationFixture('stackedBar');
+const lineChartSpec = specificationFixture('line');
+const categoricalBarChartSpec = specificationFixture('categoricalBar');
 
+const ordinalSpec = specificationFixture('line');
 ordinalSpec.encoding.color.type = 'ordinal';
 
 module('unit > scales', (hooks) => {
@@ -17,7 +17,7 @@ module('unit > scales', (hooks) => {
 
   hooks.beforeEach(() => {
     scales = {
-      ...parseScales(stackedBarChartSpec, dimensions),
+      ...parseScales(lineChartSpec, dimensions),
       colorOrdinal: parseScales(ordinalSpec, dimensions).color,
     };
   });
@@ -70,7 +70,7 @@ module('unit > scales', (hooks) => {
 
   test('extended scales', (assert) => {
     const core = parseScales(lineChartSpec, dimensions);
-    const extended = parseScales(stackedBarChartSpec, dimensions);
+    const extended = parseScales(categoricalBarChartSpec, dimensions);
 
     assert.ok(Object.keys(core).length < Object.keys(extended).length, 'creates additional scales');
     Object.entries(extended)


### PR DESCRIPTION
There's currently a performance bottleneck in the data preprocessing stage when juggling additional metadata fields for charts with three or more graphical encodings. This includes stacked bar charts, which use `x`, `y`, and `color`. The stacked bar chart JSON fixture is used extensively throughout the test suite, needlessly hitting that slower code path even when the multidimensional nature of the chart does not affect the intent of the test. Frequently using the slowest chart type is a historical accident, and simply changing to a different chart type in the tests when possible roughly triples the speed of the test suite. For the most part this does not require any other changes, although a couple tests did need to be reworked very slightly.

Along the way, a bit of additional cleanup to the test code.