### PR TITLE
static accessor for circular chart values

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -60,7 +60,7 @@ const _createAccessors = (s, type = null) => {
   }
 
   if (key === 'arc') {
-    accessors.theta = (d) => encodingValue(s, encodingChannelQuantitative(s))(d);
+    accessors.theta = (d) => d.data.value;
     accessors.color = (d) => d.data.key;
   }
 


### PR DESCRIPTION
Overly dynamic keys seem to just get in the way when you're accessing internal representations of the data that can be normalized. This should probably have been included in either pull request #84 or pull request #91.