### PR TITLE
argument key cleanup

### DIFF
--- a/source/memoize.js
+++ b/source/memoize.js
@@ -18,11 +18,7 @@ const argumentKey = (arg) => {
       return `${type}-${id}`;
     }
   } else {
-    if (type === 'string') {
-      return arg;
-    } else {
-      return `${arg}`;
-    }
+    return `${arg}`;
   }
 };
 

--- a/source/memoize.js
+++ b/source/memoize.js
@@ -7,7 +7,9 @@ const argumentKey = (arg) => {
   const type = typeof arg;
   const primitive = type !== 'object' && type !== 'function';
 
-  if (!primitive) {
+  if (primitive) {
+    return `${arg}`;
+  } else {
     if (references.map.has(arg)) {
       return `${type}-${references.map.get(arg)}`;
     } else {
@@ -17,8 +19,6 @@ const argumentKey = (arg) => {
 
       return `${type}-${id}`;
     }
-  } else {
-    return `${arg}`;
   }
 };
 

--- a/source/memoize.js
+++ b/source/memoize.js
@@ -22,10 +22,8 @@ const argumentKey = (arg) => {
   } else {
     if (type === 'string') {
       return arg;
-    } else if (type === 'undefined' || arg === null) {
-      return `${arg}`;
     } else {
-      return arg.toString();
+      return `${arg}`;
     }
   }
 };

--- a/source/memoize.js
+++ b/source/memoize.js
@@ -7,17 +7,15 @@ const argumentKey = (arg) => {
   const type = typeof arg;
   const primitive = type !== 'object' && type !== 'function';
 
-  let key;
   if (!primitive) {
-    key = type;
     if (references.map.has(arg)) {
-      return `${key}-${references.map.get(arg)}`;
+      return `${type}-${references.map.get(arg)}`;
     } else {
       const id = `${references.count++}`;
 
       references.map.set(arg, id);
 
-      return `${key}-${id}`;
+      return `${type}-${id}`;
     }
   } else {
     if (type === 'string') {

--- a/source/memoize.js
+++ b/source/memoize.js
@@ -10,8 +10,9 @@ const argumentKey = (arg) => {
   if (primitive) {
     return `${arg}`;
   } else {
-    if (references.map.has(arg)) {
-      return `${type}-${references.map.get(arg)}`;
+    const reference = references.map.get(arg)
+    if (reference) {
+      return `${type}-${reference}`;
     } else {
       const id = `${references.count++}`;
 

--- a/source/memoize.js
+++ b/source/memoize.js
@@ -4,25 +4,16 @@ const references = {
 };
 
 const argumentKey = (arg) => {
-  let key;
-
   const type = typeof arg;
-
-  if (type === 'object') {
-    key = 'object';
-  } else if (type === 'string') {
-    key = arg;
-  } else if (type === 'function') {
-    key = 'function';
-  } else if (type === 'undefined' || arg === null) {
-    key = `${arg}`;
-  } else {
-    key = arg.toString();
-  }
-
   const primitive = type !== 'object' && type !== 'function';
 
+  let key;
   if (!primitive) {
+    if (type === 'object') {
+      key = 'object';
+    } else if (type === 'function') {
+      key = 'function';
+    }
     if (references.map.has(arg)) {
       return `${key}-${references.map.get(arg)}`;
     } else {
@@ -33,7 +24,13 @@ const argumentKey = (arg) => {
       return `${key}-${id}`;
     }
   } else {
-    return key;
+    if (type === 'string') {
+      return arg;
+    } else if (type === 'undefined' || arg === null) {
+      return `${arg}`;
+    } else {
+      return arg.toString();
+    }
   }
 };
 

--- a/source/memoize.js
+++ b/source/memoize.js
@@ -9,11 +9,7 @@ const argumentKey = (arg) => {
 
   let key;
   if (!primitive) {
-    if (type === 'object') {
-      key = 'object';
-    } else if (type === 'function') {
-      key = 'function';
-    }
+    key = type;
     if (references.map.has(arg)) {
       return `${key}-${references.map.get(arg)}`;
     } else {


### PR DESCRIPTION
Various changes to make memoization keys cleaner and faster.

Benchmarking the `argumentKey()` function on its own, these changes can be up to about 18% faster, seemingly depending on how temperamental the runtime is feeling at the moment. Benchmarked in context with the rest of the library, it doesn't result in a marked speed increase in rendering time of an entire chart. In practice it does seem to mean the difference between seeing the memoization appear at all as a block in the performance flame graph in the Chrome developer tools console versus it being completely invisible, so that's something?

This change is probably still worth making anyway, for the following reasons:

1) The code is now shorter and clearer, much easier to understand and maintain.

2) Consider how frequently this function is called! It's used once for _every argument_ to a function, _every time_ that function used in the source code. It is not cached. The surface area of affected calling functions is huge, so even small improvements are worthwhile.