### PR TITLE
sort timestamps without parsing

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -113,9 +113,7 @@ const sumByCovariates = (s) => {
 const sort = (data) => {
   const keys = stackKeys(data);
   const sortedDate = data.map((item) => {
-    return item.sort((a, b) => {
-      return Number(new Date(a.data.key)) - Number(new Date(b.data.key));
-    });
+    return item.sort((a, b) => d3.descending(a.data.key, b.data.key));
   });
   const sortedSeries = sortedDate.sort((a, b) => {
     return keys.indexOf(a.key) - keys.indexOf(b.key);


### PR DESCRIPTION
Structured [Date Time objects](https://vega.github.io/vega-lite/docs/datetime.html) aside, Vega Lite's [supported timestamp formats](https://vega.github.io/vega-lite/docs/type.html#temporal) are all sortable alphabetically. Strictly speaking it's probably more type safe to cast them, but removing the conversion provides a very small speed increase.