### PR TITLE
fix tooltips for keyboard navigation

### DIFF
--- a/source/keyboard.js
+++ b/source/keyboard.js
@@ -258,7 +258,7 @@ const keyboard = (_s) => {
           navigator[RIGHT](mark, state);
         }
 
-        dispatcher.call('tooltip', this, event);
+        dispatcher.call('tooltip', this, event, s);
       });
 
       mark.on('keydown', (event) => {
@@ -281,7 +281,7 @@ const keyboard = (_s) => {
 
         if (typeof move === 'function') {
           move(mark, state);
-          dispatcher.call('tooltip', mark.nodes()[state.index()], event);
+          dispatcher.call('tooltip', mark.nodes()[state.index()], event, s);
         }
       });
     };


### PR DESCRIPTION
Pass the specification as an argument to the tooltip method from the keyboard navigation.

This should have been included as part of pull request #77.