### PR TITLE
horizontal time series bar chart tick alignment

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -171,7 +171,7 @@ const x = (s, dimensions) => {
         .text(title(s, 'x'));
     }
 
-    const shift = feature(s).isBar() && encodingType(s, encodingChannelCovariate(s)) === 'temporal';
+    const shift = feature(s).isBar() && encodingType(s, 'x') === 'temporal';
 
     x.attr('transform', () => {
       const xOffset = shift ? barOffset * 0.5 : 0;


### PR DESCRIPTION
The occasional explicit position shifts necessary for handling time series bar charts were being unnecessarily applied to the wrong channel when the bars were horizontal, resulting in imprecise alignment of the axis ticks against the data content.