### PR TITLE
interactions across multiple layers

### DIFF
--- a/source/feature.js
+++ b/source/feature.js
@@ -47,6 +47,7 @@ const _feature = (s) => {
     hasAxisTitleY: (s) => s.encoding?.y?.axis?.title !== null,
     isCartesian: (s) => s.encoding?.x && s.encoding?.y,
     isLinear: (s) => (s.encoding?.x && !s.encoding.y) || (s.encoding.y && !s.encoding.x),
+    isRadial: (s) => s.encoding.theta,
     isTemporal: () => isTemporal,
     isMulticolor: () => isMulticolor,
     hasEncodingX: (s) => s.encoding?.x,

--- a/source/feature.js
+++ b/source/feature.js
@@ -40,6 +40,7 @@ const _feature = (s) => {
     hasData: (s) => !!s.data?.values.length,
     hasLegend: (s) => s.encoding?.color?.legend !== null,
     hasLegendTitle: (s) => isPresent(s.encoding?.color?.legend?.title),
+    hasTooltip: (s) => s.mark.tooltip || s.encoding?.tooltip,
     hasTransforms: (s) => Array.isArray(s.transform),
     hasAxisLabelsY: (s) => s.encoding?.y?.axis?.labels !== false,
     hasAxisLabelsX: (s) => s.encoding?.x?.axis?.labels !== false,

--- a/source/feature.js
+++ b/source/feature.js
@@ -1,4 +1,4 @@
-import { encodingField, encodingValue } from './encodings.js';
+import { encodingValue } from './encodings.js';
 import { layerTestRecursive } from './views.js';
 import { mark, values } from './helpers.js';
 import { memoize } from './memoize.js';
@@ -36,7 +36,7 @@ const _feature = (s) => {
     isText: (s) => mark(s) === 'text',
     isAggregate: (s) => ['x', 'y'].some((channel) => s.encoding?.[channel]?.aggregate),
     hasColor: (s) => !!s.encoding?.color,
-    hasLinks: (s) => !!encodingField(s, 'href'),
+    hasLinks: (s) => !!s.encoding.href,
     hasData: (s) => !!s.data?.values.length,
     hasLegend: (s) => s.encoding?.color?.legend !== null,
     hasLegendTitle: (s) => isPresent(s.encoding?.color?.legend?.title),

--- a/source/feature.js
+++ b/source/feature.js
@@ -45,6 +45,7 @@ const _feature = (s) => {
     hasAxisLabelsX: (s) => s.encoding?.x?.axis?.labels !== false,
     hasAxisTitleX: (s) => s.encoding?.x?.axis?.title !== null,
     hasAxisTitleY: (s) => s.encoding?.y?.axis?.title !== null,
+    hasStaticText: (s) => s.mark?.text && !s.encoding?.text,
     isCartesian: (s) => s.encoding?.x && s.encoding?.y,
     isLinear: (s) => (s.encoding?.x && !s.encoding.y) || (s.encoding.y && !s.encoding.x),
     isRadial: (s) => s.encoding.theta,

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 
-import { encodingField, encodingType } from './encodings.js';
+import { encodingField, encodingType, encodingValue } from './encodings.js';
 import { feature } from './feature.js';
 
 /**
@@ -55,9 +55,11 @@ const missingSeries = () => '_';
  * @returns {string} url
  */
 const getUrl = (s, d) => {
+  if (!d) {
+    return s.encoding.href.value;
+  }
   const field = encodingField(s, 'href');
-
-  return d.data?.[missingSeries()]?.[field] || d.data?.[field] || d[field];
+  return d?.data?.[missingSeries()]?.[field] || d?.data?.[field] || encodingValue(s, 'href')(d);
 };
 
 /**

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -187,8 +187,7 @@ const interactions = (s) => {
         });
         click.on('click', function () {
           if (feature(s).hasLinks()) {
-            const url = getUrl(s, d3.select(this).datum());
-
+            const url = getUrl(s, d3.select(this).datum() || null);
             dispatcher.call('link', this, url);
           }
         });

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -118,9 +118,10 @@ const interactions = (s) => {
     const dispatcher = dispatchers.get(wrapper.node());
 
     const markMouseover = () => {
-      const mouseover = d3.select(layerNode(s, wrapper.node())).selectAll(markMouseoverSelector(s));
-      const click = d3.select(layerNode(s, wrapper.node())).selectAll(markInteractionSelector(s));
-      const tooltip = d3.select(layerNode(s, wrapper.node())).selectAll(markInteractionSelector(s));
+      const layer = layerNode(s, wrapper.node());
+      const mouseover = d3.select(layer).selectAll(markMouseoverSelector(s));
+      const click = d3.select(layer).selectAll(markInteractionSelector(s));
+      const tooltip = d3.select(layer).selectAll(markInteractionSelector(s));
 
       if (
         feature(s).isBar() ||

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -4,7 +4,7 @@ import { category, markInteractionSelector, markSelector } from './marks.js';
 import { customLinkHandler } from './config.js';
 import { feature } from './feature.js';
 import { getUrl, key, noop } from './helpers.js';
-import { layerMatch, layerNode } from './views.js';
+import { layerSpecification, layerNode } from './views.js';
 import { tooltipEvent } from './tooltips.js';
 
 const dispatchers = d3.local();
@@ -104,18 +104,11 @@ const handleUrl = (url, node) => {
 };
 
 /**
- * attach event listeners for specific events based on
- * the chart type
- * @param {object} _s Vega Lite specification
+ * attach event listeners to a layer
+ * @param {object} s Vega Lite specification
  * @returns {function} user interactions
  */
-const interactions = (_s) => {
-  const interactionTest = (s) => {
-    const datumEncoding = Object.values(s.encoding).some((definition) => definition.datum);
-
-    return s.mark && (!datumEncoding || !feature(s).isText());
-  };
-  const s = layerMatch(_s, interactionTest);
+const interactions = (s) => {
 
   const fn = (wrapper) => {
     if (!s) {
@@ -133,6 +126,7 @@ const interactions = (_s) => {
         feature(s).isBar() ||
         feature(s).isLine() ||
         feature(s).isCircular() ||
+        feature(s).isText() ||
         (!feature(s).isLine() && feature(s).hasPoints())
       ) {
         dispatcher.on('addMarkHighlight', function () {
@@ -232,4 +226,21 @@ const interactions = (_s) => {
   return fn;
 };
 
-export { dispatchers, initializeInteractions, interactions };
+/**
+ * attach event listeners for user interactions across multiple layers
+ * @param {object} s Vega Lite specification
+ * @returns {function(object)} event listener registration function
+ */
+const interactionsLayered = (s) => {
+  const layers = s.layer ? s.layer.map((_, index) => layerSpecification(s, index)) : [s];
+  if (!layers.length) {
+    throw new Error('could not determine layers for interactions');
+  }
+  return (selection) => {
+    layers.forEach((layer) => {
+      selection.call(interactions(layer));
+    });
+  };
+}
+
+export { dispatchers, initializeInteractions, interactionsLayered as interactions };

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -174,7 +174,9 @@ const interactions = (s) => {
           tooltipEvent(s, this, event);
         });
         tooltip.on('mouseover.tooltip', function (event) {
-          dispatcher.call('tooltip', this, event);
+          if (feature(s).hasTooltip()) {
+            dispatcher.call('tooltip', this, event);
+          }
         });
 
         // pivot links

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -170,12 +170,14 @@ const interactions = (s) => {
           });
 
         // tooltips
-        dispatcher.on('tooltip', function (event) {
-          tooltipEvent(s, this, event);
+        dispatcher.on('tooltip', function (event, s) {
+          if (s) {
+            tooltipEvent(s, this, event);
+          }
         });
         tooltip.on('mouseover.tooltip', function (event) {
           if (feature(s).hasTooltip()) {
-            dispatcher.call('tooltip', this, event);
+            dispatcher.call('tooltip', this, event, s);
           }
         });
 

--- a/source/marks.js
+++ b/source/marks.js
@@ -665,7 +665,8 @@ const textMarks = (s, dimensions) => {
     const dy = text.node().getBoundingClientRect().height * 0.25;
 
     text.attr('transform', `translate(0,${dy})`);
-    text.classed('link', s.encoding && encodingValue(s, 'href'));
+    const hasLink = !!(s.encoding && encodingValue(s, 'href'));
+    text.classed('link', hasLink);
 
   };
 };

--- a/source/marks.js
+++ b/source/marks.js
@@ -116,7 +116,7 @@ const barWidth = memoize(_barWidth);
 /**
  * mark tagName
  * @param {object} s Vega Lite specification
- * @returns {('rect'|'path'|'circle'|'line')} tagName to use in DOM for mark
+ * @returns {('rect'|'path'|'circle'|'line'|'text')} tagName to use in DOM for mark
  */
 const markSelector = (s) => {
   if (feature(s).isBar()) {
@@ -127,6 +127,8 @@ const markSelector = (s) => {
     return 'circle';
   } else if (feature(s).isRule()) {
     return 'line';
+  } else if (feature(s).isText()) {
+    return 'text';
   }
 };
 

--- a/source/markup.js
+++ b/source/markup.js
@@ -6,7 +6,9 @@ const selectors = [
   '.layer',
   '.marks',
   '.mark',
-  '.marks .mark.point', // more specific, needs to come after the more general .mark above
+  // marks types are more specific and need to come after the more general .mark above
+  '.marks .mark.point',
+  '.marks .mark.text',
   '.axes',
   '.axes .x',
   '.axes .x .title',

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -76,7 +76,8 @@ function tooltipEvent(s, node, interaction) {
 
     node.dispatchEvent(customEvent);
   } catch (error) {
-    throw new Error(`could not emit tooltip event - ${error.message}`);
+    error.message = `could not emit tooltip event - ${error.message}`;
+    throw error;
   }
 }
 

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -58,6 +58,11 @@ const includedChannels = memoize(_includedChannels);
 function tooltipEvent(s, node, interaction) {
   try {
     const datum = d3.select(node).datum();
+
+    if (!datum) {
+      return;
+    }
+
     const detail = { datum, node, interaction, content: tooltipContentData(s)(datum) };
 
     if (feature(s).isMulticolor()) {

--- a/source/views.js
+++ b/source/views.js
@@ -141,16 +141,6 @@ const layerMatch = (s, test) => {
 };
 
 /**
- * determine whether text is statically
- * encoded in the mark object
- * @param {object} s Vega Lite specification
- * @returns {boolean}
- */
-const staticTextMark = (s) => {
-  return s.mark?.text && !s.encoding?.text;
-};
-
-/**
  * select the layer that is likely to be the most important
  * for global functionality like axes and margins across the
  * entire chart
@@ -174,7 +164,7 @@ const _layerPrimary = (s) => {
   // add a wrapper to require encoding
   .map((heuristic) => (s) => s.encoding && heuristic(s))
   // add a wrapper to prohibit static text marks
-  .map((heuristic) => (s) => !staticTextMark(s) && heuristic(s));
+  .map((heuristic) => (s) => !feature(s).hasStaticText() && heuristic(s));
 
   for (const heuristic of heuristics) {
     let match = layerMatch(s, heuristic);

--- a/source/views.js
+++ b/source/views.js
@@ -334,4 +334,4 @@ const layerTestRecursive = (s, test) => {
   return test(s) || layerTest(s, test);
 };
 
-export { layer, layerMatch, layerPrimary, layerNode, layerTestRecursive };
+export { layer, layerMatch, layerPrimary, layerNode, layerTestRecursive, layerSpecification };

--- a/source/views.js
+++ b/source/views.js
@@ -140,6 +140,16 @@ const layerMatch = (s, test) => {
 };
 
 /**
+ * determine whether text is statically
+ * encoded in the mark object
+ * @param {object} s Vega Lite specification
+ * @returns {boolean}
+ */
+const staticTextMark = (s) => {
+  return s.mark?.text && !s.encoding?.text;
+};
+
+/**
  * select the layer that is likely to be the most important
  * for global functionality like axes and margins across the
  * entire chart
@@ -159,8 +169,11 @@ const layerPrimary = (s) => {
     (s) => s.encoding.x && s.encoding.y,
     // linear
     (s) => s.encoding.x && !s.encoding.y || !s.encoding.x && s.encoding.y,
-    // add a wrapper to require encoding
-  ].map((heuristic) => (s) => s.encoding && heuristic(s));
+  ]
+  // add a wrapper to require encoding
+  .map((heuristic) => (s) => s.encoding && heuristic(s))
+  // add a wrapper to prohibit static text marks
+  .map((heuristic) => (s) => !staticTextMark(s) && heuristic(s));
 
   for (const heuristic of heuristics) {
     let match = layerMatch(s, heuristic);

--- a/source/views.js
+++ b/source/views.js
@@ -3,6 +3,7 @@ import { feature } from './feature.js';
 
 import { mark, noop, values } from './helpers.js';
 import { markSelector, marks } from './marks.js';
+import { memoize } from './memoize.js';
 import { parseScales } from './scales.js';
 import { temporalBarDimensions } from './time.js';
 
@@ -156,7 +157,7 @@ const staticTextMark = (s) => {
  * @param {object} s Vega Lite specification
  * @returns {object} layer specification
  */
-const layerPrimary = (s) => {
+const _layerPrimary = (s) => {
   if (!s.layer) {
     return s;
   }
@@ -196,6 +197,7 @@ const layerPrimary = (s) => {
     }
   }
 };
+const layerPrimary = memoize(_layerPrimary);
 
 /**
  * find the DOM element corresponding to a layer

--- a/source/views.js
+++ b/source/views.js
@@ -233,15 +233,9 @@ const layerSpecification = (s, index) => {
     ...layer,
   };
 
-  // clean up empty properties in layers with text content defined by the mark object
+  // clean up layers with text content defined by the mark object
   if (layerSpecification.mark.type === 'text' && layerSpecification.mark.text) {
-    const properties = ['data', 'encoding'];
-
-    properties.forEach((property) => {
-      if (Object.prototype.hasOwnProperty.call(layerSpecification, property)) {
-        delete layerSpecification[property];
-      }
-    });
+    delete layerSpecification.data;
   }
 
   Object.entries(layerSpecification.encoding || {}).forEach(([channel, definition]) => {

--- a/tests/integration/tooltip-test.js
+++ b/tests/integration/tooltip-test.js
@@ -138,6 +138,8 @@ module('integration > tooltips', function () {
     element.querySelectorAll(testSelector('mark'))[0].dispatchEvent(event);
 
     assert.equal(typeof tooltipEvent.detail.datum, 'object', 'custom event detail has datum');
+    assert.equal(typeof tooltipEvent.detail.content, 'object', 'custom event detail has content');
+    assert.equal(tooltipEvent.detail.content.length, 2, 'custom event detail has two fields');
     assert.equal(
       typeof tooltipEvent.detail.interaction.bubbles,
       'boolean',
@@ -238,6 +240,8 @@ module('integration > tooltips', function () {
     element.querySelectorAll(testSelector('mark'))[0].dispatchEvent(event);
 
     assert.equal(typeof tooltipEvent.detail.datum, 'object', 'custom event detail has datum');
+    assert.equal(typeof tooltipEvent.detail.content, 'object', 'custom event detail has content');
+    assert.equal(tooltipEvent.detail.content.length, 2, 'custom event detail has two fields');
     assert.equal(
       typeof tooltipEvent.detail.interaction.bubbles,
       'boolean',

--- a/tests/integration/tooltip-test.js
+++ b/tests/integration/tooltip-test.js
@@ -150,6 +150,107 @@ module('integration > tooltips', function () {
     );
   });
 
+  test('emits a CustomEvent with tooltip details in response to mouseover on layered charts', (assert) => {
+    const s = {
+      "title": {
+        "text": "donut chart with layered event interactions"
+      },
+      "data": {
+        "values": [
+          {
+            "value": 10,
+            "group": "a",
+            "url": "https://www.example.com/a/"
+          },
+          {
+            "value": 20,
+            "group": "b",
+            "url": "https://www.example.com/b/"
+          },
+          {
+            "value": 30,
+            "group": "c",
+            "url": "https://www.example.com/c/"
+          }
+        ]
+      },
+      "usermeta": { "tooltipHandler": true },
+      "layer": [
+        {
+          "mark": {
+            "type": "arc",
+            "innerRadius": 50,
+            "tooltip": true
+          },
+          "encoding": {
+            "href": {
+              "field": "url",
+              "type": "nominal"
+            },
+            "color": {
+              "field": "group",
+              "type": "nominal"
+            },
+            "theta": {
+              "field": "value",
+              "type": "quantitative"
+            }
+          }
+        },
+        {
+          "data": {
+            "values": [
+              {
+                "a": "https://www.google.com",
+                "b": "9999"
+              }
+            ]
+          },
+          "mark": {
+            "type": "text",
+            "tooltip": true
+          },
+          "encoding": {
+            "href": {
+              "field": "a"
+            },
+            "text": {
+              "field": "b"
+            },
+            "tooltip": {
+              "field": "href",
+              "type": "nominal"
+            }
+          }
+        }
+      ]
+    };
+
+    const element = render(s);
+
+    const event = new MouseEvent('mouseover', { bubbles: true });
+    let tooltipEvent = null;
+
+    element.querySelector('.chart').addEventListener('tooltip', (event) => {
+      tooltipEvent = event;
+    });
+
+    element.querySelectorAll(testSelector('mark'))[0].dispatchEvent(event);
+
+    assert.equal(typeof tooltipEvent.detail.datum, 'object', 'custom event detail has datum');
+    assert.equal(
+      typeof tooltipEvent.detail.interaction.bubbles,
+      'boolean',
+      'custom event detail has original interaction event',
+    );
+    assert.equal(
+      typeof tooltipEvent.detail.node.querySelector,
+      'function',
+      'custom event detail has node',
+    );
+  });
+
+
   test.skip('displays a custom tooltip', async function (assert) {
     const spec = specificationFixture('circular'); // eslint-disable-line
 

--- a/tests/unit/interactions-test.js
+++ b/tests/unit/interactions-test.js
@@ -1,0 +1,84 @@
+import { dispatchers } from '../../source/interactions.js';
+import {
+    render,
+    specificationFixture,
+    testSelector
+} from '../test-helpers.js';
+import qunit from 'qunit';
+
+const { module, test } = qunit;
+
+const validateDispatcher = (dispatcher) => {
+    return ['link', 'tooltip'].every((key) => typeof dispatcher._[key] === 'object');
+};
+
+module('unit > interactions', function () {
+
+    test('registers an event dispatcher for charts with single layer', (assert) => {
+
+        const element = render(specificationFixture('circular'));
+
+        const mark = element.querySelector(testSelector('mark'));
+
+        const dispatcher = dispatchers.get(mark);
+        assert.ok(validateDispatcher(dispatcher), 'layered node has associated event dispatcher');
+    });
+
+    test('registers an event dispatcher for charts with multiple layers', (assert) => {
+        const s = {
+            title: {
+                text: 'donut chart'
+            },
+            data: {
+                values: [
+                    { value: 10, group: '*' },
+                    { value: 20, group: '_' },
+                    { value: 30, group: '•' },
+                ]
+            },
+            usermeta: {
+                customTooltipHandler: (event) => {
+                    console.log(event);
+                }
+            },
+            layer: [
+                {
+                    mark: {
+                        type: 'arc',
+                        innerRadius: 50
+                    },
+                    encoding: {
+                        color: {
+                            field: 'group',
+                            type: 'nominal'
+                        },
+                        theta: {
+                            field: 'value',
+                            type: 'quantitative'
+                        }
+                    }
+                },
+                {
+                    mark: {
+                        type: 'text',
+                        text: 60,
+                    },
+                    encoding: {
+                        href: {
+                            value: "https://www.example.com"
+                        }
+                    }
+                }
+            ]
+        };
+
+        const element = render(s);
+
+        const layers = [...element.querySelectorAll(testSelector('layer'))];
+        layers.forEach((layer, index) => {
+            const dispatcher = dispatchers.get(layer);
+            assert.ok(validateDispatcher(dispatcher), `layer node at index ${index} has an associated event dispatcher`);
+        });
+    });
+
+});


### PR DESCRIPTION
Start attaching interactions to multiple layers simultaneously so tooltips and links can be set on any content from any layer, instead of only on whatever content the heuristics of the `layerPrimary()` view helper have prioritized.

Just in case it may help divert future hassles: the trickiest piece was figuring out that the interaction handling sends the _most recent_ specification to the dispatcher based on the loop, which is not necessarily the one you want, since it may not match the mark. That's why it's provided as an explicit argument instead of through scope.