### PR TITLE
remove tick text loop

### DIFF
--- a/source/text.js
+++ b/source/text.js
@@ -219,9 +219,7 @@ const axisTickLabelText = (s, channel) => {
       styles[channel] = fontStyles(node);
     }
 
-    selection.each(function (label) {
-      d3.select(this).text(axisTickLabelTextContent(s, channel, label, styles[channel]));
-    });
+    selection.text((label) => axisTickLabelTextContent(s, channel, label, styles[channel]));
   };
 };
 


### PR DESCRIPTION
Clean up syntax and remove an unnecessary reference to the bound DOM element.