### PR TITLE
metadata module

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -163,9 +163,8 @@ const _stackData = (s) => {
         });
     });
   }
-  const sorted = sort(stacked);
 
-  return metadata(sorted, values(s), s);
+  return metadata(sort(stacked), values(s), s);
 
 };
 
@@ -178,7 +177,6 @@ const _stackData = (s) => {
 const stackData = memoize(_stackData);
 
 const _circularData = (s) => {
-  let results;
 
   const grouped = Array.from(d3.group(values(s), encodingValue(s, 'color'))).map(
     ([key, values]) => ({ key, values }),
@@ -188,9 +186,7 @@ const _circularData = (s) => {
     return { key, value: d3.sum(values, encodingValue(s, 'theta')) };
   });
 
-  results = summed;
-
-  return metadata(results, values(s), s);
+  return metadata(summed, values(s), s);
 
 };
 

--- a/source/data.js
+++ b/source/data.js
@@ -164,7 +164,7 @@ const _stackData = (s) => {
     });
   }
 
-  return metadata(sort(stacked), values(s), s);
+  return metadata(s, sort(stacked));
 
 };
 
@@ -186,7 +186,7 @@ const _circularData = (s) => {
     return { key, value: d3.sum(values, encodingValue(s, 'theta')) };
   });
 
-  return metadata(summed, values(s), s);
+  return metadata(s, summed);
 
 };
 

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -156,8 +156,6 @@ const metadata = (s, data) => {
         return transplantStackMetadata(s, data);
     } else if (mark(s) === 'arc') {
         return transplantCircularMetadata(s, data);
-    } else {
-        return data;
     }
 };
 

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -37,7 +37,7 @@ const transplantFields = (aggregated, raw, matcher, key) => {
  * @param {object} s Vega Lite specification
  * @returns {object[]} aggregated data with metadata
  */
-const transplantStackedBarMetadata = (aggregated, raw, s) => {
+const transplantStackMetadata = (aggregated, raw, s) => {
     const createMatcher = (key) => {
         const matcher = (aggregatedItem, raw) => {
             const laneChannel = encodingChannelCovariateCartesian(s);
@@ -156,7 +156,7 @@ const transplantCircularMetadata = (aggregated, raw, s) => {
  */
 const metadata = (aggregated, raw, s) => {
     if (mark(s) === 'bar' || mark(s) === 'area') {
-        return transplantStackedBarMetadata(aggregated, raw, s);
+        return transplantStackMetadata(aggregated, raw, s);
     } else if (mark(s) === 'arc') {
         return transplantCircularMetadata(aggregated, raw, s);
     } else {

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -32,12 +32,11 @@ const transplantFields = (aggregated, raw, matcher, key) => {
 
 /**
  * transfer metadata from raw data points to aggregated stack layout
- * @param {object[]} aggregated aggregated data for data join
- * @param {object[]} raw raw data with metadata
  * @param {object} s Vega Lite specification
+ * @param {object[]} aggregated aggregated data for data join
  * @returns {object[]} aggregated data with metadata
  */
-const transplantStackMetadata = (aggregated, raw, s) => {
+const transplantStackMetadata = (s, aggregated) => {
     const createMatcher = (key) => {
         const matcher = (aggregatedItem, raw) => {
             const laneChannel = encodingChannelCovariateCartesian(s);
@@ -112,12 +111,11 @@ const transplantStackMetadata = (aggregated, raw, s) => {
 
 /**
  * transfer metadata from raw data points to aggregated circular layout
- * @param {object[]} aggregated aggregated data for data join
- * @param {object[]} raw raw data with metadata
  * @param {object} s Vega Lite specification
+ * @param {object[]} aggregated aggregated data for data join
  * @returns {object[]} aggregated data with metadata
  */
-const transplantCircularMetadata = (aggregated, raw, s) => {
+const transplantCircularMetadata = (s, aggregated) => {
     const createMatcher = (channel) => {
         return (aggregatedItem, raw) => {
             return raw
@@ -149,18 +147,17 @@ const transplantCircularMetadata = (aggregated, raw, s) => {
 
 /**
  * transfer metadata from raw data points to aggregated data
- * @param {object[]} aggregated aggregated data for data join
- * @param {object[]} raw raw data with metadata
  * @param {object} s Vega Lite specification
+ * @param {object[]} data aggregated data for data join
  * @returns {object[]} aggregated data with metadata
  */
-const metadata = (aggregated, raw, s) => {
+const metadata = (s, data) => {
     if (mark(s) === 'bar' || mark(s) === 'area') {
-        return transplantStackMetadata(aggregated, raw, s);
+        return transplantStackMetadata(s, data);
     } else if (mark(s) === 'arc') {
-        return transplantCircularMetadata(aggregated, raw, s);
+        return transplantCircularMetadata(s, data);
     } else {
-        return aggregated;
+        return data;
     }
 };
 

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -1,0 +1,179 @@
+import { mark } from "./helpers.js";
+import {
+    encodingChannelCovariate,
+    encodingChannelCovariateCartesian,
+    encodingField,
+} from './encodings.js';
+import { feature } from './feature.js';
+import { isDiscrete } from './helpers.js';
+
+/**
+ * move properties from an array of source
+ * values to an aggregate
+ * @param {array} aggregated aggregated data points
+ * @param {array} raw individual data points
+ * @param {function} matcher find matching values
+ * @param {string} key property name for transplanted field
+ * @returns {array} aggregated data points with transplanted field attached
+ */
+const transplantFields = (aggregated, raw, matcher, key) => {
+    if (!Array.isArray(aggregated)) {
+        throw new Error(`cannot transplant ${key} field, aggregated data is not an array`);
+    }
+
+    if (!Array.isArray(raw)) {
+        throw new Error(`cannot transplant ${key} field, raw data is not an array`);
+    }
+
+    if (typeof matcher !== 'function') {
+        throw new Error(`cannot transplant ${key} field, matcher is not a function`);
+    }
+
+    return aggregated.map((item) => {
+        const matches = matcher(item, raw);
+        const result = { ...item };
+        const allMatch = matches.every((item) => item === matches[0]);
+
+        if (matches.length > 0 && allMatch) {
+            result[key] = matches[0];
+        }
+
+        return result;
+    });
+};
+
+/**
+ * transfer metadata from raw data points to aggregated stack layout
+ * @param {object[]} aggregated aggregated data for data join
+ * @param {object[]} raw raw data with metadata
+ * @param {object} s Vega Lite specification
+ * @returns {object[]} aggregated data with metadata
+ */
+const transplantStackedBarMetadata = (aggregated, raw, s) => {
+    const createMatcher = (key) => {
+        const matcher = (aggregatedItem, raw) => {
+            const laneChannel = encodingChannelCovariateCartesian(s);
+            const keys = {
+                lane: encodingField(s, laneChannel),
+                series: encodingField(s, 'color'),
+            };
+            const matches = raw
+                .filter((rawItem) => {
+                    let seriesMatch;
+
+                    // single-color categorical charts are still plotted using separate series nodes
+                    if (feature(s).hasColor() || isDiscrete(s, encodingChannelCovariate(s))) {
+                        seriesMatch = aggregatedItem[keys.series] === rawItem[keys.series];
+                    } else {
+                        seriesMatch = true;
+                    }
+
+                    const laneMatch =
+                        aggregatedItem[keys.lane] &&
+                        rawItem[keys.lane] &&
+                        aggregatedItem[keys.lane]?.toString() === rawItem[keys.lane]?.toString();
+                    const hasField = !!rawItem[key];
+
+                    return seriesMatch && laneMatch && hasField;
+                })
+                .map((item) => item[key])
+                .filter(Boolean);
+
+            return matches;
+        };
+
+        return matcher;
+    };
+
+    const results = [...aggregated];
+
+    results.forEach((series, i) => {
+        series.forEach((item, j) => {
+            const lookup = {};
+
+            if (encodingField(s, 'color')) {
+                lookup[encodingField(s, 'color')] = series.key;
+            }
+
+            if (encodingField(s, encodingChannelCovariate(s))) {
+                lookup[encodingField(s, encodingChannelCovariate(s))] = item.data.key;
+            }
+
+            const channels = ['href', 'description', 'tooltip'];
+            const fields = channels.map((channel) => encodingField(s, channel));
+
+            fields.forEach((field) => {
+                const value = transplantFields([lookup], s.data.values, createMatcher(field), field).pop()[
+                    field
+                ];
+
+                if (value) {
+                    // the reference to the datum object is shared across marks by the d3 layout generator, so
+                    // this needs to be set as a non-enumerable property on the array, which is a bit odd but
+                    // also how the datum object is already stored
+                    Object.defineProperty(results[i][j], field, {
+                        value,
+                    });
+                }
+            });
+        });
+    });
+
+    return results;
+};
+
+/**
+ * transfer metadata from raw data points to aggregated circular layout
+ * @param {object[]} aggregated aggregated data for data join
+ * @param {object[]} raw raw data with metadata
+ * @param {object} s Vega Lite specification
+ * @returns {object[]} aggregated data with metadata
+ */
+const transplantCircularMetadata = (aggregated, raw, s) => {
+    const createMatcher = (channel) => {
+        return (aggregatedItem, raw) => {
+            return raw
+                .filter((rawItem) => {
+                    const currentAggregateDatumField = aggregatedItem.key.toString();
+                    const rawDatumField = rawItem[encodingField(s, 'color')].toString();
+
+                    return currentAggregateDatumField === rawDatumField;
+                })
+                .map((item) => {
+                    return item[encodingField(s, channel)];
+                });
+        };
+    };
+
+    const channels = ['href', 'description', 'tooltip'];
+    channels.forEach((channel) => {
+        if (s.encoding[channel]) {
+            aggregated = transplantFields(
+                [...aggregated],
+                s.data.values,
+                createMatcher(channel),
+                encodingField(s, channel),
+            );
+        }
+    });
+    return aggregated;
+};
+
+/**
+ * transfer metadata from raw data points to aggregated data
+ * @param {object[]} aggregated aggregated data for data join
+ * @param {object[]} raw raw data with metadata
+ * @param {object} s Vega Lite specification
+ * @returns {object[]} aggregated data with metadata
+ */
+const metadata = (aggregated, raw, s) => {
+    if (mark(s) === 'bar' || mark(s) === 'area') {
+        return transplantStackedBarMetadata(aggregated, raw, s);
+    } else if (mark(s) === 'arc') {
+        return transplantCircularMetadata(aggregated, raw, s);
+    } else {
+        return aggregated;
+    }
+};
+
+export { metadata, transplantFields };

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -17,18 +17,6 @@ import { isDiscrete } from './helpers.js';
  * @returns {array} aggregated data points with transplanted field attached
  */
 const transplantFields = (aggregated, raw, matcher, key) => {
-    if (!Array.isArray(aggregated)) {
-        throw new Error(`cannot transplant ${key} field, aggregated data is not an array`);
-    }
-
-    if (!Array.isArray(raw)) {
-        throw new Error(`cannot transplant ${key} field, raw data is not an array`);
-    }
-
-    if (typeof matcher !== 'function') {
-        throw new Error(`cannot transplant ${key} field, matcher is not a function`);
-    }
-
     return aggregated.map((item) => {
         const matches = matcher(item, raw);
         const result = { ...item };

--- a/tests/unit/data-test.js
+++ b/tests/unit/data-test.js
@@ -1,7 +1,4 @@
-import {
-  data,
-  transplantFields,
-} from '../../source/data.js';
+import { data } from '../../source/data.js';
 import { encodingField } from '../../source/encodings.js';
 import { getTimeParser } from '../../source/time.js';
 import qunit from 'qunit';
@@ -70,65 +67,6 @@ module('unit > data', () => {
     assert.ok(values, 'every segment has a value');
   });
 
-  const urlData = [
-    { value: 1, group: 'a', label: '2020-01-01', url: 'https://crowdstrike.com/a' },
-    { value: 1, group: 'a', label: '2020-01-02', url: 'https://crowdstrike.com/a' },
-    { value: 2, group: 'b', label: '2020-01-03', url: 'https://crowdstrike.com/b' },
-    { value: 2, group: 'b', label: '2020-01-04', url: 'https://crowdstrike.com/b' },
-    { value: 2, group: 'b', label: '2020-01-05', url: 'https://crowdstrike.com/b' },
-    { value: 3, group: 'c', label: '2020-01-06', url: 'https://crowdstrike.com/c' },
-    { value: 3, group: 'c', label: '2020-01-07', url: 'https://crowdstrike.com/c' },
-  ];
-
-  test('transfers urls to aggregated circular chart segments', (assert) => {
-    const s = {
-      data: {
-        values: urlData,
-      },
-      mark: {
-        type: 'arc',
-      },
-      encoding: {
-        color: { field: 'group' },
-        href: { field: 'url' },
-        theta: { field: 'value' },
-      },
-    };
-
-    const layout = data(s);
-
-    assert.ok(layout.every((item) => item.url.startsWith('https://crowdstrike.com/')));
-  });
-
-  test('transfers urls to aggregated stacked bar chart segments', (assert) => {
-    const s = {
-      data: {
-        values: urlData,
-      },
-      mark: { type: 'bar' },
-      encoding: {
-        color: { field: 'group', type: 'nominal' },
-        href: { field: 'url' },
-        x: { field: 'label', type: 'temporal' },
-        y: { aggregate: 'value', type: 'quantitative' },
-      },
-    };
-
-    const layout = data(s);
-
-    layout.forEach((series) => {
-      series.forEach((item) => {
-        const difference = Math.abs(item[1] - item[0]) !== 0;
-
-        if (difference) {
-          const url = item[encodingField(s, 'href')];
-
-          assert.ok(url.startsWith('https://crowdstrike.com/'));
-        }
-      });
-    });
-  });
-
   test('compiles line chart data', (assert) => {
     const spec = specificationFixture('line');
     const dailyTotals = data(spec, encodingField(spec, 'x'));
@@ -154,55 +92,5 @@ module('unit > data', () => {
     });
 
     assert.ok(values, 'every item includes a value');
-  });
-
-  test('transplants urls between arbitrary data structures', (assert) => {
-    const key = 'url';
-    const aggregated = [{ key: 'a' }, { key: 'b' }, { key: 'c' }, { key: 'd' }];
-    const raw = [
-      { type: 'a', url: 'https://www.crowdstrike.com/1' },
-      { type: 'a', url: 'https://www.crowdstrike.com/1' },
-      { type: 'a', url: 'https://www.crowdstrike.com/1' },
-      { type: 'b', url: 'https://www.crowdstrike.com/2' },
-      { type: 'c', url: 'https://www.crowdstrike.com/3' },
-      { type: 'd', url: 'https://www.crowdstrike.com/4' },
-      { type: 'd', url: 'https://www.crowdstrike.com/5' },
-    ];
-    const matcher = (item, raw) => raw.filter((x) => x.type === item.key).map((item) => item.url);
-    const badMatcher = (item, raw) => raw.filter((item) => typeof item === 'number');
-    const hasUrl = (item) => typeof item[key] === 'string';
-
-    assert.throws(
-      () => transplantFields(null, raw, matcher, key),
-      'requires valid aggregated data',
-    );
-    assert.throws(
-      () => transplantFields(aggregated, null, matcher, key),
-      'requires valid raw data',
-    );
-    assert.throws(() => transplantFields(aggregated, raw, null, key), 'requires matching function');
-
-    const successful = transplantFields(aggregated, raw, matcher, key);
-    const unsuccessful = transplantFields(aggregated, raw, badMatcher, key);
-
-    assert.ok(Array.isArray(successful), 'returns an array');
-
-    const originals = aggregated.every((item, index) => {
-      return Object.keys(item).every((key) => successful[index][key] === aggregated[index][key]);
-    });
-
-    assert.ok(originals, 'retains all values from original aggregated data point');
-    assert.ok(
-      successful.filter((item) => item.key !== 'd').every((item) => hasUrl(item)),
-      'transplants matching urls',
-    );
-    assert.ok(
-      successful.filter((item) => item.key === 'd').every((item) => !hasUrl(item)),
-      'does not transplant mismatched urls',
-    );
-    assert.ok(
-      unsuccessful.every((item) => !hasUrl(item)),
-      'does not transplant unmatched urls',
-    );
   });
 });

--- a/tests/unit/metadata-test.js
+++ b/tests/unit/metadata-test.js
@@ -1,0 +1,118 @@
+import { data } from '../../source/data.js';
+import { transplantFields } from '../../source/metadata.js';
+import { encodingField } from '../../source/encodings.js';
+import qunit from 'qunit';
+
+const { module, test } = qunit;
+
+module('unit > metadata', () => {
+
+    const urlData = [
+        { value: 1, group: 'a', label: '2020-01-01', url: 'https://crowdstrike.com/a' },
+        { value: 1, group: 'a', label: '2020-01-02', url: 'https://crowdstrike.com/a' },
+        { value: 2, group: 'b', label: '2020-01-03', url: 'https://crowdstrike.com/b' },
+        { value: 2, group: 'b', label: '2020-01-04', url: 'https://crowdstrike.com/b' },
+        { value: 2, group: 'b', label: '2020-01-05', url: 'https://crowdstrike.com/b' },
+        { value: 3, group: 'c', label: '2020-01-06', url: 'https://crowdstrike.com/c' },
+        { value: 3, group: 'c', label: '2020-01-07', url: 'https://crowdstrike.com/c' },
+    ];
+
+    test('transfers urls to aggregated circular chart segments', (assert) => {
+        const s = {
+            data: {
+                values: urlData,
+            },
+            mark: {
+                type: 'arc',
+            },
+            encoding: {
+                color: { field: 'group' },
+                href: { field: 'url' },
+                theta: { field: 'value' },
+            },
+        };
+
+        const layout = data(s);
+
+        assert.ok(layout.every((item) => item.url.startsWith('https://crowdstrike.com/')));
+    });
+
+    test('transfers urls to aggregated stacked bar chart segments', (assert) => {
+        const s = {
+            data: {
+                values: urlData,
+            },
+            mark: { type: 'bar' },
+            encoding: {
+                color: { field: 'group', type: 'nominal' },
+                href: { field: 'url' },
+                x: { field: 'label', type: 'temporal' },
+                y: { aggregate: 'value', type: 'quantitative' },
+            },
+        };
+
+        const layout = data(s);
+
+        layout.forEach((series) => {
+            series.forEach((item) => {
+                const difference = Math.abs(item[1] - item[0]) !== 0;
+
+                if (difference) {
+                    const url = item[encodingField(s, 'href')];
+
+                    assert.ok(url.startsWith('https://crowdstrike.com/'));
+                }
+            });
+        });
+    });
+
+    test('transplants urls between arbitrary data structures', (assert) => {
+        const key = 'url';
+        const aggregated = [{ key: 'a' }, { key: 'b' }, { key: 'c' }, { key: 'd' }];
+        const raw = [
+            { type: 'a', url: 'https://www.crowdstrike.com/1' },
+            { type: 'a', url: 'https://www.crowdstrike.com/1' },
+            { type: 'a', url: 'https://www.crowdstrike.com/1' },
+            { type: 'b', url: 'https://www.crowdstrike.com/2' },
+            { type: 'c', url: 'https://www.crowdstrike.com/3' },
+            { type: 'd', url: 'https://www.crowdstrike.com/4' },
+            { type: 'd', url: 'https://www.crowdstrike.com/5' },
+        ];
+        const matcher = (item, raw) => raw.filter((x) => x.type === item.key).map((item) => item.url);
+        const badMatcher = (item, raw) => raw.filter((item) => typeof item === 'number');
+        const hasUrl = (item) => typeof item[key] === 'string';
+
+        assert.throws(
+            () => transplantFields(null, raw, matcher, key),
+            'requires valid aggregated data',
+        );
+        assert.throws(
+            () => transplantFields(aggregated, null, matcher, key),
+            'requires valid raw data',
+        );
+        assert.throws(() => transplantFields(aggregated, raw, null, key), 'requires matching function');
+
+        const successful = transplantFields(aggregated, raw, matcher, key);
+        const unsuccessful = transplantFields(aggregated, raw, badMatcher, key);
+
+        assert.ok(Array.isArray(successful), 'returns an array');
+
+        const originals = aggregated.every((item, index) => {
+            return Object.keys(item).every((key) => successful[index][key] === aggregated[index][key]);
+        });
+
+        assert.ok(originals, 'retains all values from original aggregated data point');
+        assert.ok(
+            successful.filter((item) => item.key !== 'd').every((item) => hasUrl(item)),
+            'transplants matching urls',
+        );
+        assert.ok(
+            successful.filter((item) => item.key === 'd').every((item) => !hasUrl(item)),
+            'does not transplant mismatched urls',
+        );
+        assert.ok(
+            unsuccessful.every((item) => !hasUrl(item)),
+            'does not transplant unmatched urls',
+        );
+    });
+});


### PR DESCRIPTION
While it is not a distinction that's formally drawn by Vega Lite, one could arguably loosely separate "data" from "metadata" – the former is useful for rendering, and the latter would be fields that accompany the "primary" data points as they move through the library. In particular, this difference matters when categories are collapsed and aggregated, as with slices in a pie chart for example – if two data points are both destined for the same pie slice but have different description fields attached, which wins?

All the code in this pull request deals with that sort of problem. The diff is deceptively noisy – it's mostly about pulling all the metadata code into a dedicated module and then doing a bit of long overdue syntax cleanup. By design, there are no actual changes here yet.

This is both obnoxiously code and also a performance bottleneck, so it desperately needs to be refactored. For now, this just sets the stage for that future refactoring.