### PR TITLE
consistent angle test

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -198,7 +198,7 @@ const x = (s, dimensions) => {
 
     const angle = degrees(rotation(s, 'x'));
 
-    if (angle) {
+    if (typeof angle !== 'undefined') {
       x.selectAll('.tick text')
         .attr('transform', function () {
           const textHeight = d3.select(this).node().getBBox().height;


### PR DESCRIPTION
The x and y axes should either both check for truthy values or both check for `undefined`.

It's a bit more conservative to still run this routine even when [`labelAngle`](https://vega.github.io/vega-lite/docs/axis.html#labels) is set to `0`, but that's not really a condition worth worrying about either way.