### PR TITLE
rename layer function

### DIFF
--- a/source/chart.js
+++ b/source/chart.js
@@ -3,7 +3,7 @@ import { axes } from './axes.js';
 import { init } from './init.js';
 import { initializeInteractions, interactions } from './interactions.js';
 import { keyboard } from './keyboard.js';
-import { layer } from './views.js';
+import { layerMarks } from './views.js';
 import { legend } from './legend.js';
 import { margin, position } from './position.js';
 import { marks } from './marks.js';
@@ -52,7 +52,7 @@ const chart = (s, panelDimensions) => {
 
       wrapper
         .call(axes(s, dimensions))
-        .call((s.layer ? layer : marks)(s, dimensions))
+        .call((s.layer ? layerMarks : marks)(s, dimensions))
         .call(keyboard(s))
         .call(interactions(s));
       selection.call(testAttributes);

--- a/source/views.js
+++ b/source/views.js
@@ -288,7 +288,7 @@ const layerSpecification = (s, index) => {
  * @param {object} dimensions chart dimensions
  * @returns {function} layer renderer
  */
-const layer = (s, dimensions) => {
+const layerMarks = (s, dimensions) => {
   if (!s.layer.length) {
     return noop;
   }
@@ -346,4 +346,4 @@ const layerCall = (s, fn) => {
   };
 }
 
-export { layer, layerMatch, layerPrimary, layerNode, layerTestRecursive, layerSpecification, layerCall };
+export { layerMarks, layerMatch, layerPrimary, layerNode, layerTestRecursive, layerSpecification, layerCall };


### PR DESCRIPTION
Renames the existing `layer()` function to use the more specific term `layerMarks()` in light of the additional layer interaction functionality in pull request #77 and the generic helper in pull request #81.