### PR TITLE
allow disabled axes

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -123,6 +123,9 @@ const tickText = (s, channel) => {
  * @returns {function} x axis renderer
  */
 const x = (s, dimensions) => {
+  if (!feature(s).hasAxisX()) {
+    return noop;
+  }
   return (selection) => {
     const scales = parseScales(s, dimensions);
     const barOffset = feature(s).isBar() ? barWidth(s, dimensions) : 0;
@@ -216,6 +219,9 @@ const x = (s, dimensions) => {
  * @returns {function} y axis renderer
  */
 const y = (s, dimensions) => {
+  if (!feature(s).hasAxisY()) {
+    return noop;
+  }
   return (selection) => {
     const scales = parseScales(s, dimensions);
     const barOffset = feature(s).isBar() ? barWidth(s, dimensions) : 0;

--- a/source/feature.js
+++ b/source/feature.js
@@ -42,6 +42,8 @@ const _feature = (s) => {
     hasLegendTitle: (s) => isPresent(s.encoding?.color?.legend?.title),
     hasTooltip: (s) => s.mark.tooltip || s.encoding?.tooltip,
     hasTransforms: (s) => Array.isArray(s.transform),
+    hasAxisX: (s) => s.encoding.x && s.encoding.x.axis !== null,
+    hasAxisY: (s) => s.encoding.y && s.encoding.y.axis !== null,
     hasAxisLabelsY: (s) => s.encoding?.y?.axis?.labels !== false,
     hasAxisLabelsX: (s) => s.encoding?.x?.axis?.labels !== false,
     hasAxisTitleX: (s) => s.encoding?.x?.axis?.title !== null,

--- a/tests/integration/axes-test.js
+++ b/tests/integration/axes-test.js
@@ -104,4 +104,12 @@ module('integration > axes', function () {
       assert.ok(node.getBoundingClientRect().width <= max);
     });
   });
+  test('disables axes', (assert) => {
+    const spec = specificationFixture('temporalBar');
+    spec.encoding.x.axis = null;
+    spec.encoding.y.axis = null;
+    const element = render(spec);
+    assert.notOk(element.querySelector('axes-x'));
+    assert.notOk(element.querySelector('axes-y'));
+  });
 });


### PR DESCRIPTION
Vega Lite allows users to completely disable an [axis](https://vega.github.io/vega-lite/docs/axis.html) by setting e.g. `specification.encoding.y.axis = null`.