### PR TITLE
layer function call utility

### DIFF
--- a/source/interactions.js
+++ b/source/interactions.js
@@ -4,7 +4,7 @@ import { category, markInteractionSelector, markSelector } from './marks.js';
 import { customLinkHandler } from './config.js';
 import { feature } from './feature.js';
 import { getUrl, key, noop } from './helpers.js';
-import { layerSpecification, layerNode } from './views.js';
+import { layerCall, layerNode } from './views.js';
 import { tooltipEvent } from './tooltips.js';
 
 const dispatchers = d3.local();
@@ -108,7 +108,7 @@ const handleUrl = (url, node) => {
  * @param {object} s Vega Lite specification
  * @returns {function} user interactions
  */
-const interactions = (s) => {
+const _interactions = (s) => {
 
   const fn = (wrapper) => {
     if (!s) {
@@ -230,21 +230,6 @@ const interactions = (s) => {
   return fn;
 };
 
-/**
- * attach event listeners for user interactions across multiple layers
- * @param {object} s Vega Lite specification
- * @returns {function(object)} event listener registration function
- */
-const interactionsLayered = (s) => {
-  const layers = s.layer ? s.layer.map((_, index) => layerSpecification(s, index)) : [s];
-  if (!layers.length) {
-    throw new Error('could not determine layers for interactions');
-  }
-  return (selection) => {
-    layers.forEach((layer) => {
-      selection.call(interactions(layer));
-    });
-  };
-}
+const interactions = (s) => layerCall(s, _interactions);
 
-export { dispatchers, initializeInteractions, interactionsLayered as interactions };
+export { dispatchers, initializeInteractions, interactions };

--- a/source/views.js
+++ b/source/views.js
@@ -324,4 +324,26 @@ const layerTestRecursive = (s, test) => {
   return test(s) || layerTest(s, test);
 };
 
-export { layer, layerMatch, layerPrimary, layerNode, layerTestRecursive, layerSpecification };
+/**
+ * run a function with selection.call() across multiple layers
+ * @param {object} s Vega Lite specification
+ * @returns {function(object)}
+ */
+const layerCall = (s, fn) => {
+  const layers = s.layer ? s.layer.map((_, index) => layerSpecification(s, index)) : [s];
+  if (!layers.length) {
+    throw new Error(`could not determine layers for calling function ${fn.name}`);
+  }
+  return (selection) => {
+    layers.forEach((layer, index) => {
+      try {
+        selection.call(fn(layer));
+      } catch (error) {
+        error.message = `function ${fn.name} does not return a function for layer ${index}`;
+        throw new Error(error);
+      }
+    });
+  };
+}
+
+export { layer, layerMatch, layerPrimary, layerNode, layerTestRecursive, layerSpecification, layerCall };

--- a/tests/unit/views-test.js
+++ b/tests/unit/views-test.js
@@ -1,10 +1,12 @@
 import {
+  layerCall,
   layerMatch,
   layerNode,
   layerPrimary
 } from '../../source/views.js';
 import qunit from 'qunit';
 import { parseScales } from '../../source/scales.js';
+import * as d3 from 'd3';
 
 const { module, test } = qunit;
 
@@ -704,6 +706,67 @@ module('unit > views', () => {
         };
         assert.equal(layerPrimary(specification).mark.type, 'bar', 'selects layers with explicit axis configuration from charts with multiple graphical layers');
       });
+    });
+
+
+    test('calls a function for multiple layers', (assert) => {
+      const s = {
+        title: {
+          text: 'layerCall() test specification'
+        },
+        data: {
+          values: [
+            { a: 1, b: 10 },
+            { a: 2, b: 11 },
+            { a: 3, b: 12 },
+          ]
+        },
+        layer: [
+          {
+            mark: {
+              type: 'point'
+            },
+            encoding: {
+              x: {
+                field: 'a',
+                type: 'quantitative'
+              },
+              y: {
+                field: 'b',
+                type: 'quantitative'
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'text'
+            },
+            encoding: {
+              x: {
+                field: 'a',
+                type: 'quantitative'
+              },
+              y: {
+                field: 'b',
+                type: 'quantitative'
+              },
+              text: {
+                field: 'b'
+              }
+            }
+          }
+        ]
+      }
+      const results = {};
+      const track = (s) => {
+        return () => {
+          results[s.mark.type] = true;
+        };
+      };
+      const element = document.createElement('div');
+      d3.select(element).call(layerCall(s, track));
+      assert.ok(results.point);
+      assert.ok(results.text);
     });
   });
 });


### PR DESCRIPTION
Refactors the layer handling abstraction added for interactions in pull request #77 into a generic helper which becomes part of the `views.js` module. This now allows any function to be called on each layer of a specification using d3's [`selection.call()`](https://github.com/d3/d3-selection#selection_call).