### PR TITLE
dynamic field names in circular charts

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -8,7 +8,6 @@ import {
   encodingChannelQuantitative,
   encodingType,
   encodingValue,
-  encodingValueQuantitative,
 } from './encodings.js';
 import { data, pointData } from './data.js';
 import { datum, isDiscrete, key, missingSeries, values } from './helpers.js';
@@ -504,7 +503,8 @@ const circularMarks = (s, dimensions) => {
   const innerRadius = outerRadius * innerRadiusRatio;
   const { color } = parseScales(s);
   const sort = (a, b) => color.domain().indexOf(a.group) - color.domain().indexOf(b.group);
-  const layout = d3.pie().value(encodingValueQuantitative(s)).sort(sort);
+  const value = (d) => d.value;
+  const layout = d3.pie().value(value).sort(sort);
   const encoders = createEncoders(s, dimensions, createAccessors(s));
   const renderer = (selection) => {
     const marks = selection.append('g').attr('class', 'marks');

--- a/tests/integration/circular-test.js
+++ b/tests/integration/circular-test.js
@@ -93,6 +93,43 @@ module('integration > circular', function () {
     assert.ok(mark.length === colors.size, 'every segment is a different color');
   });
 
+  test('renders a circular chart with arbitrary field names', (assert) => {
+    const spec = specificationFixture('circular');
+    const keys = {
+      group: '•',
+      label: '-',
+      value: '+'
+    };
+    spec.data.values = spec.data.values.map((item) => {
+      Object.entries(keys).forEach(([original, altered]) => {
+        item[altered] = item[original];
+        delete item[original];
+      });
+      return item;
+    });
+    Object.entries(spec.encoding).forEach(([channel, definition]) => {
+      const original = definition.field;
+      const altered = keys[original];
+      spec.encoding[channel].field = altered;
+    });
+
+    const element = render(spec);
+
+    const markSelector = testSelector('mark');
+
+    assert.ok(element.querySelector(markSelector));
+    assert.equal(element.querySelector(markSelector).tagName, 'path');
+
+    const marks = element.querySelector(testSelector('marks'));
+
+    assert.ok(isCircular(marks), 'marks group has approximately equal height and width');
+
+    const mark = [...marks.querySelectorAll(markSelector)];
+    const colors = new Set(mark.map((item) => item.style.fill));
+
+    assert.ok(mark.length === colors.size, 'every segment is a different color');
+  });
+
   test('renders a pie chart', (assert) => {
     const spec = specificationFixture('circular');
 


### PR DESCRIPTION
Circular charts should use _static_ keys when looking up values from the layout object, and trying to make this dynamic actually _prevents_ charts from rendering.