### PR TITLE
high contrast color ordering

### DIFF
--- a/source/color.js
+++ b/source/color.js
@@ -12,9 +12,15 @@ const colors = (count) => {
     if (!count || count === 1) {
         return [defaultColor];
     }
-    const swatch = d3.range(count).map((item, index) => {
-        return `hsl(${(360 / count) * index}, 100%, 50%)`;
+    const hues = d3.range(count).map((item, index) => {
+        const hue = 360 / count * index;
+        return hue;
     });
+    const midpoint = Math.floor(count * 0.5);
+    const a = hues.slice(0, midpoint);
+    const b = hues.slice(midpoint);
+    const ordered = d3.zip(a, b).flat();
+    const swatch = ordered.map(hue => `hsl(${hue}, 100%, 50%)`);
 
     return swatch;
 };


### PR DESCRIPTION
Sorts the default categorical colors into a high contrast order. This makes it easier for readers to distinguish between adjacent data segments than ordering by hue in the more familiar "rainbow" style. The tradeoff is that it's much louder visually.

For example, consider the same set of ten colors.

With conventional rainbow-style hue order:

![rainbow-hue-order](https://user-images.githubusercontent.com/3488572/201468108-5d9625b7-ea66-40ce-995d-056b07146e26.png)

With this change for a high-contrast order:

![high-contrast-order](https://user-images.githubusercontent.com/3488572/201468148-75e19628-9342-430f-83cf-36ac00389d07.png)

To override this, you can always add an array of whatever CSS colors you want to `specification.encoding.color.scale.range`, including a rainbow spectrum.

```javascript
specification.encoding.color.scale.range = [
  'red',
  'orange',
  'yellow',
  'green',
  'blue',
  'indigo',
  'violet'
]
```