### PR TITLE
vertical alignment for text marks

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -651,9 +651,6 @@ const textMarks = (s, dimensions) => {
 		text.attr('text-anchor', s.mark.align || 'middle')
 		text.attr('alignment-baseline', s.mark.baseline || 'baseline')
 
-		const dy = text.node().getBoundingClientRect().height * 0.25
-
-		text.attr('transform', `translate(0,${dy})`)
 		const hasLink = !!(s.encoding && encodingValue(s, 'href'))
 		text.classed('link', hasLink)
 	}

--- a/source/marks.js
+++ b/source/marks.js
@@ -649,7 +649,7 @@ const textMarks = (s, dimensions) => {
 		})
 
 		text.attr('text-anchor', s.mark.align || 'middle')
-		text.attr('alignment-baseline', s.mark.baseline || 'baseline')
+		text.attr('alignment-baseline', s.mark.baseline || 'middle')
 
 		const hasLink = !!(s.encoding && encodingValue(s, 'href'))
 		text.classed('link', hasLink)


### PR DESCRIPTION
Vertically centers text marks using the SVG [`alignment-baseline` attribute](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline) instead of measuring the node. This is both cleaner and faster, and is in fact the _only_ way to get the positioning to work now that marks are [rendered to a detached node](https://github.com/vijithassar/bisonica/pull/163/).

Use the platform!