### PR TITLE
remove dimensions from margin calculations

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -165,7 +165,7 @@ const x = (s, dimensions) => {
         .attr('x', dimensions.x * 0.5 - barOffset * 0.5)
         .attr('y', () => {
           const axisHeight = xAxis.node().getBBox().height * 2;
-          const tickHeight = tickMargin(s, dimensions).bottom;
+          const tickHeight = tickMargin(s).bottom;
           const yPosition = axisHeight + tickHeight;
 
           return yPosition;

--- a/source/position.js
+++ b/source/position.js
@@ -27,11 +27,10 @@ const marginCircular = () => {
 /**
  * compute margin for Cartesian chart axis ticks
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
  * @returns {object} D3 margin convention object
  */
-const tickMargin = (s, dimensions) => {
-  const textLabels = longestAxisTickLabelTextWidth(s, dimensions);
+const tickMargin = (s) => {
+  const textLabels = longestAxisTickLabelTextWidth(s);
   const result = {};
 
   Object.entries(axes).forEach(([channel, position]) => {
@@ -64,10 +63,9 @@ const titleMargin = (s) => {
 /**
  * compute margin for Cartesian chart
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
  * @returns {object} D3 margin convention object
  */
-const marginCartesian = (s, dimensions) => {
+const marginCartesian = (s) => {
   const defaultMargin = {
     top: GRID * 2,
     right: GRID * 2,
@@ -79,7 +77,7 @@ const marginCartesian = (s, dimensions) => {
 
   Object.values(axes).forEach((position) => {
     dynamicMargin[position] =
-      tickMargin(s, dimensions)?.[position] + titleMargin(s)?.[position] + GRID;
+      tickMargin(s)?.[position] + titleMargin(s)?.[position] + GRID;
   });
 
   return {
@@ -90,18 +88,17 @@ const marginCartesian = (s, dimensions) => {
   };
 };
 
-const _margin = (s, dimensions) => {
+const _margin = (s) => {
   if (feature(s).isCircular()) {
     return marginCircular();
   } else {
-    return marginCartesian(layerPrimary(s), dimensions);
+    return marginCartesian(layerPrimary(s));
   }
 };
 
 /**
  * compute margin values based on chart type
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
  * @returns {object} D3 margin convention object
  */
 const margin = memoize(_margin);

--- a/source/text.js
+++ b/source/text.js
@@ -169,11 +169,10 @@ const axisTickLabelTextContent = memoize(_axisTickLabelTextContent);
 /**
  * compute margin values based on chart type
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
  * @returns {object} longest axis tick label text length in pixels
  */
-const _longestAxisTickLabelTextWidth = (s, dimensions) => {
-  const scales = parseScales(s, dimensions);
+const _longestAxisTickLabelTextWidth = (s) => {
+  const scales = parseScales(s);
 
   const channels = ['x', 'y'];
   const tickLabels = channels.map((channel) => {


### PR DESCRIPTION
Computing margins is expensive because it requires running `measureText()` with a live `<canvas>` node on all the axis tick text in order to figure out how much space to reserve. It does not actually require the chart dimensions as an input, however – it _seemed_ like it did because it needs to generate scales, but the text is available from `scale.domain()`, not `scale.range()`, so it works just fine with `{x: 0, y: 0}`. Removing the dimensions argument and internally substituting the `defaultDimensions` variable introduced in pull request #98 means it can hit the memoization cache more frequently instead of redundantly calling `measureText()` again.