### PR TITLE
reorganize memoization conditions

### DIFF
--- a/source/memoize.js
+++ b/source/memoize.js
@@ -20,11 +20,7 @@ const argumentKey = (arg) => {
 
   const primitive = type !== 'object' && type !== 'function';
 
-  if (primitive) {
-    return key;
-  }
-
-  if (type === 'object' || type === 'function') {
+  if (!primitive) {
     if (references.map.has(arg)) {
       return `${key}-${references.map.get(arg)}`;
     } else {
@@ -34,6 +30,8 @@ const argumentKey = (arg) => {
 
       return `${key}-${id}`;
     }
+  } else {
+    return key;
   }
 };
 

--- a/source/memoize.js
+++ b/source/memoize.js
@@ -8,12 +8,14 @@ const argumentKey = (arg) => {
 
   const type = typeof arg;
 
-  if (type === 'undefined' || arg === null) {
-    key = `${arg}`;
+  if (type === 'object') {
+    key = 'object';
+  } else if (type === 'string') {
+    key = arg;
   } else if (type === 'function') {
     key = 'function';
-  } else if (type === 'object') {
-    key = 'object';
+  } else if (type === 'undefined' || arg === null) {
+    key = `${arg}`;
   } else {
     key = arg.toString();
   }


### PR DESCRIPTION
Change the order of the conditions in the memoization helper such that the cases most likely to match will come up first.