### PR TITLE
bidirectional line charts

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -1,5 +1,5 @@
 import { layoutDirection } from './marks.js';
-import { encodingChannelQuantitative, encodingValue } from './encodings.js';
+import { encodingChannelCovariateCartesian, encodingChannelQuantitative, encodingValue } from './encodings.js';
 import { feature } from './feature.js';
 import { mark } from './helpers.js';
 import { memoize } from './memoize.js';
@@ -73,8 +73,11 @@ const _createAccessors = (s, type = null) => {
   }
 
   if (key === 'line') {
-    standard('y');
-    accessors.x = feature(s).isTemporal() ? (d) => parseTime(d.period) : accessor('x');
+    const quantitative = encodingChannelQuantitative(s);
+    const covariate = encodingChannelCovariateCartesian(s);
+
+    standard(quantitative);
+    accessors[covariate] = feature(s).isTemporal() ? (d) => parseTime(d.period) : accessor(covariate);
     accessors.color = (d) => (feature(s).hasColor() ? encodingValue(s, 'color')(d) : null);
   }
 

--- a/source/data.js
+++ b/source/data.js
@@ -2,6 +2,7 @@ import * as d3 from 'd3';
 
 import { layoutDirection } from './marks.js';
 import {
+  encodingChannelQuantitative,
   encodingChannelCovariate,
   encodingChannelCovariateCartesian,
   encodingField,
@@ -306,21 +307,21 @@ const _circularData = (s) => {
 const circularData = memoize(_circularData);
 
 const _lineData = (s) => {
-  const summed = groupAndSumByProperties(
-    values(s),
-    encodingField(s, 'x') || missingSeries(),
-    encodingField(s, 'color'),
-    encodingField(s, 'y'),
-  );
+
+  const quantitative = encodingField(s, encodingChannelQuantitative(s));
+  const covariate = encodingField(s, encodingChannelCovariateCartesian(s)) || missingSeries();
+  const color = encodingField(s, 'color');
+
+  const summed = groupAndSumByProperties(values(s), covariate, color, quantitative);
   const channels = ['href', 'description', 'tooltip'];
   const results = stackKeys(summed).map((key) => {
     const values = summed
       .filter((item) => !!item[key])
       .map((item) => {
-        const bucket = feature(s).isTemporal() ? 'period' : encodingField(s, 'x');
+        const bucket = feature(s).isTemporal() ? 'period' : encodingField(s, encodingChannelCovariate(s));
         const result = {
           [bucket]: item.key,
-          [encodingField(s, 'y')]: item[key].value,
+          [encodingField(s, encodingChannelQuantitative(s))]: item[key].value,
         };
 
         channels.forEach((channel) => {


### PR DESCRIPTION
Why would you want to make a line chart using vertical orientation instead of horizontal orientation? Who knows, it's probably a bad idea, but the encoding paradigm supports it. As previously noted in pull request #30, switching from channel names to field types is what makes this flexible.