### PR TITLE
mark href property

### DIFF
--- a/source/feature.js
+++ b/source/feature.js
@@ -36,7 +36,7 @@ const _feature = (s) => {
 		isText: (s) => mark(s) === 'text',
 		isAggregate: (s) => ['x', 'y'].some((channel) => s.encoding?.[channel]?.aggregate),
 		hasColor: (s) => s.encoding?.color,
-		hasLinks: (s) => s.encoding?.href,
+		hasLinks: (s) => s.encoding?.href || s.mark?.href,
 		hasData: (s) => s.data?.values.length,
 		hasLegend: (s) => s.encoding?.color?.legend !== null,
 		hasLegendTitle: (s) => isPresent(s.encoding?.color?.legend?.title),

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -82,6 +82,9 @@ const missingSeries = () => '_'
  * @returns {string} url
  */
 const getUrl = (s, d) => {
+	if (s.mark.href) {
+		return s.mark.href
+	}
 	if (s.encoding.href.value) {
 		return s.encoding.href.value
 	}


### PR DESCRIPTION
Adds support for [`mark.href`](https://vega.github.io/vega-lite/docs/mark.html#hyperlink), which allows a clickable link to be specified universally and statically as a property on the mark object instead of dynamically through the `href` [encoding](https://vega.github.io/vega-lite/docs/encoding.html#href).