### PR TITLE
stricter commit message linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: latest

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -8,6 +8,7 @@ const config = {
         'references-empty': [0],
         'signed-off-by': [0],
         'scope-case': [2, 'always', 'lower-case'],
+        'scope-enum': [2, 'always', ['core', 'tooling', 'tests', 'docs']],
         'type-enum': [2, 'always', ['chore', 'fix', 'feat']]
     },
 };

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -7,6 +7,8 @@ const config = {
         'footer-max-line-length': [0],
         'references-empty': [0],
         'signed-off-by': [0],
+        'scope-case': [2, 'always', 'lower-case'],
+        'type-enum': [2, 'always', ['chore', 'fix', 'feat']]
     },
 };
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "esbuild --bundle --format=esm --external:d3 --external:string.prototype.matchall --outfile=build/bisonica.js source/chart.js",
     "postbuild": "yarn run archive",
     "archive": "zip -jr build/bisonica-$(npm view bisonica version).zip build/bisonica.js source/index.css",
-    "lint-git": "commitlint -- --to=HEAD",
+    "lint-git": "commitlint --to=HEAD --from=11cd541",
     "lint-js": "eslint source tests/unit tests/integration",
     "lint-styles": "stylelint source/index.css",
     "test": "qunit --require jsdom-global/register --require ./tests/image-shim.cjs tests/**/*.js",


### PR DESCRIPTION
Commit message linting was one of the very first things I set up in this repository, way back in b507193, in the hopes that it would make all subsequent development cleaner. Unfortunately the configuration was insufficiently strict, so some nonsense still slipped through, most recently as part of pull request #107. Additional [commitlint](https://commitlint.js.org/) rules will help keep things in check from this point forward.