### PR TITLE
test href encoding for keyboard links

### DIFF
--- a/source/keyboard.js
+++ b/source/keyboard.js
@@ -267,10 +267,11 @@ const keyboard = (_s) => {
         if (event.key === 'Enter') {
           const node = mark.nodes()[state.index()];
           const d = d3.select(node).datum();
-          const url = getUrl(s, d);
-
-          if (url) {
-            dispatcher.call('link', node, url);
+          if (feature(s).hasLinks()) {
+            const url = getUrl(s, d);
+            if (url) {
+              dispatcher.call('link', node, url);
+            }
           }
         }
       });


### PR DESCRIPTION
Adds a small safety check to the keyboard navigation when trying to open a link with the `Enter` key, so it won't throw an error if there's no `href` channel defined.