### PR TITLE
prefer data level encoding helpers

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -169,8 +169,7 @@ const layoutDirection = (s) => {
 const stackEncoders = (s, dimensions) => {
   const encoders = createEncoders(s, dimensions, createAccessors(s));
   const vertical = layoutDirection(s) === 'vertical';
-  const laneChannel = vertical ? 'x' : 'y';
-  const lane = encoders[laneChannel];
+  const lane = encoders[encodingChannelCovariateCartesian(s)];
   const start = encoders.start;
   const length = encoders.length;
   const width = () => barWidth(s, dimensions);


### PR DESCRIPTION
Bidirectional chart layout logic originally involved _juggling visual encodings_, but using _data-level_ encoding helpers makes the code simpler, not least because you no longer need a separate code branch for each option.