### PR TITLE
add top level aria-description with chart type

### DIFF
--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -129,10 +129,12 @@ const markDescription = (s) => {
 /**
  * chart description
  * @param {object} s Vega Lite specification
- * @returns {string} chart type
+ * @returns {string|null} chart type
  */
 const chartDescription = (s) => {
-    if (feature(s).isBar()) {
+    if (feature(s).hasLayers()) {
+        return 'chart';
+    } else if (feature(s).isBar()) {
         return 'bar chart';
     } else if (feature(s).isCircular()) {
         if (s.mark && s.mark.innerRadius) {
@@ -147,6 +149,7 @@ const chartDescription = (s) => {
     } else if (feature(s).hasPoints && !feature(s).isLine() && feature(s).hasEncodingX() && feature(s).hasEncodingY()) {
         return 'scatterplot';
     }
+    return null;
 };
 
 /**

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -158,7 +158,11 @@ const chartName = (s) => {
     if (!s.title.text) {
       throw new Error('specification title is required');
     }
-    return [s.title.text, s.title.subtitle].filter(Boolean).join(' - ');
+    if (s.description) {
+        return s.description;
+    } else {
+        return [s.title.text, s.title.subtitle].filter(Boolean).join(' - ');
+    }
 };
 
 export { markDescription, chartName, chartDescription }

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -126,4 +126,39 @@ const markDescription = (s) => {
     };
 };
 
-export { markDescription }
+/**
+ * chart description
+ * @param {object} s Vega Lite specification
+ * @returns {string} chart type
+ */
+const chartDescription = (s) => {
+    if (feature(s).isBar()) {
+        return 'bar chart';
+    } else if (feature(s).isCircular()) {
+        if (s.mark && s.mark.innerRadius) {
+            return 'donut chart';
+        } else {
+            return 'pie chart';
+        }
+    } else if (feature(s).isLine()) {
+        return 'line chart';
+    } else if (feature(s).isArea()) {
+        return 'area chart';
+    } else if (feature(s).hasPoints && !feature(s).isLine() && feature(s).hasEncodingX() && feature(s).hasEncodingY()) {
+        return 'scatterplot';
+    }
+};
+
+/**
+ * chart name which includes title and subtitle
+ * @param {object} s Vega Lite specification
+ * @returns {string} chart title
+ */
+const chartName = (s) => {
+    if (!s.title.text) {
+      throw new Error('specification title is required');
+    }
+    return [s.title.text, s.title.subtitle].filter(Boolean).join(' - ');
+};
+
+export { markDescription, chartName, chartDescription }

--- a/source/init.js
+++ b/source/init.js
@@ -1,6 +1,7 @@
 import { WRAPPER_CLASS } from './config.js';
 import { feature } from './feature.js';
 import { extension } from './extensions.js';
+import { chartName, chartDescription } from './descriptions.js';
 
 /**
  * prepare the DOM of a specified element for rendering a chart
@@ -28,9 +29,8 @@ const init = (s, dimensions) => {
       throw new Error('specification title is required');
     }
 
-    const label = [s.title.text, s.title.subtitle].filter(Boolean).join(' - ');
-
-    svg.attr('aria-label', label);
+    svg.attr('aria-label', chartName(s));
+    svg.attr('aria-description', chartDescription(s));
 
     if (feature(s).hasAxis()) {
       const axes = wrapper.append('g').classed('axes', true);


### PR DESCRIPTION
Sets a top-level `aria-description` attribute on the chart SVG with the type of chart form, like `"bar chart"` and `"pie chart"` and so on. Charts that use [layers](https://vega.github.io/vega-lite/docs/layer.html) are described more generically as just `"chart"` because it's not always clear what to call them if they compose different mark types.