### PR TITLE
metadata doesn't use layout generators

### DIFF
--- a/source/metadata.js
+++ b/source/metadata.js
@@ -121,9 +121,9 @@ const countFields = (s, data, createKey) => {
 };
 
 /**
- * restructure a data point from a circular layout
- * to make it easier to find the data fields of
- * interest for comparison
+ * restructure a data point from aggregate data
+ * for a circular chart to make it easier to find
+ * the data fields of interest for comparison
  * @param {object} s Vega Lite specification
  * @param {object} item datum
  * @returns {object} object with lookup fields at the top level
@@ -142,9 +142,9 @@ const lookupCircular = (s, item) => {
 };
 
 /**
- * restructure a data point from a stack layout
- * to make it easier to find the data fields of
- * interest for comparison
+ * restructure a data point from aggregated data for
+ * a stack-based chart to make it easier to find the
+ * data fields of interest for comparison
  *
  * due to a performance bottleneck, fields are
  * looked up once externally and then passed into
@@ -208,8 +208,8 @@ const metadata = (s, data) => {
     if (!hasMetadata(s)) {
         return data;
     }
-    const layout = feature(s).isBar() || feature(s).isArea() || feature(s).isCircular();
-    if (layout) {
+    const aggregate = feature(s).isBar() || feature(s).isArea() || feature(s).isCircular();
+    if (aggregate) {
         return transplantFields(s, data, values(s));
     }
 };

--- a/tests/unit/metadata-test.js
+++ b/tests/unit/metadata-test.js
@@ -40,9 +40,7 @@ module('unit > metadata', () => {
             },
         };
 
-        const layout = data(s);
-
-        assert.ok(layout.every((item) => item.url.startsWith('https://example.com/')));
+        assert.ok(data(s).every((item) => item.url.startsWith('https://example.com/')));
     });
 
     test('avoids transplanting mismatched data in aggregated circular chart segments', (assert) => {
@@ -60,9 +58,7 @@ module('unit > metadata', () => {
             },
         };
 
-        const layout = data(s);
-
-        layout.forEach((item) => {
+        data(s).forEach((item) => {
             const url = item[encodingField(s, 'href')];
             const check = url?.startsWith('https://example.com/');
             if (item.key === 'c') {
@@ -88,9 +84,7 @@ module('unit > metadata', () => {
             },
         };
 
-        const layout = data(s);
-
-        layout.forEach((series) => {
+        data(s).forEach((series) => {
             series.forEach((item) => {
                 const difference = Math.abs(item[1] - item[0]) !== 0;
 
@@ -117,9 +111,7 @@ module('unit > metadata', () => {
             },
         };
 
-        const layout = data(s);
-
-        layout.forEach((series) => {
+        data(s).forEach((series) => {
             series.forEach((item) => {
                 const difference = Math.abs(item[1] - item[0]) !== 0;
 


### PR DESCRIPTION
Cleans up the terminology used for data sets in the [metadata handling](https://github.com/vijithassar/bisonica/pull/123), which doesn't actually depend on the layout generators from [d3-shape](https://github.com/d3/d3-shape/).