### PR TITLE
dynamic category lookup for line and point marks

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -450,9 +450,10 @@ const lineMarks = (s, dimensions) => {
       .classed('series', true);
 
     series.each((d) => {
-      category.set(d, encodingValue(s, 'color')(d));
+      const categoryValue = encodingValue(s, 'color')(d);
+      category.set(d, categoryValue);
       d.values.forEach((item) => {
-        category.set(item, d.group);
+        category.set(item, categoryValue);
       });
     });
 

--- a/source/marks.js
+++ b/source/marks.js
@@ -385,8 +385,9 @@ const pointMarks = (s, dimensions) => {
 
     points
       .each(function (d) {
-        if (d.group) {
-          category.set(this, d.group);
+        const categoryValue = encodingValue(s, 'color')(d);
+        if (categoryValue) {
+          category.set(this, categoryValue);
         }
       })
       .attr('aria-label', (d) => {


### PR DESCRIPTION
Removes hard-coded `group` property access in line chart series and point marks (which are also used by line charts when `mark.point` is `true`), replacing them with dynamic lookups using the encoding helper functions. This was already working properly at the rendering stage, but incorrectly registering it with the category helper based on a static property then meant that computing descriptive strings later for use in tooltips and `aria-label` attributes could fail, retrieving `undefined` instead of the appropriate data value.