### PR TITLE
don't hide axis ticks for ordinal encodings

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -88,7 +88,7 @@ const alternate = (s) => {
       const axisSelector = `.${channel}`;
       const ticks = selection.select(axisSelector).selectAll('.tick');
 
-      if (encodingType(s, channel) !== 'nominal') {
+      if (!isDiscrete(s, channel)) {
         if (overlap([...ticks.nodes()])) {
           selection.select(axisSelector).classed('alternate-ticks', true);
         }


### PR DESCRIPTION
The `alternate()` function checks the DOM for overlapping tick text and hides ticks if it finds a problem. This remedial operation doesn't make sense for ordinal encodings, because those require that the reader always be able to see the tick text.