### PR TITLE
enforce boolean returns from feature methods

### DIFF
--- a/source/feature.js
+++ b/source/feature.js
@@ -30,14 +30,14 @@ const _feature = (s) => {
     isLine: (s) => mark(s) === 'line',
     isArea: (s) => mark(s) === 'area',
     hasPoints: (s) => mark(s) === 'point' || s.mark?.point === true,
-    hasLayers: (s) => !!s.layer,
+    hasLayers: (s) => s.layer,
     isCircular: (s) => mark(s) === 'arc',
     isRule: (s) => mark(s) === 'rule',
     isText: (s) => mark(s) === 'text',
     isAggregate: (s) => ['x', 'y'].some((channel) => s.encoding?.[channel]?.aggregate),
-    hasColor: (s) => !!s.encoding?.color,
-    hasLinks: (s) => !!s.encoding.href,
-    hasData: (s) => !!s.data?.values.length,
+    hasColor: (s) => s.encoding?.color,
+    hasLinks: (s) => s.encoding.href,
+    hasData: (s) => s.data?.values.length,
     hasLegend: (s) => s.encoding?.color?.legend !== null,
     hasLegendTitle: (s) => isPresent(s.encoding?.color?.legend?.title),
     hasTooltip: (s) => s.mark.tooltip || s.encoding?.tooltip,
@@ -49,14 +49,14 @@ const _feature = (s) => {
     hasAxisTitleX: (s) => s.encoding?.x?.axis?.title !== null,
     hasAxisTitleY: (s) => s.encoding?.y?.axis?.title !== null,
     hasStaticText: (s) => s.mark?.text && !s.encoding?.text,
-    isCartesian: (s) => s.encoding?.x && s.encoding?.y,
+    isCartesian: (s) => (s.encoding?.x && s.encoding?.y),
     isLinear: (s) => (s.encoding?.x && !s.encoding.y) || (s.encoding.y && !s.encoding.x),
     isRadial: (s) => s.encoding.theta,
     isTemporal: () => isTemporal,
     isMulticolor: () => isMulticolor,
     hasEncodingX: (s) => s.encoding?.x,
     hasEncodingY: (s) => s.encoding?.y,
-    hasEncodingColor: (s) => s.encoding.color,
+    hasEncodingColor: (s) => s.encoding?.color,
   };
 
   tests.hasAxis = (s) => tests.hasEncodingX(s) || tests.hasEncodingY(s);
@@ -67,7 +67,7 @@ const _feature = (s) => {
 
   Object.entries(tests).forEach(([key, test]) => {
     layerTests[key] = memoize(() => {
-      return layerTestRecursive(s, test);
+      return !!layerTestRecursive(s, test);
     });
   });
 


### PR DESCRIPTION
The feature helper should only be used for control flow. To ensure this and prevent future architectural mistakes, the methods should all return booleans.