### PR TITLE
use internal static value property for line charts

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -76,7 +76,7 @@ const _createAccessors = (s, type = null) => {
     const quantitative = encodingChannelQuantitative(s);
     const covariate = encodingChannelCovariateCartesian(s);
 
-    standard(quantitative);
+    accessors[quantitative] = (d) => d.value;
     accessors[covariate] = feature(s).isTemporal() ? (d) => parseTime(d.period) : accessor(covariate);
     accessors.color = (d) => (feature(s).hasColor() ? encodingValue(s, 'color')(d) : null);
   }

--- a/source/data.js
+++ b/source/data.js
@@ -320,7 +320,7 @@ const _lineData = (s) => {
         const bucket = feature(s).isTemporal() ? 'period' : encodingField(s, encodingChannelCovariate(s));
         const result = {
           [bucket]: item.key,
-          [encodingField(s, encodingChannelQuantitative(s))]: item[key].value,
+          value: item[key].value,
         };
 
         channels.forEach((channel) => {

--- a/source/scales.js
+++ b/source/scales.js
@@ -164,7 +164,8 @@ const domainBaseValues = (s, channel) => {
         .map((item) => item.values)
         .flat();
       const nonzero = s.encoding.y.scale?.zero === false;
-      const periodMin = d3.min(byPeriod, encodingValue(s, channel));
+      const accessor = (d) => d.value;
+      const periodMin = d3.min(byPeriod, accessor);
       const positive = typeof periodMin === 'number' && periodMin > 0;
 
       if (nonzero && positive) {
@@ -175,7 +176,7 @@ const domainBaseValues = (s, channel) => {
         min = 0;
       }
 
-      max = d3.max(byPeriod, encodingValue(s, channel));
+      max = d3.max(byPeriod, accessor);
     } else {
       min = 0;
       max = d3.max(values(s), encodingValue(s, channel));


### PR DESCRIPTION
Arbitrary data field names in the input specifications should be supported, but there's no reason for internal-only representations of the data set to continue to look up those fields dynamically. Coercing to `value` as a standard property name actually creates more flexibility downstream because the abstraction does not need to be maintained.

This is equivalent to the change made for circular chart layouts in pull request #84. Line charts don't technically rely on an intermediate layout object, but the output of `lineData()` plays essentially the same role even if is always used directly.