### PR TITLE
use layer feature test

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -284,7 +284,7 @@ const y = (s, dimensions) => {
  */
 const axes = (_s, dimensions) => {
   const test = (s) => {
-    if (!_s.layer) {
+    if (feature(_s).hasLayers()) {
       return s;
     } else {
       return s.encoding?.x?.type && s.encoding?.y?.type;

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -74,7 +74,7 @@ const empty = () => ''
  */
 const _extentDescription = (s) => {
     const disabled = extension(s, 'description')?.extent === false;
-    if (disabled || s.layer) {
+    if (disabled || feature(s).hasLayers()) {
         return empty;
     }
     const extents = calculateExtents(s);

--- a/source/legend.js
+++ b/source/legend.js
@@ -45,7 +45,7 @@ const isOverflown = ({ clientWidth, clientHeight, scrollWidth, scrollHeight }) =
  * @returns {function} renderer
  */
 const color = (_s) => {
-  let s = _s.layer ? layerPrimary(_s) : _s;
+  let s = feature(_s).hasLayers() ? layerPrimary(_s) : _s;
 
   const renderer = (selection) => {
     try {


### PR DESCRIPTION
It's generally better to use the helpers in `feature.js` rather than traversing the JSON directly, at least when checking conditionals. There's a `.hasLayers()` method available, but in a few cases the conditional tests were checking `s.layer` anyway. (This principle doesn't apply to the `views.js` module, however, since there you typically want to _work with_ the layers, instead of merely checking for their existence.)