### PR TITLE
return empty string for extent descriptions

### DIFF
--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -88,6 +88,8 @@ const _extentDescription = (s) => {
         }).filter(Boolean);
         if (endpoints.length) {
             return delimiter + endpoints.join(delimiter);
+        } else {
+            return '';
         }
     };
 };


### PR DESCRIPTION
This is a small follow up to pull request #146 to clean up the descriptions for items that don't match the extent endpoints. Those should return an empty string instead of `undefined`, since the latter would be cast to a string and included in the text.