### PR TITLE
throw error for missing title

### DIFF
--- a/source/init.js
+++ b/source/init.js
@@ -24,7 +24,7 @@ const init = (s, dimensions) => {
     svg.attr('width', dimensions.x);
     svg.attr('role', 'document');
 
-    if (!s.title.text) {
+    if (!s.title?.text) {
       throw new Error('specification title is required');
     }
 


### PR DESCRIPTION
When the title is missing, use optional chaining to get down into the body of the conditional where a helpful descriptive error is thrown instead of crashing with a more cryptic error in the conditional test itself.