### PR TITLE
mark description fixes

### DIFF
--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -119,7 +119,7 @@ const description = memoize(_description);
  */
 const markDescription = (s) => {
     return (d) => {
-        if (s.mark.tooltip === false || s.mark.aria === false) {
+        if (s.mark.aria === false) {
             return;
         }
         return description(s)(d);

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -97,12 +97,15 @@ const _extentDescription = (s) => {
 const extentDescription = memoize(_extentDescription);
 
 /**
- * compute the text string to describe a mark
+ * render a description into the DOM
  * @param {object} s Vega Lite specification
- * @returns {function} description computation function
+ * @returns {function(object)} mark description renderer
  */
-const _description = (s) => {
+const _markDescription = (s) => {
     return (d) => {
+        if (s.mark.aria === false) {
+            return;
+        }
         if (s.encoding.description) {
             return encodingValue(s, 'description')(datum(s, d));
         } else {
@@ -110,21 +113,7 @@ const _description = (s) => {
         }
     };
 };
-const description = memoize(_description);
-
-/**
- * render a description into the DOM
- * @param {object} s Vega Lite specification
- * @returns {function(object)} mark description renderer
- */
-const markDescription = (s) => {
-    return (d) => {
-        if (s.mark.aria === false) {
-            return;
-        }
-        return description(s)(d);
-    };
-};
+const markDescription = memoize(_markDescription);
 
 /**
  * chart description

--- a/source/marks.js
+++ b/source/marks.js
@@ -380,9 +380,7 @@ const pointMarks = (s, dimensions) => {
           category.set(this, categoryValue);
         }
       })
-      .attr('aria-label', (d) => {
-        return markDescription(s)(d);
-      })
+      .attr('aria-label', markDescription(s))
       .attr('cx', encoders.x)
       .attr('cy', encoders.y)
       .attr('r', radius)
@@ -392,7 +390,7 @@ const pointMarks = (s, dimensions) => {
     if (!feature(s).isLine()) {
       points.style('stroke', encoders.color);
 
-      points.attr('aria-label', (d) => markDescription(s)(d));
+      points.attr('aria-label', markDescription(s));
 
       if (s.mark?.filled) {
         points.style('fill', encoders.color);
@@ -516,9 +514,7 @@ const circularMarks = (s, dimensions) => {
 
     mark
       .attr('d', arc)
-      .attr('aria-label', (d) => {
-        return markDescription(s)(d);
-      })
+      .attr('aria-label', markDescription(s))
       .style('fill', encoders.color)
       .classed('link', (d) => {
         return encodingValue(s, 'href')(datum(s, d))
@@ -598,9 +594,7 @@ const ruleMarks = (s, dimensions) => {
       .attr('class', 'mark rule')
       .attr('role', 'region')
       .attr('aria-roledescription', 'data point')
-      .attr('aria-label', (d) => {
-        return markDescription(s)(d);
-      })
+      .attr('aria-label', markDescription(s))
       .style('fill', encoders.color);
   };
 

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -230,10 +230,9 @@ const tooltipContentData = (s) => {
  * @param {object} s Vega Lite specification
  * @returns {function} tooltip content renderer
  */
-const tooltipContent = (s) => {
-  return (d) => {
-    return formatTooltipContent(tooltipContentData(s)(d));
-  };
+const _tooltipContent = (s) => {
+  return memoize((d) => formatTooltipContent(tooltipContentData(s)(d)));
 };
+const tooltipContent = memoize(_tooltipContent);
 
 export { tooltips, tooltipEvent, tooltipContent, getTooltipField };

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -99,11 +99,12 @@ const tooltip = (selection, s) => {
  * @returns {function} tooltip rendering function
  */
 const tooltips = (s) => {
+  if (s.usermeta?.tooltipHandler) {
+    return noop;
+  }
   return (selection) => {
     selection.each(function () {
-      if (!s.usermeta?.tooltipHandler) {
-        tooltip(d3.select(this), s);
-      }
+      tooltip(d3.select(this), s);
     });
   };
 };


### PR DESCRIPTION
Various fixes to descriptions as rendered in the `aria-label` attribute of the mark nodes, mostly related to more efficient use of factory scopes. Also corrects a bug whereby the configuration setting for tooltips could erroneously disable `aria-label` descriptions entirely.