### PR TITLE
return discrete axis tick count

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -43,6 +43,10 @@ const ticks = (s, channel) => {
 
   const scales = parseScales(s);
 
+  if (isDiscrete(s, channel)) {
+    return scales[channel].range();
+  }
+
   const hasSingleValue = scales[channel].domain()[0] === scales[channel].domain()[1];
 
   if (hasSingleValue) {


### PR DESCRIPTION
Discrete axes need every possible to be labeled in order to be readable, so they can simply return the domain or range length as the tick quantity instead of running through the remainder of the function.