### PR TITLE
use generic point data in scatterplots

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -371,7 +371,7 @@ const pointMarks = (s, dimensions) => {
       return classes.join(' ');
     });
 
-    const getPointData = feature(s).isLine() ? (d) => d.values : pointData(values(s));
+    const getPointData = feature(s).isLine() ? (d) => d.values : pointData(s);
 
     const points = marks
       .selectAll('circle')


### PR DESCRIPTION
Switch scatterplots to the generic data function added in pull request #143.