### PR TITLE
always use value encodings

### DIFF
--- a/source/helpers.js
+++ b/source/helpers.js
@@ -83,7 +83,7 @@ const missingSeries = () => '_';
  * @returns {string} url
  */
 const getUrl = (s, d) => {
-  if (!d) {
+  if (s.encoding.href.value) {
     return s.encoding.href.value;
   }
   const field = encodingField(s, 'href');


### PR DESCRIPTION
This conditional was wrong, and would only rely on a value encoding in cases where a valid datum was not supplied as an input argument to the `getUrl()` helper. Static value encodings can always supersede dynamic lookup on the datum.