### PR TITLE
run initialization function with detached node

### DIFF
--- a/source/helpers.js
+++ b/source/helpers.js
@@ -193,7 +193,9 @@ const polarToCartesian = (radius, angle) => {
  */
 const detach = (fn, ...rest) => {
   return (selection) => {
-    const detached = d3.create(`svg:${selection.node().tagName}`);
+    const tag = selection.node().tagName;
+    const namespace = tag === 'g' ? 'svg' : 'html';
+    const detached = d3.create(`${namespace}:${tag}`);
     detached.call(fn, ...rest);
     selection.append(() => detached.node());
   };

--- a/source/init.js
+++ b/source/init.js
@@ -2,6 +2,7 @@ import { WRAPPER_CLASS } from './config.js';
 import { feature } from './feature.js';
 import { extension } from './extensions.js';
 import { chartName, chartDescription } from './descriptions.js';
+import { detach } from './helpers.js';
 
 /**
  * prepare the DOM of a specified element for rendering a chart
@@ -53,7 +54,7 @@ const init = (s, dimensions) => {
     }
   };
 
-  return initializer;
+  return detach(initializer);
 };
 
 export { init };


### PR DESCRIPTION
Running the DOM initialization function using the detached node helper introduced in pull request #163 seems to speed it up by somewhere between 2x and 5x. It's already very fast, but sure, why not?