### PR TITLE
remove unnecessary typeof checks

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -85,7 +85,7 @@ const title = (s, channel) => {
 const alternate = (s) => {
   return (selection) => {
     ['x', 'y'].forEach((channel) => {
-      if (typeof s.encoding[channel] === 'undefined') {
+      if (s.encoding[channel] === undefined) {
         return;
       }
 

--- a/source/chart.js
+++ b/source/chart.js
@@ -61,7 +61,7 @@ const chart = (s, panelDimensions) => {
   };
 
   renderer.tooltip = (h) => {
-    if (typeof h === 'undefined') {
+    if (h === undefined) {
       return tooltipHandler;
     } else {
       if (typeof h === 'function') {

--- a/source/data.js
+++ b/source/data.js
@@ -37,7 +37,7 @@ const sumByProperty = (datum, property, valueKey) => {
   datum.values.forEach((item) => {
     const key = item[property];
 
-    if (typeof result[key] === 'undefined') {
+    if (result[key] === undefined) {
       result[key] = { value: 0 };
     }
 

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -39,7 +39,7 @@ const encodingValue = (s, channel) => {
   const key = encodingField(s, channel);
   const nesting = key && key.includes('.');
   return (d) => {
-    if (!nesting && typeof d[key] !== 'undefined') {
+    if (!nesting && d[key] !== undefined) {
       return d[key];
     } else if (nesting) {
       return nested(d, key);
@@ -160,11 +160,11 @@ const createEncoders = (s, dimensions, accessors) => {
 
       const value = encodingType(s, channel) === 'temporal' ? parseTime(accessor(d)) : accessor(d);
 
-      if (accessor && typeof scale === 'undefined') {
+      if (accessor && scale === undefined) {
         throw new Error(`accessor function ${channel}() is missing corresponding scale function`);
       }
 
-      if (typeof d === 'undefined' && value !== null) {
+      if (d === undefined && value !== null) {
         throw new Error(`datum for ${channel} is undefined`);
       }
 
@@ -172,13 +172,13 @@ const createEncoders = (s, dimensions, accessors) => {
         throw new Error(`scale function for ${channel} is not available`);
       }
 
-      if (typeof value === 'undefined' && feature(s).isMulticolor()) {
+      if (value === undefined && feature(s).isMulticolor()) {
         throw new Error(`data value for ${channel} is undefined`);
       }
 
       const encoded = scale(value);
 
-      if (typeof encoded === 'undefined') {
+      if (encoded === undefined) {
         throw new Error(`encoded value for ${channel} is undefined`);
       }
 

--- a/source/keyboard.js
+++ b/source/keyboard.js
@@ -67,7 +67,7 @@ const key = (s, direction) => {
       return false;
     };
 
-    if (typeof state.index() === 'undefined') {
+    if (state.index() === undefined) {
       state.init();
       dispatcher.call('addMarkHighlight', current());
       dispatcher.call('addLegendHighlight', null, category.get(current()));
@@ -165,12 +165,12 @@ const createState = () => {
 
   return {
     init() {
-      if (typeof index === 'undefined') {
+      if (index === undefined) {
         index = 0;
       }
     },
     index(n) {
-      return typeof n === 'undefined' ? index : ((index = n), true);
+      return n === undefined ? index : ((index = n), true);
     },
   };
 };
@@ -254,7 +254,7 @@ const keyboard = (_s) => {
       // fire navigation initialization behaviors on first focus
 
       mark.on('focus', function (event) {
-        if (typeof state.index() === 'undefined') {
+        if (state.index() === undefined) {
           navigator[RIGHT](mark, state);
         }
 

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -137,7 +137,7 @@ const _getTooltipField = (s, type) => {
 
     value = getValue(d);
 
-    if (channel === 'color' && typeof value === 'undefined') {
+    if (channel === 'color' && value === undefined) {
       value = category.get(d);
     }
 

--- a/source/views.js
+++ b/source/views.js
@@ -217,7 +217,7 @@ const layerNode = (s, wrapper) => {
  * @returns {object} Vega Lite specification for a single layer
  */
 const layerSpecification = (s, index) => {
-  if (typeof index === 'undefined') {
+  if (index === undefined) {
     throw new Error(`layer ${index} in specification is undefined`);
   }
 


### PR DESCRIPTION
Consistently using `typeof` makes it easier to refer to variables that don't exist without immediately crashing on a [`ReferenceError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError), but the crash is preferable because ultimately it is better to have a tightly disciplined codebase in which that condition cannot exist.