### PR TITLE
render values directly with disabled scales

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -23,6 +23,18 @@ const colors = (count = 5) => {
 };
 
 /**
+ * make a normal function appear to be a scale function
+ * by adding domain and range methods
+ * @param {function} scale scale function
+ * @param {array} domain scale domain
+ * @param {array} range scale range
+ * @returns {function} scale function with mocked domain and range
+ */
+const syntheticScale = (scale, domain, range) => {
+  return Object.assign(scale, { domain: () => domain, range: () => range });
+};
+
+/**
  * determine the d3 method name of the scale function to
  * generate for a given dimension of visual encoding
  * @param {object} s Vega Lite specification
@@ -270,9 +282,7 @@ const coreScales = (s, dimensions) => {
     .forEach(([channel]) => {
       try {
         if (scaleType(s, channel) === null) {
-          scales[channel] = identity;
-          scales[channel].domain = () => domain(s, channel);
-          scales[channel].range = () => domain(s, channel);
+          scales[channel] = syntheticScale(identity, domain(s, channel), domain(s, channel));
         } else {
           const method = scaleType(s, channelRoot(s, channel));
           const scale = d3[method]().domain(domain(s, channel)).range(range(s, dimensions, channel));

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -272,6 +272,34 @@ module('unit > scales', (hooks) => {
     });
   });
 
+  test('null disables scales and passes values directly', (assert) => {
+    const s = {
+      data: {
+        values: [
+          { group: 'red', value: 0 },
+          { group: 'blue', value: 10 },
+          { group: 'green', value: 100 },
+        ],
+      },
+      mark: {
+        type: 'arc'
+      },
+      encoding: {
+        theta: {
+          type: 'quantitative',
+          field: 'value',
+        },
+        color: {
+          type: 'nominal',
+          field: 'group',
+          scale: null
+        }
+      },
+    };
+    assert.equal(parseScales(s).color('red'), 'red');
+
+  })
+
   test('throws errors for unknown encoding types', (assert) => {
     const s = {
       data: {


### PR DESCRIPTION
Vega Lite allows scales to be [disabled entirely](https://vega.github.io/vega-lite/docs/scale.html#disable) by setting `[channel].scale: null`, after which it will plot values pulled directly from the data without first encoding or transforming them. This is sort of conceptually equivalent to a [value encoding](https://vega.github.io/vega-lite/docs/encoding.html#value-def) or a [datum encoding](https://vega.github.io/vega-lite/docs/encoding.html#datum-def), but it doesn't rely on the encoding definition because the desired output values are already in present the data set.