### PR TITLE
add single-line specification fixture

### DIFF
--- a/fixtures/line.js
+++ b/fixtures/line.js
@@ -1,0 +1,128 @@
+const lineChartSpec = {
+    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "title": {
+      "text": "Line Chart Example"
+    },
+    "mark": {
+      "type": "line",
+      "point": true,
+      "tooltip": true
+    },
+    "encoding": {
+      "x": {
+        "field": "label",
+        "type": "temporal",
+        "axis": {
+          "title": "date",
+          "format": "%d"
+        }
+      },
+      "y": {
+        "title": "count",
+        "field": "value",
+        "type": "quantitative"
+      },
+    },
+    "data": {
+      "values": [
+        {
+          "label": "2020-05-20",
+          "value": 8
+        },
+        {
+          "label": "2020-05-21",
+          "value": 4
+        },
+        {
+          "label": "2020-05-23",
+          "value": 2
+        },
+        {
+          "label": "2020-05-24",
+          "value": 8
+        },
+        {
+          "label": "2020-05-25",
+          "value": 4
+        },
+        {
+          "label": "2020-05-26",
+          "value": 2
+        },
+        {
+          "label": "2020-05-28",
+          "value": 5
+        },
+        {
+          "label": "2020-05-29",
+          "value": 3
+        },
+        {
+          "label": "2020-05-31",
+          "value": 9
+        },
+        {
+          "label": "2020-06-02",
+          "value": 1
+        },
+        {
+          "label": "2020-06-03",
+          "value": 7
+        },
+        {
+          "label": "2020-06-04",
+          "value": 7
+        },
+        {
+          "label": "2020-06-05",
+          "value": 14
+        },
+        {
+          "label": "2020-06-06",
+          "value": 5
+        },
+        {
+          "label": "2020-06-07",
+          "value": 4
+        },
+        {
+          "label": "2020-06-08",
+          "value": 7
+        },
+        {
+          "label": "2020-06-09",
+          "value": 7
+        },
+        {
+          "label": "2020-06-10",
+          "value": 1
+        },
+        {
+          "label": "2020-06-11",
+          "value": 3
+        },
+        {
+          "label": "2020-06-12",
+          "value": 1
+        },
+        {
+          "label": "2020-06-13",
+          "value": 17
+        },
+        {
+          "label": "2020-06-14",
+          "value": 26
+        },
+        {
+          "label": "2020-06-15",
+          "value": 19
+        },
+        {
+          "label": "2020-06-16",
+          "value": 3
+        }
+      ]
+    }
+  };
+  
+  export { lineChartSpec };

--- a/fixtures/multiline.js
+++ b/fixtures/multiline.js
@@ -1,4 +1,4 @@
-const lineChartSpec = {
+const multilineChartSpec = {
   $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
   title: { text: 'Line Chart Example' },
   mark: {
@@ -716,4 +716,4 @@ const lineChartSpec = {
   },
 };
 
-export { lineChartSpec };
+export { multilineChartSpec };

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -4,6 +4,7 @@ import { circularChartSpec } from '../fixtures/circular.js';
 import { dotPlotSpec } from '../fixtures/dot-plot.js';
 import { groupedBarChartSpec } from '../fixtures/grouped-bar.js';
 import { lineChartSpec } from '../fixtures/line.js';
+import { multilineChartSpec } from '../fixtures/multiline.js';
 import { rulesSpec } from '../fixtures/rules.js';
 import { scatterPlotSpec } from '../fixtures/scatter-plot.js';
 import { stackedBarChartSpec } from '../fixtures/stacked-bar.js';
@@ -66,6 +67,8 @@ export function specificationFixture(type) {
     spec = circularChartSpec;
   } else if (type === 'line') {
     spec = lineChartSpec;
+  } else if (type === 'multiline') {
+    spec = multilineChartSpec;
   } else if (type === 'categoricalBar') {
     spec = categoricalBarChartSpec;
   } else if (type === 'groupedBar') {

--- a/tests/unit/data-test.js
+++ b/tests/unit/data-test.js
@@ -68,7 +68,7 @@ module('unit > data', () => {
   });
 
   test('compiles line chart data', (assert) => {
-    const spec = specificationFixture('line');
+    const spec = specificationFixture('multiline');
     const dailyTotals = data(spec, encodingField(spec, 'x'));
     const groupNames = dailyTotals.every(
       (item) => typeof item[encodingField(spec, 'color')] === 'string',

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -6,10 +6,10 @@ import { specificationFixture } from '../test-helpers.js';
 
 const { module, test } = qunit;
 
-const lineChartSpec = specificationFixture('line');
+const lineChartSpec = specificationFixture('multiline');
 const categoricalBarChartSpec = specificationFixture('categoricalBar');
 
-const ordinalSpec = specificationFixture('line');
+const ordinalSpec = specificationFixture('multiline');
 ordinalSpec.encoding.color.type = 'ordinal';
 
 module('unit > scales', (hooks) => {


### PR DESCRIPTION
Adds a new single-line specification fixture and moves the existing line chart fixture to `multiline.js`.