### PR TITLE
metadata refactor

### DIFF
--- a/source/metadata.js
+++ b/source/metadata.js
@@ -100,6 +100,7 @@ const coreEncodingFields = (s) => {
  */
 const countFields = (s, data, createKey) => {
     const counter = {};
+    const fields = metadataFields(s);
     data.forEach((item) => {
         const key = createKey(item);
         if (!counter[key]) {
@@ -108,9 +109,8 @@ const countFields = (s, data, createKey) => {
         counter[key].count++;
         const count = counter[key].count;
         if (count === 1) {
-            counter[key].fields = pick(item, metadataFields(s));
+            counter[key].fields = pick(item, fields);
         } else if (count > 1) {
-            const fields = metadataFields(s);
             const matches = matchingFields(counter[key].fields, pick(item, fields), fields);
             if (matches.length !== fields.length) {
                 counter[key].fields = pick(item, matches);

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -5,6 +5,22 @@ import { values } from './helpers.js';
 const metadataChannels = ['description', 'tooltip', 'href'];
 
 /**
+ * compare field values on two objects
+ * @param {object} a object to compare
+ * @param {object} b object to compare
+ * @param {string[]} fields list of fields to compare
+ * @returns {boolean} whether all fields match
+ */
+const compareFields = (a, b, fields) => {
+    for (let i = 0; i < fields.length; i++) {
+        if (a[fields[i]] !== b[fields[i]]) {
+            return false;
+        }
+    }
+    return true;
+};
+
+/**
  * create a function for looking up core encoding channels
  * and returning them as a string key suitable for indexing
  * @param {object} s Vega Lite specification

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -32,7 +32,7 @@ const matchingFields = (a, b, fields) => {
  */
 const createKeyBuilder = (s) => {
     const delimiter = ' + ';
-    const fields = coreEncodingChannels(s).map(channel => encodingField(s, channel))
+    const fields = coreEncodingFields(s);
     const getters = fields.map((field) => (item) => item[field]);
     const getter = (item) => getters.map(getter => getter(item)).join(delimiter);
     return getter;
@@ -81,6 +81,16 @@ const pick = (object, fields) => {
     return channels;
  };
 
+ /**
+  * fields used to represent core
+  * encoding channels
+  * @param {object} s Vega Lite specification
+  * @returns {string[]} encoding fields
+  */
+const coreEncodingFields = (s) => {
+    return coreEncodingChannels(s).map(channel => encodingField(s, channel)).filter(Boolean);
+};
+
 /**
  * count the metadata fields in a data set and look for conflicts
  * @param {object} s Vega Lite specification
@@ -119,8 +129,7 @@ const countFields = (s, data, createKey) => {
  */
 const lookupCircular = (s, item) => {
     let result = {};
-    const fields = coreEncodingChannels(s)
-        .map(channel => encodingField(s, channel))
+    const fields = coreEncodingFields(s);
     if (feature(s).isCircular()) {
         return {
             // this is equivalent to using accessor functions

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -1,147 +1,33 @@
-import { mark } from "./helpers.js";
-import {
-    encodingChannelCovariate,
-    encodingChannelCovariateCartesian,
-    encodingField,
-} from './encodings.js';
+import { encodingChannelCovariateCartesian, encodingField } from './encodings.js';
 import { feature } from './feature.js';
-import { isDiscrete } from './helpers.js';
+import { values } from './helpers.js';
+
+const metadataChannels = ['description', 'tooltip', 'href'];
+const encodingChannels = ['x', 'y', 'color'];
 
 /**
  * move properties from an array of source
  * values to an aggregate
- * @param {array} aggregated aggregated data points
- * @param {array} raw individual data points
- * @param {function} matcher find matching values
- * @param {string} key property name for transplanted field
- * @returns {array} aggregated data points with transplanted field attached
- */
-const transplantFields = (aggregated, raw, matcher, key) => {
-    return aggregated.map((item) => {
-        const matches = matcher(item, raw);
-        const result = { ...item };
-        const allMatch = matches.every((item) => item === matches[0]);
-
-        if (matches.length > 0 && allMatch) {
-            result[key] = matches[0];
-        }
-
-        return result;
-    });
-};
-
-/**
- * transfer metadata from raw data points to aggregated stack layout
  * @param {object} s Vega Lite specification
- * @param {object[]} aggregated aggregated data for data join
- * @returns {object[]} aggregated data with metadata
+ * @param {object[]} aggregated aggregated data points
+ * @param {object[]} raw individual data points
+ * @returns {object[]} aggregated data points with transplanted field attached
  */
-const transplantStackMetadata = (s, aggregated) => {
-    const createMatcher = (key) => {
-        const matcher = (aggregatedItem, raw) => {
-            const laneChannel = encodingChannelCovariateCartesian(s);
-            const keys = {
-                lane: encodingField(s, laneChannel),
-                series: encodingField(s, 'color'),
-            };
-            const matches = raw
-                .filter((rawItem) => {
-                    let seriesMatch;
-
-                    // single-color categorical charts are still plotted using separate series nodes
-                    if (feature(s).hasColor() || isDiscrete(s, encodingChannelCovariate(s))) {
-                        seriesMatch = aggregatedItem[keys.series] === rawItem[keys.series];
-                    } else {
-                        seriesMatch = true;
-                    }
-
-                    const laneMatch =
-                        aggregatedItem[keys.lane] &&
-                        rawItem[keys.lane] &&
-                        aggregatedItem[keys.lane]?.toString() === rawItem[keys.lane]?.toString();
-                    const hasField = !!rawItem[key];
-
-                    return seriesMatch && laneMatch && hasField;
-                })
-                .map((item) => item[key])
-                .filter(Boolean);
-
-            return matches;
-        };
-
-        return matcher;
-    };
-
-    const results = [...aggregated];
-
-    results.forEach((series, i) => {
-        series.forEach((item, j) => {
-            const lookup = {};
-
-            if (encodingField(s, 'color')) {
-                lookup[encodingField(s, 'color')] = series.key;
-            }
-
-            if (encodingField(s, encodingChannelCovariate(s))) {
-                lookup[encodingField(s, encodingChannelCovariate(s))] = item.data.key;
-            }
-
-            const channels = ['href', 'description', 'tooltip'];
-            const fields = channels.map((channel) => encodingField(s, channel));
-
-            fields.forEach((field) => {
-                const value = transplantFields([lookup], s.data.values, createMatcher(field), field).pop()[
-                    field
-                ];
-
-                if (value) {
-                    // the reference to the datum object is shared across marks by the d3 layout generator, so
-                    // this needs to be set as a non-enumerable property on the array, which is a bit odd but
-                    // also how the datum object is already stored
-                    Object.defineProperty(results[i][j], field, {
-                        value,
-                    });
-                }
-            });
-        });
-    });
-
-    return results;
-};
-
-/**
- * transfer metadata from raw data points to aggregated circular layout
- * @param {object} s Vega Lite specification
- * @param {object[]} aggregated aggregated data for data join
- * @returns {object[]} aggregated data with metadata
- */
-const transplantCircularMetadata = (s, aggregated) => {
-    const createMatcher = (channel) => {
-        return (aggregatedItem, raw) => {
-            return raw
-                .filter((rawItem) => {
-                    const currentAggregateDatumField = aggregatedItem.key.toString();
-                    const rawDatumField = rawItem[encodingField(s, 'color')].toString();
-
-                    return currentAggregateDatumField === rawDatumField;
-                })
-                .map((item) => {
-                    return item[encodingField(s, channel)];
-                });
-        };
-    };
-
-    const channels = ['href', 'description', 'tooltip'];
-    channels.forEach((channel) => {
-        if (s.encoding[channel]) {
-            aggregated = transplantFields(
-                [...aggregated],
-                s.data.values,
-                createMatcher(channel),
-                encodingField(s, channel),
-            );
+const transplantFields = (s, aggregated, raw) => {
+    const counter = {};
+    const createKey = createKeyBuilder(s);
+    const pluck = createPlucker(s);
+    raw.forEach((item) => {
+        const key = createKey(item);
+        if (!counter[key]) {
+            counter[key] = {count: 0};
         }
+        counter[key].count++;
+        counter[key].fields = pluck(item);
     });
+    aggregated.forEach(item => {
+        const key = createKey(lookup(s, item));
+    })
     return aggregated;
 };
 
@@ -152,10 +38,8 @@ const transplantCircularMetadata = (s, aggregated) => {
  * @returns {object[]} aggregated data with metadata
  */
 const metadata = (s, data) => {
-    if (feature(s).isBar() || feature(s).isArea()) {
-        return transplantStackMetadata(s, data);
-    } else if (feature(s).isCircular()) {
-        return transplantCircularMetadata(s, data);
+    if (feature(s).isBar() || feature(s).isArea() || feature(s).isCircular()) {
+        return transplantFields(s, data);
     }
 };
 

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -27,6 +27,27 @@ const createKeyBuilder = (s) => {
 };
 
 /**
+ * create a function which extracts the necessary
+ * metadata fields from an input object
+ * @param {object} s Vega Lite specification
+ * @returns {function(object)} extract metadata fields
+ */
+const createPicker = (s) => {
+    return (item) => {
+        let result = {};
+        let fields = metadataChannels
+            .map((channel) => encodingField(s, channel))
+            .filter(Boolean);
+        fields.forEach(field => {
+            if (item[field]) {
+                result[field] = item[field];
+            }
+        })
+        return result;
+    }
+};
+
+/**
  * move properties from an array of source
  * values to an aggregate
  * @param {object} s Vega Lite specification
@@ -37,14 +58,14 @@ const createKeyBuilder = (s) => {
 const transplantFields = (s, aggregated, raw) => {
     const counter = {};
     const createKey = createKeyBuilder(s);
-    const pluck = createPlucker(s);
+    const pick = createPicker(s);
     raw.forEach((item) => {
         const key = createKey(item);
         if (!counter[key]) {
             counter[key] = {count: 0};
         }
         counter[key].count++;
-        counter[key].fields = pluck(item);
+        counter[key].fields = pick(item);
     });
     aggregated.forEach(item => {
         const key = createKey(lookup(s, item));

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -38,8 +38,9 @@ const transplantFields = (s, aggregated, raw) => {
  * @returns {object[]} aggregated data with metadata
  */
 const metadata = (s, data) => {
-    if (feature(s).isBar() || feature(s).isArea() || feature(s).isCircular()) {
-        return transplantFields(s, data);
+    const layout = feature(s).isBar() || feature(s).isArea() || feature(s).isCircular();
+    if (layout) {
+        return transplantFields(s, data, values(s));
     }
 };
 

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -166,6 +166,16 @@ const transplantFields = (s, aggregated, raw) => {
         });
     }
 
+    if (feature(s).isBar()) {
+        const covariate = encodingField(s, encodingChannelCovariateCartesian(s));
+        aggregated.forEach(series => {
+            series.forEach(item => {
+                const key = createKey(lookupStack(s, series.key, covariate, item));
+                Object.assign(item, counter[key]?.fields);
+            });
+        });
+    }
+
     return aggregated;
 };
 

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -1,6 +1,6 @@
 import { encodingChannelCovariateCartesian, encodingField } from './encodings.js';
 import { feature } from './feature.js';
-import { values } from './helpers.js';
+import { missingSeries, values } from './helpers.js';
 
 const metadataChannels = ['description', 'tooltip', 'href'];
 
@@ -119,6 +119,31 @@ const lookupCircular = (s, item) => {
             [fields[0]]: item.key
         };
     }
+    return result;
+};
+
+/**
+ * restructure a data point from a stack layout
+ * to make it easier to find the data fields of
+ * interest for comparison
+ *
+ * due to a performance bottleneck, fields are
+ * looked up once externally and then passed into
+ * this restructuring function as arguments instead
+ * of being kept entirely inside this scope
+ * @param {object} s Vega Lite specification
+ * @param {string} series series key
+ * @param {object} item datum
+ * @returns {object} object with lookup fields at the top level
+ */
+const lookupStack = (s, series, covariate, item) => {
+    let result = {};
+    if (series !== missingSeries()) {
+        result[encodingField(s, 'color')] = series;
+    }
+    // this is equivalent to using accessor functions
+    // but is hard coded here for performance reasons
+    result[covariate] = item.data.key;
     return result;
 };
 

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -5,6 +5,15 @@ import { missingSeries, values } from './helpers.js';
 const metadataChannels = ['description', 'tooltip', 'href'];
 
 /**
+ * test whether a specification has metadata
+ * @param {object} s Vega Lite specification
+ * @returns {boolean}
+ */
+const hasMetadata = (s) => {
+    return Object.keys(s.encoding).some((key) => metadataChannels.includes(key));
+};
+
+/**
  * determine which field values match between two objects
  * @param {object} a object to compare
  * @param {object} b object to compare
@@ -186,6 +195,9 @@ const transplantFields = (s, aggregated, raw) => {
  * @returns {object[]} aggregated data with metadata
  */
 const metadata = (s, data) => {
+    if (!hasMetadata(s)) {
+        return data;
+    }
     const layout = feature(s).isBar() || feature(s).isArea() || feature(s).isCircular();
     if (layout) {
         return transplantFields(s, data, values(s));

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -110,9 +110,9 @@ const countFields = (s, data, createKey) => {
         if (count === 1) {
             counter[key].fields = pick(item, metadataFields(s));
         } else if (count > 1) {
-            const channels = metadataChannels.map((channel) => encodingField(s, channel)).filter(Boolean);
-            const matches = matchingFields(counter[key].fields, pick(item, metadataFields(s)), channels);
-            if (matches.length !== channels.length) {
+            const fields = metadataFields(s);
+            const matches = matchingFields(counter[key].fields, pick(item, fields), fields);
+            if (matches.length !== fields.length) {
                 counter[key].fields = pick(item, matches);
             }
         }

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -5,19 +5,14 @@ import { values } from './helpers.js';
 const metadataChannels = ['description', 'tooltip', 'href'];
 
 /**
- * compare field values on two objects
+ * determine which field values match between two objects
  * @param {object} a object to compare
  * @param {object} b object to compare
  * @param {string[]} fields list of fields to compare
- * @returns {boolean} whether all fields match
+ * @returns {string[]} matching fields
  */
-const compareFields = (a, b, fields) => {
-    for (let i = 0; i < fields.length; i++) {
-        if (a[fields[i]] !== b[fields[i]]) {
-            return false;
-        }
-    }
-    return true;
+const matchingFields = (a, b, fields) => {
+    return fields.filter((field) => a[field] === b[field]);
 };
 
 /**
@@ -92,8 +87,8 @@ const countFields = (s, data, createKey) => {
             counter[key].fields = pluck(item);
         } else if (count > 1) {
             const channels = metadataChannels.map((channel) => encodingField(s, channel)).filter(Boolean);
-            const match = !compareFields(counter[key].fields, pluck(item), channels);
-            if (match) {
+            const matches = matchingFields(counter[key].fields, pluck(item), channels);
+            if (matches.length === channels.length) {
                 counter[key].count++
             } else {
                 counter[key].fields = {};

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -214,4 +214,4 @@ const metadata = (s, data) => {
     }
 };
 
-export { metadata, transplantFields };
+export { metadata };

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -105,7 +105,8 @@ const countFields = (s, data, createKey) => {
         if (!counter[key]) {
             counter[key] = {count: 0};
         }
-        const count = counter[key].count++;
+        counter[key].count++;
+        const count = counter[key].count;
         if (count === 1) {
             counter[key].fields = pick(item, metadataFields(s));
         } else if (count > 1) {

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -132,7 +132,8 @@ const transplantFields = (s, aggregated, raw) => {
     const counter = countFields(s, raw, createKey);
     aggregated.forEach(item => {
         const key = createKey(lookup(s, item));
-    })
+        Object.assign(item, counter[key]?.fields);
+    });
     return aggregated;
 };
 

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -152,9 +152,9 @@ const transplantCircularMetadata = (s, aggregated) => {
  * @returns {object[]} aggregated data with metadata
  */
 const metadata = (s, data) => {
-    if (mark(s) === 'bar' || mark(s) === 'area') {
+    if (feature(s).isBar() || feature(s).isArea()) {
         return transplantStackMetadata(s, data);
-    } else if (mark(s) === 'arc') {
+    } else if (feature(s).isCircular()) {
         return transplantCircularMetadata(s, data);
     }
 };

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -92,10 +92,8 @@ const countFields = (s, data, createKey) => {
         } else if (count > 1) {
             const channels = metadataChannels.map((channel) => encodingField(s, channel)).filter(Boolean);
             const matches = matchingFields(counter[key].fields, pick(item, metadataFields(s)), channels);
-            if (matches.length === channels.length) {
-                counter[key].count++
-            } else {
-                counter[key].fields = {};
+            if (matches.length !== channels.length) {
+                counter[key].fields = pick(item, matches);
             }
         }
     });

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -3,7 +3,6 @@ import { feature } from './feature.js';
 import { values } from './helpers.js';
 
 const metadataChannels = ['description', 'tooltip', 'href'];
-const encodingChannels = ['x', 'y', 'color'];
 
 /**
  * create a function for looking up core encoding channels
@@ -13,14 +12,7 @@ const encodingChannels = ['x', 'y', 'color'];
  */
 const createKeyBuilder = (s) => {
     const delimiter = ' + ';
-    let channels = [];
-    if (feature(s).hasColor()) {
-        channels.push('color');
-    }
-    if (feature(s).isCartesian()) {
-        channels.push(encodingChannelCovariateCartesian(s));
-    }
-    const fields = channels.map(channel => encodingField(s, channel))
+    const fields = coreEncodingChannels(s).map(channel => encodingField(s, channel))
     const getters = fields.map((field) => (item) => item[field]);
     const getter = (item) => getters.map(getter => getter(item)).join(delimiter);
     return getter;
@@ -48,6 +40,23 @@ const createPicker = (s) => {
 };
 
 /**
+ * determine which core encoding channels are
+ * represented in a Vega Lite specification
+ * @param {object} s Vega Lite specification
+ * @returns {string[]} encoding channels
+ */
+ const coreEncodingChannels = (s) => {
+    let channels = [];
+    if (feature(s).hasColor()) {
+        channels.push('color');
+    }
+    if (feature(s).isCartesian()) {
+        channels.push(encodingChannelCovariateCartesian(s));
+    }
+    return channels;
+};
+
+/**
  * restructure a data point to make it easier to
  * find the data fields of interest for comparison
  * @param {object} s Vega Lite specification
@@ -56,9 +65,7 @@ const createPicker = (s) => {
  */
 const lookup = (s, item) => {
     let result = {};
-    let channels = encodingChannels
-        .filter((channel) => s.encoding[channel])
-    const fields = channels
+    const fields = coreEncodingChannels(s)
         .map(channel => encodingField(s, channel))
     if (feature(s).isCircular()) {
         return {

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -6,6 +6,27 @@ const metadataChannels = ['description', 'tooltip', 'href'];
 const encodingChannels = ['x', 'y', 'color'];
 
 /**
+ * create a function for looking up core encoding channels
+ * and returning them as a string key suitable for indexing
+ * @param {object} s Vega Lite specification
+ * @returns {function(object)} convert datum to string key
+ */
+const createKeyBuilder = (s) => {
+    const delimiter = ' + ';
+    let channels = [];
+    if (feature(s).hasColor()) {
+        channels.push('color');
+    }
+    if (feature(s).isCartesian()) {
+        channels.push(encodingChannelCovariateCartesian(s));
+    }
+    const fields = channels.map(channel => encodingField(s, channel))
+    const getters = fields.map((field) => (item) => item[field]);
+    const getter = (item) => getters.map(getter => getter(item)).join(delimiter);
+    return getter;
+};
+
+/**
  * move properties from an array of source
  * values to an aggregate
  * @param {object} s Vega Lite specification

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -48,6 +48,27 @@ const createPicker = (s) => {
 };
 
 /**
+ * restructure a data point to make it easier to
+ * find the data fields of interest for comparison
+ * @param {object} s Vega Lite specification
+ * @param {object} item datum
+ * @returns {object} object with lookup fields at the top level
+ */
+const lookup = (s, item) => {
+    let result = {};
+    let channels = encodingChannels
+        .filter((channel) => s.encoding[channel])
+    const fields = channels
+        .map(channel => encodingField(s, channel))
+    if (feature(s).isCircular()) {
+        return {
+            [fields[0]]: item.key
+        };
+    }
+    return result;
+};
+
+/**
  * move properties from an array of source
  * values to an aggregate
  * @param {object} s Vega Lite specification

--- a/tests/integration/axes-test.js
+++ b/tests/integration/axes-test.js
@@ -6,7 +6,7 @@ const { module, test } = qunit;
 
 module('integration > axes', function () {
   test('renders a chart with axes', (assert) => {
-    const spec = specificationFixture('line');
+    const spec = specificationFixture('categoricalBar');
     const element = render(spec);
 
     const single = [testSelector('axes'), testSelector('axes-x'), testSelector('axes-y')];
@@ -17,7 +17,7 @@ module('integration > axes', function () {
   });
 
   test('renders a chart with custom axis titles', (assert) => {
-    const spec = specificationFixture('line');
+    const spec = specificationFixture('categoricalBar');
 
     spec.encoding.x.axis = { title: 'a' };
     spec.encoding.y.axis = { title: 'b' };
@@ -28,7 +28,7 @@ module('integration > axes', function () {
 
   test('renders a chart without y-axis tick labels', (assert) => {
 
-    const spec = specificationFixture('line');
+    const spec = specificationFixture('categoricalBar');
 
     spec.encoding.y.axis = {labels: false};
 
@@ -81,7 +81,7 @@ module('integration > axes', function () {
   });
 
   test('renders a chart without axis titles', (assert) => {
-    const spec = specificationFixture('line');
+    const spec = specificationFixture('categoricalBar');
 
     spec.encoding.x.axis = { title: null };
     spec.encoding.y.axis = { title: null };
@@ -105,7 +105,7 @@ module('integration > axes', function () {
     });
   });
   test('disables axes', (assert) => {
-    const spec = specificationFixture('temporalBar');
+    const spec = specificationFixture('categoricalBar');
     spec.encoding.x.axis = null;
     spec.encoding.y.axis = null;
     const element = render(spec);

--- a/tests/unit/metadata-test.js
+++ b/tests/unit/metadata-test.js
@@ -1,5 +1,6 @@
 import { data } from '../../source/data.js';
 import { encodingField } from '../../source/encodings.js';
+import { specificationFixture } from '../test-helpers.js';
 import qunit from 'qunit';
 
 const { module, test } = qunit;
@@ -134,4 +135,22 @@ module('unit > metadata', () => {
             });
         });
     });
+
+    test('copies multiple metadata fields', (assert) => {
+        const s = specificationFixture('circular');
+        s.data.values = [
+            {a: '•', b: '-', c: 'https://www.example.com/a', group: 'a', value: 95},
+            {a: '+', b: '_', c: 'https://www.example.com/b', group: 'b', value: 3},
+            {a: '@', b: '|', c: 'https://www.example.com/c', group: 'c', value: 2},
+        ];
+        s.encoding.tooltip = { field: 'a' };
+        s.encoding.description = { field: 'b' };
+        s.encoding.href = { field: 'c' };
+        data(s).forEach(item => {
+            assert.equal(typeof item.a, 'string');
+            assert.equal(typeof item.b, 'string');
+            assert.equal(typeof item.c, 'string');
+        });
+    });
+
 });

--- a/tests/unit/metadata-test.js
+++ b/tests/unit/metadata-test.js
@@ -1,5 +1,4 @@
 import { data } from '../../source/data.js';
-import { transplantFields } from '../../source/metadata.js';
 import { encodingField } from '../../source/encodings.js';
 import qunit from 'qunit';
 
@@ -134,55 +133,5 @@ module('unit > metadata', () => {
                 }
             });
         });
-    });
-
-    test('transplants urls between arbitrary data structures', (assert) => {
-        const key = 'url';
-        const aggregated = [{ key: 'a' }, { key: 'b' }, { key: 'c' }, { key: 'd' }];
-        const raw = [
-            { type: 'a', url: 'https://www.example.com/1' },
-            { type: 'a', url: 'https://www.example.com/1' },
-            { type: 'a', url: 'https://www.example.com/1' },
-            { type: 'b', url: 'https://www.example.com/2' },
-            { type: 'c', url: 'https://www.example.com/3' },
-            { type: 'd', url: 'https://www.example.com/4' },
-            { type: 'd', url: 'https://www.example.com/5' },
-        ];
-        const matcher = (item, raw) => raw.filter((x) => x.type === item.key).map((item) => item.url);
-        const badMatcher = (item, raw) => raw.filter((item) => typeof item === 'number');
-        const hasUrl = (item) => typeof item[key] === 'string';
-
-        assert.throws(
-            () => transplantFields(null, raw, matcher, key),
-            'requires valid aggregated data',
-        );
-        assert.throws(
-            () => transplantFields(aggregated, null, matcher, key),
-            'requires valid raw data',
-        );
-        assert.throws(() => transplantFields(aggregated, raw, null, key), 'requires matching function');
-
-        const successful = transplantFields(aggregated, raw, matcher, key);
-        const unsuccessful = transplantFields(aggregated, raw, badMatcher, key);
-
-        assert.ok(Array.isArray(successful), 'returns an array');
-
-        const originals = aggregated.every((item, index) => {
-            return Object.keys(item).every((key) => successful[index][key] === aggregated[index][key]);
-        });
-
-        assert.ok(originals, 'retains all values from original aggregated data point');
-        assert.ok(
-            successful.filter((item) => item.key !== 'd').every((item) => hasUrl(item)),
-            'transplants matching urls',
-        );
-        assert.ok(
-            successful.filter((item) => item.key === 'd').every((item) => !hasUrl(item)),
-            'does not transplant mismatched urls',
-        );
-        assert.ok(
-            unsuccessful.every((item) => !hasUrl(item)),
-            'does not transplant unmatched urls',
-        );
     });
 });


### PR DESCRIPTION
The [metadata](https://github.com/vijithassar/bisonica/pull/123) handling has long been overdue for a refactor. Previously it had the concept of a "matcher function" which would allow a single data point to query the data set for other data points which shared the same encoding values. Once they had been identified, they could be examined as a group in order to ensure that there weren't any conflicts regarding what the metadata value should be. If there was a disagreement, that metadata point would be dropped, and you wouldn't have a clickable pivot link, or whatever.

It seemed sort of elegant conceptually at first, but in practice it was awful. Many charts needed to bail out of the general case matcher functions in order to handle nested series, which meant the code wasn't particularly clean, and then on top of that it had hideously quadratic performance which scaled poorly both with the number of significant visual encodings (so a multicolor stacked bar chart would get hit harder than a pie chart) and also with the number of metadata fields.

To make it faster, you need to collapse the encoding fields down to a string and then use that string as the key on an intermediate data structure which can track the metadata values for that set of values and invalidate them if a conflict is found. This results in linear performance, which in turn roughly quadruples the rendering speed for stacked bar charts.