### PR TITLE
detached node helper

### DIFF
--- a/source/helpers.js
+++ b/source/helpers.js
@@ -180,6 +180,25 @@ const polarToCartesian = (radius, angle) => {
   return { x: radius * Math.cos(angle), y: radius * Math.sin(angle) };
 };
 
+/**
+ * run a rendering function using a detached node
+ * and then transfer the results to the original
+ * selection
+ *
+ * this will not work properly if the rendering function
+ * depends on accurate DOM measurements or reflow, such as
+ * by using scrollTop or .getBoundingClientRect()
+ *
+ * @returns {function(object)} rendering function which uses detached node
+ */
+const detach = (fn, ...rest) => {
+  return (selection) => {
+    const detached = d3.create(`svg:${selection.node().tagName}`);
+    detached.call(fn, ...rest);
+    selection.append(() => detached.node());
+  };
+};
+
 export {
   abbreviateNumbers,
   mark,
@@ -196,4 +215,5 @@ export {
   isDiscrete,
   overlap,
   polarToCartesian,
+  detach
 };

--- a/source/marks.js
+++ b/source/marks.js
@@ -11,7 +11,7 @@ import {
 } from './encodings.js';
 import { data, pointData } from './data.js';
 import { markDescription } from './descriptions.js';
-import { datum, isDiscrete, key, missingSeries, values } from './helpers.js';
+import { detach, datum, isDiscrete, key, missingSeries, values } from './helpers.js';
 import { feature } from './feature.js';
 import { memoize } from './memoize.js';
 import { parseScales } from './scales.js';
@@ -667,7 +667,7 @@ const textMarks = (s, dimensions) => {
  * @param {object} dimensions chart dimensions
  * @returns {function} mark renderer
  */
-const marks = (s, dimensions) => {
+const _marks = (s, dimensions) => {
   try {
     if (feature(s).isBar()) {
       return barMarks(s, dimensions);
@@ -689,5 +689,6 @@ const marks = (s, dimensions) => {
     throw error;
   }
 };
+const marks = (s, dimensions) => detach(_marks(s, dimensions));
 
 export { marks, radius, barWidth, layoutDirection, markSelector, markInteractionSelector, category };

--- a/tests/unit/helpers-test.js
+++ b/tests/unit/helpers-test.js
@@ -1,3 +1,4 @@
+import * as d3 from 'd3';
 import * as helpers from '../../source/helpers.js';
 import qunit from 'qunit';
 
@@ -23,5 +24,14 @@ module('unit > helpers', () => {
     assert.equal(left.x, radius * -1);
     assert.equal(down.y, radius * -1);
     assert.equal(loop.x, right.x);
+  });
+  test('renders to a detached node', (assert) => {
+    const renderer = (selection) => {
+      selection.append('g').classed('test', true).append('circle').attr('r', 10);
+    };
+    const selection = d3.create('svg');
+    selection.call(helpers.detach(renderer));
+    assert.ok(selection.select('g.test').size(), 1);
+    assert.ok(selection.select('circle').size(), 1);
   });
 });


### PR DESCRIPTION
Adds a helper function for running any rendering function with a detached node in memory before attaching to the live DOM and then wraps all the mark renderers with it. This provides a speed increase of about 5% or 10% in charts with high mark counts. The impact is not as noticeable in smaller and simpler charts, but this is still probably a good idea because it means any wrapped function starts batching DOM updates, which is generally a best practice.

Inside the wrapped function, positioning logic dependent on reflow is no longer available because `.getBoundingClientRect()` and `scrollTop` and so forth no longer work properly – it will silently compute the wrong positions. By extension, this mandates that everything rendered within the data rectangle must now use positioning derived from data values, not text length or font size. If that ends up being overly restrictive, it should be possible detect the exceptions based on the structure of the specification and add some conditionals to the function wrapping `_marks()`.