### PR TITLE
extent descriptions

### DIFF
--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -1,7 +1,67 @@
+import * as d3 from 'd3';
 import { datum } from './helpers.js';
 import { encodingValue } from './encodings.js';
 import { memoize } from './memoize.js';
 import { tooltipContent } from './tooltips.js';
+import { data } from './data.js';
+import { feature } from './feature.js';
+
+const quantitativeChannels = (s) => {
+    const result = Object.entries(s.encoding)
+        .filter(([,definition]) => {
+            return definition.type === 'quantitative';
+        })
+        .map(([channel]) => channel);
+    return result;
+};
+
+/**
+ * calculate minimum and maximum value for
+ * each quantitative channel
+ * @param {object} s Vega Lite specification
+ * @returns {object} extents
+ */
+const calculateExtents = (s) => {
+    const quantitative = quantitativeChannels(s);
+
+    let result = {};
+
+    let values;
+    let value;
+    if (feature(s).isCircular()) {
+        values = data(s);
+        value = (d) => d.value;
+    } else if (feature(s).isLine()) {
+        values = data(s).map((series) => series.values).flat();
+        value = (d) => d.value;
+    } else if (feature(s).isBar()) {
+        values = data(s).flat();
+        value = (d) => d[1] - d[0];
+    } else {
+        values = data(s);
+        value = (d) => d;
+    }
+
+    quantitative.forEach((channel) => {
+        result[channel] = new Map();
+        const [min, max] = d3.extent(values, value);
+        result[channel].set(min, {type: 'minimum' });
+        result[channel].set(max, { type: 'maximum' });
+    });
+
+    return result;
+};
+
+const extentDescription = (s) => {
+    const disabled = s.usermeta?.description?.extent === false;
+    if (disabled) {
+        return () => '';
+    }
+    const extents = calculateExtents(s);
+    return () => {
+        return '';
+    };
+};
 
 /**
  * compute the text string to describe a mark
@@ -15,7 +75,7 @@ const _markDescription = (s) => {
         } else if (s.encoding.description) {
             return encodingValue(s, 'description')(datum(s, d));
         } else {
-            return tooltipContent(s)(d);
+            return `${tooltipContent(s)(d)}${extentDescription(s)(d)}`;
         }
     };
 };

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -88,19 +88,31 @@ const extentDescription = (s) => {
 /**
  * compute the text string to describe a mark
  * @param {object} s Vega Lite specification
- * @returns {function} mark description computation function
+ * @returns {function} description computation function
  */
-const _markDescription = (s) => {
+const _description = (s) => {
     return (d) => {
-        if (s.mark.aria === false) {
-            return;
-        } else if (s.encoding.description) {
+        if (s.encoding.description) {
             return encodingValue(s, 'description')(datum(s, d));
         } else {
             return `${tooltipContent(s)(d)}${extentDescription(s)(d)}`;
         }
     };
 };
-const markDescription = memoize(_markDescription);
+const description = memoize(_description);
+
+/**
+ * render a description into the DOM
+ * @param {object} s Vega Lite specification
+ * @returns {function(object)} mark description renderer
+ */
+const markDescription = (s) => {
+    return (d) => {
+        if (s.mark.tooltip === false || s.mark.aria === false) {
+            return;
+        }
+        return description(s)(d);
+    };
+};
 
 export { markDescription }

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -27,21 +27,26 @@ const calculateExtents = (s) => {
     const quantitative = quantitativeChannels(s);
     let result = {};
 
-    quantitative.forEach((channel) => {
+    let values;
+    let value;
+    if (feature(s).isCircular()) {
+        values = data(s);
+        value = (d) => d.value;
+    } else if (feature(s).isLine()) {
+        values = data(s).map((series) => series.values).flat();
+        value = (d) => d.value;
+    } else if (feature(s).isBar()) {
+        values = data(s).flat();
+        value = (d) => d[1] - d[0];
+    } else {
+        values = data(s);
+    }
 
-        let values;
-        let value;
-        if (feature(s).isCircular()) {
-            values = data(s);
-            value = (d) => d.value;
-        } else if (feature(s).isLine()) {
-            values = data(s).map((series) => series.values).flat();
-            value = (d) => d.value;
-        } else if (feature(s).isBar()) {
-            values = data(s).flat();
-            value = (d) => d[1] - d[0];
-        } else {
-            values = data(s);
+    quantitative.forEach((channel) => {
+        // if the value function can't be determined before
+        // this point, there may be multiple quantitative
+        // encodings
+        if (!value) {
             value = (d) => encodingValue(s, channel)(d);
         }
 

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -1,0 +1,24 @@
+import { datum } from './helpers.js';
+import { encodingValue } from './encodings.js';
+import { memoize } from './memoize.js';
+import { tooltipContent } from './tooltips.js';
+
+/**
+ * compute the text string to describe a mark
+ * @param {object} s Vega Lite specification
+ * @returns {function} mark description computation function
+ */
+const _markDescription = (s) => {
+    return (d) => {
+        if (s.mark.aria === false) {
+            return;
+        } else if (s.encoding.description) {
+            return encodingValue(s, 'description')(datum(s, d));
+        } else {
+            return tooltipContent(s)(d);
+        }
+    };
+};
+const markDescription = memoize(_markDescription);
+
+export { markDescription }

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -71,7 +71,7 @@ const empty = () => ''
  * @param {object} s Vega Lite specification
  * @returns {function(object)} extent description
  */
-const extentDescription = (s) => {
+const _extentDescription = (s) => {
     const disabled = s.usermeta?.description?.extent === false;
     if (disabled || s.layer) {
         return empty;
@@ -91,6 +91,7 @@ const extentDescription = (s) => {
         }
     };
 };
+const extentDescription = memoize(_extentDescription);
 
 /**
  * compute the text string to describe a mark

--- a/source/marks.js
+++ b/source/marks.js
@@ -10,13 +10,14 @@ import {
   encodingValue,
 } from './encodings.js';
 import { data, pointData } from './data.js';
+import { markDescription } from './descriptions.js';
 import { datum, isDiscrete, key, missingSeries, values } from './helpers.js';
 import { feature } from './feature.js';
 import { memoize } from './memoize.js';
 import { parseScales } from './scales.js';
 import { parseTime, timePeriod } from './time.js';
 import { sortMarkData } from './sort.js';
-import { tooltipContent, tooltips } from './tooltips.js';
+import { tooltips } from './tooltips.js';
 
 /**
  * aggregate and sort mark data
@@ -52,24 +53,6 @@ const category = {
 };
 
 const stroke = 3;
-
-/**
- * compute the text string to describe a mark
- * @param {object} s Vega Lite specification
- * @returns {function} mark description computation function
- */
-const _markDescription = (s) => {
-  return (d) => {
-    if (s.mark.aria === false) {
-      return;
-    } else if (s.encoding.description) {
-      return encodingValue(s, 'description')(datum(s, d));
-    } else {
-      return tooltipContent(s)(d);
-    }
-  };
-};
-const markDescription = memoize(_markDescription);
 
 /**
  * bar chart bar width

--- a/source/marks.js
+++ b/source/marks.js
@@ -385,6 +385,8 @@ const pointMarks = (s, dimensions) => {
     if (!feature(s).isLine()) {
       points.style('stroke', encoders.color);
 
+      points.attr('aria-label', (d) => markDescription(s)(d));
+
       if (s.mark?.filled) {
         points.style('fill', encoders.color);
       } else {

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -235,4 +235,4 @@ const tooltipContent = (s) => {
   };
 };
 
-export { tooltips, tooltipEvent, tooltipContent, tooltipContentData };
+export { tooltips, tooltipEvent, tooltipContent, getTooltipField };

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -196,7 +196,7 @@ const tooltipContentAll = memoize(_tooltipContentAll);
  */
 const tooltipContentData = (s) => {
   return (d) => {
-    if (!Object.keys(d).length || !s.mark.tooltip) {
+    if (!Object.keys(d).length) {
       return;
     }
 

--- a/tests/integration/aria-test.js
+++ b/tests/integration/aria-test.js
@@ -5,7 +5,7 @@ const { module, test } = qunit;
 
 module('integration > aria', function () {
 
-  test('aria-label matches tooltip by default', (assert) => {
+  test('aria-label includes tooltip by default', (assert) => {
     const spec = specificationFixture('circular');
 
     spec.usermeta = { tooltipHandler: false };
@@ -15,12 +15,12 @@ module('integration > aria', function () {
     const marks = [...element.querySelectorAll(testSelector('mark'))];
     const labels = marks.map((mark) => mark.getAttribute('aria-label'));
     const titles = marks.map((mark) => mark.querySelector(testSelector('mark-title')));
-    const match = labels.every((label, index) => label === titles[index].textContent);
+    const match = labels.every((label, index) => label.includes(titles[index].textContent));
 
     assert.ok(match);
   });
 
-  test('aria-label matches tooltip when tooltip channel is specified', (assert) => {
+  test('aria-label includes tooltip when tooltip channel is specified', (assert) => {
     const spec = specificationFixture('circular');
 
     spec.usermeta = { tooltipHandler: false };
@@ -33,7 +33,7 @@ module('integration > aria', function () {
     const marks = [...element.querySelectorAll(testSelector('mark'))];
     const labels = marks.map((mark) => mark.getAttribute('aria-label'));
     const titles = marks.map((mark) => mark.querySelector(testSelector('mark-title')).textContent);
-    const match = labels.every((label, index) => label === titles[index]);
+    const match = labels.every((label, index) => label.includes(titles[index]));
 
     assert.ok(match);
   });

--- a/tests/integration/description-test.js
+++ b/tests/integration/description-test.js
@@ -3,7 +3,7 @@ import { specificationFixture, testSelector, render } from '../test-helpers.js';
 
 const { module, test } = qunit;
 
-module('unit > description', () => {
+module('integration > description', () => {
     const charts = ['line', 'temporalBar', 'categoricalBar', 'circular', 'stackedBar'];
     charts.forEach((chart) => {
         test(`detects extent for ${chart} chart`, (assert) => {

--- a/tests/unit/description-test.js
+++ b/tests/unit/description-test.js
@@ -1,0 +1,54 @@
+import qunit from 'qunit';
+import { specificationFixture, testSelector, render } from '../test-helpers.js';
+
+const { module, test } = qunit;
+
+module('unit > description', () => {
+    const charts = ['line', 'temporalBar', 'categoricalBar', 'circular', 'stackedBar'];
+    charts.forEach((chart) => {
+        test(`detects extent for ${chart} chart`, (assert) => {
+            const s = specificationFixture(chart);
+            const element = render(s);
+            const labels = [
+                ...element.querySelectorAll(testSelector('mark')),
+                ...element.querySelectorAll(testSelector('marks-mark-point')),
+            ].map((node) => node.getAttribute('aria-label'));
+            assert.ok(labels.some((item) => item.includes('minimum value')), 'detects minimum value');
+            assert.ok(labels.some((item) => item.includes('maximum value')), 'detects maximum value');
+            assert.ok(labels.some((item) => !item.includes('minimum') && !item.includes('maximum')), 'some marks do not match extent');
+        });
+    });
+    test(`detects single minimum and maximum value`, (assert) => {
+        let s = specificationFixture('circular');
+        s.data.values = [
+            {group: 'a', value: 1},
+            {group: 'b', value: 2},
+            {group: 'c', value: 3},
+            {group: 'd', value: 4},
+            {group: 'e', value: 5},
+        ]
+        const element = render(s);
+        const labels = [
+            ...element.querySelectorAll(testSelector('mark')),
+        ].map((node) => node.getAttribute('aria-label'));
+        assert.equal(labels.filter((item) => item.includes('minimum value')).length, 1, 'detects single minimum value');
+        assert.equal(labels.filter((item) => item.includes('maximum value')).length, 1, 'detects single maximum value');
+    });
+    test(`detects multiple minimum and maximum values`, (assert) => {
+        let s = specificationFixture('circular');
+        s.data.values = [
+            {group: 'a', value: 1},
+            {group: 'b', value: 1},
+            {group: 'c', value: 3},
+            {group: 'd', value: 5},
+            {group: 'e', value: 5},
+        ]
+        const element = render(s);
+        const labels = [
+            ...element.querySelectorAll(testSelector('mark')),
+        ].map((node) => node.getAttribute('aria-label'));
+        assert.equal(labels.filter((item) => item.includes('minimum value')).length, 2, 'detects multiple minimum values');
+        assert.equal(labels.filter((item) => item.includes('maximum value')).length, 2, 'detects multiple maximum values');
+    });
+
+});

--- a/tests/unit/description-test.js
+++ b/tests/unit/description-test.js
@@ -50,5 +50,44 @@ module('unit > description', () => {
         assert.equal(labels.filter((item) => item.includes('minimum value')).length, 2, 'detects multiple minimum values');
         assert.equal(labels.filter((item) => item.includes('maximum value')).length, 2, 'detects multiple maximum values');
     });
+    test(`detects minimum and maximum values in multiple channels`, (assert) => {
+        const s = {
+            title: {
+                text: 'multiple channel extent demos'
+            },
+            mark: {
+                type: 'point'
+            },
+            data: {
+                values: [
+                    {a: 1, b: 1},
+                    {a: 2, b: 1},
+                    {a: 3, b: 3},
+                    {a: 4, b: 5},
+                    {a: 5, b: 5},
+                ]
+            },
+            encoding: {
+                x: {
+                    field: 'a',
+                    type: 'quantitative'
+                },  
+                y: {
+                    field: 'b',
+                    type: 'quantitative'
+                }
+            }
+        };
+
+        const element = render(s);
+
+        const labels = [
+            ...element.querySelectorAll(testSelector('marks-mark-point')),
+        ].map((node) => node.getAttribute('aria-label'));
+        assert.equal(labels.filter((item) => item.includes('minimum value of a')).length, 1, 'detects single minimum value in field a');
+        assert.equal(labels.filter((item) => item.includes('maximum value of a')).length, 1, 'detects single maximum value in field a');
+        assert.equal(labels.filter((item) => item.includes('minimum value of b')).length, 2, 'detects multiple minimum values in field b');
+        assert.equal(labels.filter((item) => item.includes('maximum value of b')).length, 2, 'detects multiple maximum values in field b');
+    });
 
 });


### PR DESCRIPTION
Detects the cases where a mark encodes the highest or lowest value for a given data field and appends annotations to that effect to the text description used in the `aria-label` attributes, and also likewise in the `title` nodes if the [tooltip configuration](https://vega.github.io/vega-lite/docs/tooltip.html) calls for them.

For example, a data point that generates the descriptive text `count: 1; group: a` might now instead generate `count: 1, group: a; minimum value in the count field;` if there aren't any smaller values in the chart.

This can work with multiple quantitative encodings simultaneously, as with the axes on a [scatterplot](https://vega.github.io/vega-lite/examples/point_2d.html). When multiple data points share the same value and that value is also the minimum or maximum, the extra text is added to all of them. The same data point can simultaneously be labeled as a minimum on one axis and the maximum on another. Non-quantitative encodings are not changed.

The Vega Lite specification says the `aria-label` should list the encodings like the default tooltips:

> By default, Vega-Lite generates a description based on the encoding similar to [default tooltips](https://vega.github.io/vega-lite/docs/tooltip.html#encoding).

This could arguably be considered a break with the specification, or a partial break, or an [extension](https://github.com/vijithassar/bisonica/pull/64). On the other hand, the documentation does say _similar_ and not _identical_, so maybe this is within bounds. Either way, you can disable this behavior by setting `specification.usermeta.description.extent = false`.

It might also be nice to make this more customizable in the future, such as by allowing customizations of the language. In the meantime you can always attach completely custom text using the [description channel](https://vega.github.io/vega-lite/docs/encoding.html#description).