### PR TITLE
metadata rejection tests

### DIFF
--- a/tests/unit/metadata-test.js
+++ b/tests/unit/metadata-test.js
@@ -16,7 +16,13 @@ module('unit > metadata', () => {
             { value: 2, group: 'b', label: '2020-01-05', url: 'https://example.com/b' },
             { value: 3, group: 'c', label: '2020-01-06', url: 'https://example.com/c' },
             { value: 3, group: 'c', label: '2020-01-07', url: 'https://example.com/c' },
+            { value: 3, group: 'c', label: '2020-01-07', url: 'https://example.com/c' },
         ];
+    };
+
+    const mismatch = (data) => {
+        data[data.length - 1].url = 'https://example.com/d';
+        return data;
     };
 
     test('transfers urls to aggregated circular chart segments', (assert) => {
@@ -37,6 +43,35 @@ module('unit > metadata', () => {
         const layout = data(s);
 
         assert.ok(layout.every((item) => item.url.startsWith('https://example.com/')));
+    });
+
+    test('avoids transplanting mismatched data in aggregated circular chart segments', (assert) => {
+        const s = {
+            data: {
+                values: mismatch(urlData()),
+            },
+            mark: {
+                type: 'arc',
+            },
+            encoding: {
+                color: { field: 'group' },
+                href: { field: 'url' },
+                theta: { field: 'value' },
+            },
+        };
+
+        const layout = data(s);
+
+        layout.forEach((item) => {
+            const url = item[encodingField(s, 'href')];
+            const check = url?.startsWith('https://example.com/');
+            if (item.key === 'c') {
+                assert.notOk(check);
+            } else {
+                assert.ok(check);
+            }
+        })
+
     });
 
     test('transfers urls to aggregated stacked bar chart segments', (assert) => {
@@ -63,6 +98,42 @@ module('unit > metadata', () => {
                     const url = item[encodingField(s, 'href')];
 
                     assert.ok(url.startsWith('https://example.com/'));
+                }
+            });
+        });
+    });
+
+    test('avoids transplanting mismatched data in aggregated stacked bar chart segments', (assert) => {
+        const s = {
+            data: {
+                values: mismatch(urlData()),
+            },
+            mark: { type: 'bar' },
+            encoding: {
+                color: { field: 'group', type: 'nominal' },
+                href: { field: 'url' },
+                x: { field: 'label', type: 'temporal' },
+                y: { aggregate: 'value', type: 'quantitative' },
+            },
+        };
+
+        const layout = data(s);
+
+        console.log(s, layout);
+
+        layout.forEach((series) => {
+            series.forEach((item) => {
+                const difference = Math.abs(item[1] - item[0]) !== 0;
+                console.log(item);
+
+                if (difference) {
+                    const url = item[encodingField(s, 'href')];
+                    const check = url?.startsWith('https://example.com/');
+                    if (item.data.key === '2020-01-07') {
+                        assert.notOk(check);
+                    } else {
+                        assert.ok(check);
+                    }
                 }
             });
         });

--- a/tests/unit/metadata-test.js
+++ b/tests/unit/metadata-test.js
@@ -7,20 +7,22 @@ const { module, test } = qunit;
 
 module('unit > metadata', () => {
 
-    const urlData = [
-        { value: 1, group: 'a', label: '2020-01-01', url: 'https://example.com/a' },
-        { value: 1, group: 'a', label: '2020-01-02', url: 'https://example.com/a' },
-        { value: 2, group: 'b', label: '2020-01-03', url: 'https://example.com/b' },
-        { value: 2, group: 'b', label: '2020-01-04', url: 'https://example.com/b' },
-        { value: 2, group: 'b', label: '2020-01-05', url: 'https://example.com/b' },
-        { value: 3, group: 'c', label: '2020-01-06', url: 'https://example.com/c' },
-        { value: 3, group: 'c', label: '2020-01-07', url: 'https://example.com/c' },
-    ];
+    const urlData = () => {
+        return [
+            { value: 1, group: 'a', label: '2020-01-01', url: 'https://example.com/a' },
+            { value: 1, group: 'a', label: '2020-01-02', url: 'https://example.com/a' },
+            { value: 2, group: 'b', label: '2020-01-03', url: 'https://example.com/b' },
+            { value: 2, group: 'b', label: '2020-01-04', url: 'https://example.com/b' },
+            { value: 2, group: 'b', label: '2020-01-05', url: 'https://example.com/b' },
+            { value: 3, group: 'c', label: '2020-01-06', url: 'https://example.com/c' },
+            { value: 3, group: 'c', label: '2020-01-07', url: 'https://example.com/c' },
+        ];
+    };
 
     test('transfers urls to aggregated circular chart segments', (assert) => {
         const s = {
             data: {
-                values: urlData,
+                values: urlData(),
             },
             mark: {
                 type: 'arc',
@@ -40,7 +42,7 @@ module('unit > metadata', () => {
     test('transfers urls to aggregated stacked bar chart segments', (assert) => {
         const s = {
             data: {
-                values: urlData,
+                values: urlData(),
             },
             mark: { type: 'bar' },
             encoding: {


### PR DESCRIPTION
Add tests to ensure metadata is not copied across between raw and aggregated data points in cases where the values don't match.