### PR TITLE
reusable empty object to optimize text calculations

### DIFF
--- a/source/text.js
+++ b/source/text.js
@@ -9,14 +9,15 @@ import { ticks } from './axes.js';
 const canvas = document.createElement('canvas');
 const context = canvas.getContext('2d');
 
+const defaultStyles = {};
+
 /**
  * measure the width of a text string
  * @param {string} text text string
- * @param {object} [_styles] styles
+ * @param {object} [styles] styles
  * @returns {number} string width
  */
-const _measureText = (text, _styles) => {
-  const styles = _styles || defaultStyles;
+const _measureText = (text, styles = defaultStyles) => {
   // set styles
   Object.entries(styles).forEach(([key, value]) => {
     context[key] = value;
@@ -122,7 +123,7 @@ const rotation = (s, channel) => (s.encoding?.[channel]?.axis?.labelAngle * Math
  * @param {object} [styles] styles to incorporate when measuring text width
  * @returns {string} truncated string
  */
-const _truncate = (s, channel, text, styles) => {
+const _truncate = (s, channel, text, styles = defaultStyles) => {
   const max = 180;
 
   let limit = d3.min([s.encoding[channel].axis?.labelLimit, max]);
@@ -151,7 +152,7 @@ const truncate = memoize(_truncate);
  * @param {object} [styles] styles to incorporate when measuring text width
  * @returns {string} text processing function
  */
-const _axisTickLabelTextContent = (s, channel, textContent, styles) => {
+const _axisTickLabelTextContent = (s, channel, textContent, styles = defaultStyles) => {
   let text = textContent;
 
   text = format(s, channel)(text);
@@ -164,7 +165,6 @@ const _axisTickLabelTextContent = (s, channel, textContent, styles) => {
 };
 const axisTickLabelTextContent = memoize(_axisTickLabelTextContent);
 
-const defaultStyles = {};
 /**
  * compute margin values based on chart type
  * @param {object} s Vega Lite specification
@@ -177,7 +177,7 @@ const longestAxisTickLabelTextWidth = (s, dimensions) => {
   const channels = ['x', 'y'];
   const tickLabels = channels.map((channel) => {
     const type = encodingType(s, channel);
-    const processText = (tick) => axisTickLabelTextContent(s, channel, tick, defaultStyles);
+    const processText = (tick) => axisTickLabelTextContent(s, channel, tick);
 
     if (['quantitative', 'temporal'].includes(type)) {
       return scales[channel].ticks(ticks(s, channel)).map(processText);

--- a/source/text.js
+++ b/source/text.js
@@ -118,10 +118,10 @@ const rotation = (s, channel) => (s.encoding?.[channel]?.axis?.labelAngle * Math
  * @param {object} s Vega Lite specification
  * @param {'x'|'y'} channel encoding channel
  * @param {string} text text to truncate
- * @param {array} [styles] styles to incorporate when measuring text width
+ * @param {object} [styles] styles to incorporate when measuring text width
  * @returns {string} truncated string
  */
-const _truncate = (s, channel, text, styles = []) => {
+const _truncate = (s, channel, text, styles = {}) => {
   const max = 180;
 
   let limit = d3.min([s.encoding[channel].axis?.labelLimit, max]);
@@ -147,7 +147,7 @@ const truncate = memoize(_truncate);
  * @param {object} s Vega Lite specification
  * @param {'x'|'y'} channel axis dimension
  * @param {string} textContent text to process
- * @param {array} [styles] styles to incorporate when measuring text width
+ * @param {object} [styles] styles to incorporate when measuring text width
  * @returns {string} text processing function
  */
 const _axisTickLabelTextContent = (s, channel, textContent, styles) => {

--- a/source/text.js
+++ b/source/text.js
@@ -12,10 +12,11 @@ const context = canvas.getContext('2d');
 /**
  * measure the width of a text string
  * @param {string} text text string
- * @param {object} [styles] styles
+ * @param {object} [_styles] styles
  * @returns {number} string width
  */
-const _measureText = (text, styles = {}) => {
+const _measureText = (text, _styles) => {
+  const styles = _styles || defaultStyles;
   // set styles
   Object.entries(styles).forEach(([key, value]) => {
     context[key] = value;
@@ -121,7 +122,7 @@ const rotation = (s, channel) => (s.encoding?.[channel]?.axis?.labelAngle * Math
  * @param {object} [styles] styles to incorporate when measuring text width
  * @returns {string} truncated string
  */
-const _truncate = (s, channel, text, styles = {}) => {
+const _truncate = (s, channel, text, styles) => {
   const max = 180;
 
   let limit = d3.min([s.encoding[channel].axis?.labelLimit, max]);
@@ -163,6 +164,7 @@ const _axisTickLabelTextContent = (s, channel, textContent, styles) => {
 };
 const axisTickLabelTextContent = memoize(_axisTickLabelTextContent);
 
+const defaultStyles = {};
 /**
  * compute margin values based on chart type
  * @param {object} s Vega Lite specification
@@ -175,7 +177,7 @@ const longestAxisTickLabelTextWidth = (s, dimensions) => {
   const channels = ['x', 'y'];
   const tickLabels = channels.map((channel) => {
     const type = encodingType(s, channel);
-    const processText = (tick) => axisTickLabelTextContent(s, channel, tick, []);
+    const processText = (tick) => axisTickLabelTextContent(s, channel, tick, defaultStyles);
 
     if (['quantitative', 'temporal'].includes(type)) {
       return scales[channel].ticks(ticks(s, channel)).map(processText);


### PR DESCRIPTION
Text operations that rely on the hidden canvas node are computationally expensive, and using default argument syntax created a new object reference each time the function was run. This in turn meant that even though the function had already been memoized, multiple invocations weren't actually hitting the cache as frequently as they could be, because the empty object would always be a different reference. Changing this to use a single shared empty object is more efficient.