### PR TITLE
terminal visualization for benchmarks

### DIFF
--- a/benchmarks/benchmarks.js
+++ b/benchmarks/benchmarks.js
@@ -13,6 +13,13 @@ const fixtures = [
 
 const count = 100;
 
+const bar = (time) => {
+    const step = 50; // milliseconds per unit
+    const units = time / step;
+    const bar = Array.from({ length: units }).fill('■').join('');
+    return bar;
+};
+
 fixtures.forEach(fixture => {
     const specification = specificationFixture(fixture);
     bench(`${fixture} × ${count}`, (b) => {
@@ -20,6 +27,7 @@ fixtures.forEach(fixture => {
         for (let i = 0; i < count; i++) {
             render(specification)
         }
+        b.log(bar(b.elapsed()));
         b.end();
     });
 });

--- a/benchmarks/benchmarks.js
+++ b/benchmarks/benchmarks.js
@@ -14,12 +14,12 @@ const fixtures = [
 const count = 100;
 
 fixtures.forEach(fixture => {
-const specification = specificationFixture(fixture);
+    const specification = specificationFixture(fixture);
     bench(`${fixture} × ${count}`, (b) => {
         b.start();
         for (let i = 0; i < count; i++) {
-                render(specification)
-                }
+            render(specification)
+        }
         b.end();
     });
 });


### PR DESCRIPTION
Adds a little bar chart visualization to the terminal output when running benchmarks.

```
# categoricalBar × 100
# ■■■■■■■■
ok ~444 ms (0 s + 444280292 ns)

# circular × 100
# ■■■
ok ~196 ms (0 s + 195553583 ns)

# line × 100
# ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
ok ~1.71 s (1 s + 712177542 ns)

# scatterPlot × 100
# ■■■■■■■■■
ok ~495 ms (0 s + 494699459 ns)
```