### PR TITLE
Cartesian covariate helper

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -3,7 +3,7 @@ import * as d3 from 'd3';
 import { layoutDirection } from './marks.js';
 import {
   encodingChannelCovariate,
-  encodingChannelQuantitative,
+  encodingChannelCovariateCartesian,
   encodingField,
   encodingType,
   encodingValue,
@@ -137,7 +137,7 @@ const sort = (data) => {
 const transplantStackedBarMetadata = (aggregated, raw, s) => {
   const createMatcher = (key) => {
     const matcher = (aggregatedItem, raw) => {
-      const laneChannel = ['x', 'y'].find((channel) => channel !== encodingChannelQuantitative(s));
+      const laneChannel = encodingChannelCovariateCartesian(s);
       const keys = {
         lane: encodingField(s, laneChannel),
         series: encodingField(s, 'color'),

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -119,6 +119,22 @@ const encodingChannelCovariate = (s) => {
 };
 
 /**
+ * determine which channel of a Cartesian specification object
+ * is secondary to the quantitative channel
+ * @param {object} s Vega Lite specification
+ * @returns {string} visual encoding chanel
+ */
+const encodingChannelCovariateCartesian = (s) => {
+    const channel = ['x', 'y'].find((channel => channel !== encodingChannelQuantitative(s)));
+    if (channel) {
+      return channel;
+    } else {
+      const message = feature(s).isCartesian() ? 'could not determine Cartesian covariate encoding' : 'specification is not Cartesian';
+      throw new Error(message);
+    }
+};
+
+/**
  * generate a set of complex encoders
  * @param {object} s Vega Lite specification
  * @param {object} dimensions desired dimensions of the chart
@@ -182,6 +198,7 @@ export {
   encodingType,
   encodingChannelQuantitative,
   encodingChannelCovariate,
+  encodingChannelCovariateCartesian,
   createEncoders,
   encodingValueQuantitative,
 };

--- a/source/marks.js
+++ b/source/marks.js
@@ -4,6 +4,7 @@ import { BAR_WIDTH_MINIMUM } from './config.js';
 import { createAccessors } from './accessors.js';
 import {
   createEncoders,
+  encodingChannelCovariateCartesian,
   encodingChannelQuantitative,
   encodingType,
   encodingValue,
@@ -78,7 +79,7 @@ const markDescription = memoize(_markDescription);
  * @returns {number} bar width
  */
 const _barWidth = (s, dimensions) => {
-  const channel = ['x', 'y'].find((channel => channel !== encodingChannelQuantitative(s)));
+  const channel = encodingChannelCovariateCartesian(s);
   const barWidthMaximum = dimensions[channel] / 3;
   const stacked = markData(s);
   const type = encodingType(s, channel);

--- a/source/time.js
+++ b/source/time.js
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import { encodingChannelQuantitative, encodingValue } from './encodings.js';
+import { encodingChannelCovariateCartesian, encodingValue } from './encodings.js';
 import { memoize } from './memoize.js';
 import { feature } from './feature.js';
 import { barWidth } from './marks.js';
@@ -190,7 +190,7 @@ const getTimeFormatter = memoize(_getTimeFormatter);
  */
 const temporalBarDimensions = (s, dimensions) => {
   const offset = feature(s).isTemporalBar() ? barWidth(s, dimensions) : 0;
-  const channel = ['x', 'y'].find(channel => channel !== encodingChannelQuantitative(s));
+  const channel = encodingChannelCovariateCartesian(s);
   return {
     ...dimensions,
     [channel]: dimensions[channel] - offset


### PR DESCRIPTION
Adds a reusable helper function to determine the secondary non-quantitative encoding of any Cartesian chart. For example, for a bar chart with horizontal bars it will return `"y"`, and for a standard time series line chart it will return `"x"`.