### PR TITLE
add JSDoc for extension helper

### DIFF
--- a/source/extensions.js
+++ b/source/extensions.js
@@ -1,3 +1,8 @@
+/**
+ * retrieve information from usermeta
+ * @param {object} s Vega Lite specification
+ * @param {string} key usermeta key
+ */
 const extension = (s, key) => {
     if (s.usermeta?.[key]) {
         return s.usermeta[key];


### PR DESCRIPTION
Given that `specification.usermeta` can hold arbitrary information, it's not really possible to type the return value.