### PR TITLE
clear chart content before rendering

### DIFF
--- a/source/chart.js
+++ b/source/chart.js
@@ -22,6 +22,9 @@ const chart = (s, panelDimensions) => {
   let tooltipHandler;
 
   const renderer = (selection) => {
+
+    selection.html('');
+
     selection.call(init(s, panelDimensions));
 
     initializeInteractions(selection.node(), s);


### PR DESCRIPTION
It's no longer sufficient to clean up old content in `init.js`. As of pull request #166, that function has now been detached from the live DOM, so the cleanup needs to move into the main chart function.