### PR TITLE
lint fixes for specification fixtures

### DIFF
--- a/fixtures/categorical-bar.js
+++ b/fixtures/categorical-bar.js
@@ -1,21 +1,21 @@
 const categoricalBarChartSpec = {
-  $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
-  title: { text: 'Categorical Bar Chart' },
-  data: {
-    values: [
-      { animal: 'rabbit', value: 31 },
-      { animal: 'cow', value: 25 },
-      { animal: 'snake', value: 25 },
-      { animal: 'elephant', value: 25 },
-      { animal: 'mouse', value: 24 },
-    ],
-  },
-  mark: { type: 'bar', tooltip: true },
-  encoding: {
-    x: { field: 'animal', type: 'nominal' },
-    y: { title: 'count', field: 'value', type: 'quantitative' },
-    color: { field: null, type: 'nominal' },
-  },
-};
+	$schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+	title: { text: 'Categorical Bar Chart' },
+	data: {
+		values: [
+			{ animal: 'rabbit', value: 31 },
+			{ animal: 'cow', value: 25 },
+			{ animal: 'snake', value: 25 },
+			{ animal: 'elephant', value: 25 },
+			{ animal: 'mouse', value: 24 }
+		]
+	},
+	mark: { type: 'bar', tooltip: true },
+	encoding: {
+		x: { field: 'animal', type: 'nominal' },
+		y: { title: 'count', field: 'value', type: 'quantitative' },
+		color: { field: null, type: 'nominal' }
+	}
+}
 
-export { categoricalBarChartSpec };
+export { categoricalBarChartSpec }

--- a/fixtures/circular.js
+++ b/fixtures/circular.js
@@ -1,54 +1,54 @@
 const circularChartSpec = {
-  $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
-  title: {
-    text: 'circular chart example',
-  },
-  description: 'A simple circular pie chart.',
-  mark: { type: 'arc', tooltip: true },
-  encoding: {
-    theta: { field: 'value', type: 'quantitative' },
-    color: {
-      field: 'group',
-      type: 'nominal',
-    },
-  },
-  view: { stroke: null },
-  data: {
-    values: [
-      {
-        group: 'A',
-        value: 8,
-      },
-      {
-        group: 'B',
-        value: 4,
-      },
-      {
-        group: 'C',
-        value: 2,
-      },
-      {
-        group: 'D',
-        value: 2,
-      },
-      {
-        group: 'E',
-        value: 1,
-      },
-      {
-        group: 'F',
-        value: 4,
-      },
-      {
-        group: 'G',
-        value: 14,
-      },
-      {
-        group: 'H',
-        value: 2,
-      },
-    ],
-  },
-};
+	$schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+	title: {
+		text: 'circular chart example'
+	},
+	description: 'A simple circular pie chart.',
+	mark: { type: 'arc', tooltip: true },
+	encoding: {
+		theta: { field: 'value', type: 'quantitative' },
+		color: {
+			field: 'group',
+			type: 'nominal'
+		}
+	},
+	view: { stroke: null },
+	data: {
+		values: [
+			{
+				group: 'A',
+				value: 8
+			},
+			{
+				group: 'B',
+				value: 4
+			},
+			{
+				group: 'C',
+				value: 2
+			},
+			{
+				group: 'D',
+				value: 2
+			},
+			{
+				group: 'E',
+				value: 1
+			},
+			{
+				group: 'F',
+				value: 4
+			},
+			{
+				group: 'G',
+				value: 14
+			},
+			{
+				group: 'H',
+				value: 2
+			}
+		]
+	}
+}
 
-export { circularChartSpec };
+export { circularChartSpec }

--- a/fixtures/dot-plot.js
+++ b/fixtures/dot-plot.js
@@ -1,25 +1,25 @@
 const dotPlotSpec = {
-  $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
-  title: {
-    text: 'dot plot example',
-  },
-  data: {
-    values: [
-      { label: 'a', value: 21 },
-      { label: 'b', value: 13 },
-      { label: 'c', value: 8 },
-      { label: 'd', value: 5 },
-      { label: 'e', value: 3 },
-      { label: 'f', value: 2 },
-      { label: 'g', value: 1 },
-      { label: 'h', value: 1 },
-    ],
-  },
-  encoding: {
-    y: { field: 'label', type: 'nominal', title: null },
-    x: { field: 'value', type: 'quantitative', title: null },
-  },
-  mark: { type: 'point', tooltip: true, filled: true },
-};
+	$schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+	title: {
+		text: 'dot plot example'
+	},
+	data: {
+		values: [
+			{ label: 'a', value: 21 },
+			{ label: 'b', value: 13 },
+			{ label: 'c', value: 8 },
+			{ label: 'd', value: 5 },
+			{ label: 'e', value: 3 },
+			{ label: 'f', value: 2 },
+			{ label: 'g', value: 1 },
+			{ label: 'h', value: 1 }
+		]
+	},
+	encoding: {
+		y: { field: 'label', type: 'nominal', title: null },
+		x: { field: 'value', type: 'quantitative', title: null }
+	},
+	mark: { type: 'point', tooltip: true, filled: true }
+}
 
-export { dotPlotSpec };
+export { dotPlotSpec }

--- a/fixtures/grouped-bar.js
+++ b/fixtures/grouped-bar.js
@@ -1,105 +1,105 @@
 const groupedBarChartSpec = {
-  $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
-  title: {
-    text: 'Grouped Bar Chart',
-  },
-  mark: 'bar',
-  encoding: {
-    column: {
-      field: 'label',
-      type: 'temporal',
-      title: '',
-      timeUnit: 'utcday',
-    },
-    y: {
-      field: 'value',
-      type: 'quantitative',
-      axis: { title: 'value', grid: false },
-    },
-    x: {
-      field: 'group',
-      type: 'nominal',
-      axis: { title: '' },
-    },
-    color: {
-      field: 'group',
-      type: 'nominal',
-    },
-  },
-  data: {
-    values: [
-      {
-        label: '2020-05-20',
-        group: 'a',
-        value: 8,
-      },
-      {
-        label: '2020-05-20',
-        group: 'b',
-        value: 4,
-      },
-      {
-        label: '2020-05-21',
-        group: 'a',
-        value: 4,
-      },
-      {
-        label: '2020-05-21',
-        group: 'b',
-        value: 34,
-      },
-      {
-        label: '2020-05-22',
-        group: 'a',
-        value: 6,
-      },
-      {
-        label: '2020-05-22',
-        group: 'b',
-        value: 6,
-      },
-      {
-        label: '2020-05-23',
-        group: 'a',
-        value: 22,
-      },
-      {
-        label: '2020-05-23',
-        group: 'b',
-        value: 46,
-      },
-      {
-        label: '2020-05-24',
-        group: 'a',
-        value: 13,
-      },
-      {
-        label: '2020-05-24',
-        group: 'b',
-        value: 14,
-      },
-      {
-        label: '2020-05-25',
-        group: 'a',
-        value: 13,
-      },
-      {
-        label: '2020-05-25',
-        group: 'b',
-        value: 14,
-      },
-      {
-        label: '2020-05-26',
-        group: 'a',
-        value: 18,
-      },
-      {
-        label: '2020-05-26',
-        group: 'b',
-        value: 21,
-      },
-    ],
-  },
-};
+	$schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+	title: {
+		text: 'Grouped Bar Chart'
+	},
+	mark: 'bar',
+	encoding: {
+		column: {
+			field: 'label',
+			type: 'temporal',
+			title: '',
+			timeUnit: 'utcday'
+		},
+		y: {
+			field: 'value',
+			type: 'quantitative',
+			axis: { title: 'value', grid: false }
+		},
+		x: {
+			field: 'group',
+			type: 'nominal',
+			axis: { title: '' }
+		},
+		color: {
+			field: 'group',
+			type: 'nominal'
+		}
+	},
+	data: {
+		values: [
+			{
+				label: '2020-05-20',
+				group: 'a',
+				value: 8
+			},
+			{
+				label: '2020-05-20',
+				group: 'b',
+				value: 4
+			},
+			{
+				label: '2020-05-21',
+				group: 'a',
+				value: 4
+			},
+			{
+				label: '2020-05-21',
+				group: 'b',
+				value: 34
+			},
+			{
+				label: '2020-05-22',
+				group: 'a',
+				value: 6
+			},
+			{
+				label: '2020-05-22',
+				group: 'b',
+				value: 6
+			},
+			{
+				label: '2020-05-23',
+				group: 'a',
+				value: 22
+			},
+			{
+				label: '2020-05-23',
+				group: 'b',
+				value: 46
+			},
+			{
+				label: '2020-05-24',
+				group: 'a',
+				value: 13
+			},
+			{
+				label: '2020-05-24',
+				group: 'b',
+				value: 14
+			},
+			{
+				label: '2020-05-25',
+				group: 'a',
+				value: 13
+			},
+			{
+				label: '2020-05-25',
+				group: 'b',
+				value: 14
+			},
+			{
+				label: '2020-05-26',
+				group: 'a',
+				value: 18
+			},
+			{
+				label: '2020-05-26',
+				group: 'b',
+				value: 21
+			}
+		]
+	}
+}
 
-export { groupedBarChartSpec };
+export { groupedBarChartSpec }

--- a/fixtures/line.js
+++ b/fixtures/line.js
@@ -1,128 +1,128 @@
 const lineChartSpec = {
-    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
-    "title": {
-      "text": "Line Chart Example"
-    },
-    "mark": {
-      "type": "line",
-      "point": true,
-      "tooltip": true
-    },
-    "encoding": {
-      "x": {
-        "field": "label",
-        "type": "temporal",
-        "axis": {
-          "title": "date",
-          "format": "%d"
-        }
-      },
-      "y": {
-        "title": "count",
-        "field": "value",
-        "type": "quantitative"
-      },
-    },
-    "data": {
-      "values": [
-        {
-          "label": "2020-05-20",
-          "value": 8
-        },
-        {
-          "label": "2020-05-21",
-          "value": 4
-        },
-        {
-          "label": "2020-05-23",
-          "value": 2
-        },
-        {
-          "label": "2020-05-24",
-          "value": 8
-        },
-        {
-          "label": "2020-05-25",
-          "value": 4
-        },
-        {
-          "label": "2020-05-26",
-          "value": 2
-        },
-        {
-          "label": "2020-05-28",
-          "value": 5
-        },
-        {
-          "label": "2020-05-29",
-          "value": 3
-        },
-        {
-          "label": "2020-05-31",
-          "value": 9
-        },
-        {
-          "label": "2020-06-02",
-          "value": 1
-        },
-        {
-          "label": "2020-06-03",
-          "value": 7
-        },
-        {
-          "label": "2020-06-04",
-          "value": 7
-        },
-        {
-          "label": "2020-06-05",
-          "value": 14
-        },
-        {
-          "label": "2020-06-06",
-          "value": 5
-        },
-        {
-          "label": "2020-06-07",
-          "value": 4
-        },
-        {
-          "label": "2020-06-08",
-          "value": 7
-        },
-        {
-          "label": "2020-06-09",
-          "value": 7
-        },
-        {
-          "label": "2020-06-10",
-          "value": 1
-        },
-        {
-          "label": "2020-06-11",
-          "value": 3
-        },
-        {
-          "label": "2020-06-12",
-          "value": 1
-        },
-        {
-          "label": "2020-06-13",
-          "value": 17
-        },
-        {
-          "label": "2020-06-14",
-          "value": 26
-        },
-        {
-          "label": "2020-06-15",
-          "value": 19
-        },
-        {
-          "label": "2020-06-16",
-          "value": 3
-        }
-      ]
-    }
-  };
-  
-  export { lineChartSpec };
+	'$schema': 'https://vega.github.io/schema/vega-lite/v4.json',
+	'title': {
+		'text': 'Line Chart Example'
+	},
+	'mark': {
+		'type': 'line',
+		'point': true,
+		'tooltip': true
+	},
+	'encoding': {
+		'x': {
+			'field': 'label',
+			'type': 'temporal',
+			'axis': {
+				'title': 'date',
+				'format': '%d'
+			}
+		},
+		'y': {
+			'title': 'count',
+			'field': 'value',
+			'type': 'quantitative'
+		}
+	},
+	'data': {
+		'values': [
+			{
+				'label': '2020-05-20',
+				'value': 8
+			},
+			{
+				'label': '2020-05-21',
+				'value': 4
+			},
+			{
+				'label': '2020-05-23',
+				'value': 2
+			},
+			{
+				'label': '2020-05-24',
+				'value': 8
+			},
+			{
+				'label': '2020-05-25',
+				'value': 4
+			},
+			{
+				'label': '2020-05-26',
+				'value': 2
+			},
+			{
+				'label': '2020-05-28',
+				'value': 5
+			},
+			{
+				'label': '2020-05-29',
+				'value': 3
+			},
+			{
+				'label': '2020-05-31',
+				'value': 9
+			},
+			{
+				'label': '2020-06-02',
+				'value': 1
+			},
+			{
+				'label': '2020-06-03',
+				'value': 7
+			},
+			{
+				'label': '2020-06-04',
+				'value': 7
+			},
+			{
+				'label': '2020-06-05',
+				'value': 14
+			},
+			{
+				'label': '2020-06-06',
+				'value': 5
+			},
+			{
+				'label': '2020-06-07',
+				'value': 4
+			},
+			{
+				'label': '2020-06-08',
+				'value': 7
+			},
+			{
+				'label': '2020-06-09',
+				'value': 7
+			},
+			{
+				'label': '2020-06-10',
+				'value': 1
+			},
+			{
+				'label': '2020-06-11',
+				'value': 3
+			},
+			{
+				'label': '2020-06-12',
+				'value': 1
+			},
+			{
+				'label': '2020-06-13',
+				'value': 17
+			},
+			{
+				'label': '2020-06-14',
+				'value': 26
+			},
+			{
+				'label': '2020-06-15',
+				'value': 19
+			},
+			{
+				'label': '2020-06-16',
+				'value': 3
+			}
+		]
+	}
+}
+
+export { lineChartSpec }

--- a/fixtures/multiline.js
+++ b/fixtures/multiline.js
@@ -1,719 +1,719 @@
 const multilineChartSpec = {
-  $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
-  title: { text: 'Line Chart Example' },
-  mark: {
-    type: 'line',
-    point: true,
-    tooltip: true,
-  },
-  encoding: {
-    x: {
-      field: 'label',
-      type: 'temporal',
-      axis: {
-        title: 'date',
-        format: '%d',
-      },
-    },
-    y: {
-      title: 'count',
-      field: 'value',
-      type: 'quantitative',
-    },
-    color: {
-      field: 'group',
-      type: 'nominal',
-    },
-  },
-  data: {
-    values: [
-      {
-        label: '2020-05-20',
-        group: 'A',
-        value: 8,
-      },
-      {
-        label: '2020-05-20',
-        group: 'B',
-        value: 4,
-      },
-      {
-        label: '2020-05-20',
-        group: 'I',
-        value: 2,
-      },
-      {
-        label: '2020-05-20',
-        group: 'C',
-        value: 2,
-      },
-      {
-        label: '2020-05-20',
-        group: 'D',
-        value: 2,
-      },
-      {
-        label: '2020-05-20',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-05-21',
-        group: 'A',
-        value: 4,
-      },
-      {
-        label: '2020-05-21',
-        group: 'F',
-        value: 4,
-      },
-      {
-        label: '2020-05-21',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-05-21',
-        group: 'C',
-        value: 2,
-      },
-      {
-        label: '2020-05-21',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-05-21',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-05-22',
-        group: 'B',
-        value: 6,
-      },
-      {
-        label: '2020-05-23',
-        group: 'G',
-        value: 3,
-      },
-      {
-        label: '2020-05-23',
-        group: 'A',
-        value: 2,
-      },
-      {
-        label: '2020-05-23',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-05-23',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-05-23',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-05-23',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-05-24',
-        group: 'A',
-        value: 8,
-      },
-      {
-        label: '2020-05-24',
-        group: 'G',
-        value: 3,
-      },
-      {
-        label: '2020-05-24',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-05-24',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-05-25',
-        group: 'A',
-        value: 4,
-      },
-      {
-        label: '2020-05-25',
-        group: 'J',
-        value: 3,
-      },
-      {
-        label: '2020-05-25',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-05-25',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-05-26',
-        group: 'A',
-        value: 2,
-      },
-      {
-        label: '2020-05-26',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-05-28',
-        group: 'A',
-        value: 5,
-      },
-      {
-        label: '2020-05-28',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-05-28',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-05-28',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-05-28',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-05-28',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-05-29',
-        group: 'A',
-        value: 3,
-      },
-      {
-        label: '2020-05-29',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-05-29',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-05-31',
-        group: 'A',
-        value: 9,
-      },
-      {
-        label: '2020-05-31',
-        group: 'B',
-        value: 2,
-      },
-      {
-        label: '2020-05-31',
-        group: 'I',
-        value: 2,
-      },
-      {
-        label: '2020-05-31',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-05-31',
-        group: 'E',
-        value: 2,
-      },
-      {
-        label: '2020-05-31',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-02',
-        group: 'A',
-        value: 1,
-      },
-      {
-        label: '2020-06-02',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-06-02',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-03',
-        group: 'A',
-        value: 7,
-      },
-      {
-        label: '2020-06-03',
-        group: 'G',
-        value: 5,
-      },
-      {
-        label: '2020-06-03',
-        group: 'D',
-        value: 3,
-      },
-      {
-        label: '2020-06-03',
-        group: 'E',
-        value: 3,
-      },
-      {
-        label: '2020-06-03',
-        group: 'I',
-        value: 3,
-      },
-      {
-        label: '2020-06-03',
-        group: 'F',
-        value: 2,
-      },
-      {
-        label: '2020-06-03',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-04',
-        group: 'A',
-        value: 7,
-      },
-      {
-        label: '2020-06-04',
-        group: 'C',
-        value: 2,
-      },
-      {
-        label: '2020-06-04',
-        group: 'D',
-        value: 2,
-      },
-      {
-        label: '2020-06-04',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-04',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-06-04',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-06-05',
-        group: 'A',
-        value: 14,
-      },
-      {
-        label: '2020-06-05',
-        group: 'G',
-        value: 4,
-      },
-      {
-        label: '2020-06-05',
-        group: 'H',
-        value: 4,
-      },
-      {
-        label: '2020-06-05',
-        group: 'F',
-        value: 3,
-      },
-      {
-        label: '2020-06-05',
-        group: 'B',
-        value: 2,
-      },
-      {
-        label: '2020-06-05',
-        group: 'J',
-        value: 2,
-      },
-      {
-        label: '2020-06-05',
-        group: 'D',
-        value: 1,
-      },
-      {
-        label: '2020-06-05',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-06',
-        group: 'A',
-        value: 5,
-      },
-      {
-        label: '2020-06-06',
-        group: 'D',
-        value: 3,
-      },
-      {
-        label: '2020-06-06',
-        group: 'I',
-        value: 2,
-      },
-      {
-        label: '2020-06-06',
-        group: 'H',
-        value: 2,
-      },
-      {
-        label: '2020-06-06',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-06-06',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-06-06',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-06-07',
-        group: 'A',
-        value: 4,
-      },
-      {
-        label: '2020-06-07',
-        group: 'E',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'A',
-        value: 7,
-      },
-      {
-        label: '2020-06-08',
-        group: 'F',
-        value: 3,
-      },
-      {
-        label: '2020-06-08',
-        group: 'D',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'C',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'E',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-08',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'A',
-        value: 7,
-      },
-      {
-        label: '2020-06-09',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'D',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-10',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-06-10',
-        group: 'A',
-        value: 1,
-      },
-      {
-        label: '2020-06-10',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-06-10',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-11',
-        group: 'A',
-        value: 3,
-      },
-      {
-        label: '2020-06-11',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-06-11',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-11',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'A',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-13',
-        group: 'A',
-        value: 17,
-      },
-      {
-        label: '2020-06-13',
-        group: 'G',
-        value: 3,
-      },
-      {
-        label: '2020-06-13',
-        group: 'D',
-        value: 3,
-      },
-      {
-        label: '2020-06-13',
-        group: 'B',
-        value: 2,
-      },
-      {
-        label: '2020-06-13',
-        group: 'I',
-        value: 2,
-      },
-      {
-        label: '2020-06-13',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-06-13',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-14',
-        group: 'A',
-        value: 26,
-      },
-      {
-        label: '2020-06-14',
-        group: 'B',
-        value: 3,
-      },
-      {
-        label: '2020-06-14',
-        group: 'I',
-        value: 3,
-      },
-      {
-        label: '2020-06-14',
-        group: 'E',
-        value: 2,
-      },
-      {
-        label: '2020-06-14',
-        group: 'H',
-        value: 2,
-      },
-      {
-        label: '2020-06-14',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-06-14',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-14',
-        group: 'D',
-        value: 1,
-      },
-      {
-        label: '2020-06-14',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-06-15',
-        group: 'A',
-        value: 19,
-      },
-      {
-        label: '2020-06-15',
-        group: 'E',
-        value: 5,
-      },
-      {
-        label: '2020-06-15',
-        group: 'H',
-        value: 4,
-      },
-      {
-        label: '2020-06-15',
-        group: 'F',
-        value: 3,
-      },
-      {
-        label: '2020-06-15',
-        group: 'J',
-        value: 2,
-      },
-      {
-        label: '2020-06-15',
-        group: 'B',
-        value: 2,
-      },
-      {
-        label: '2020-06-15',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-06-15',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'A',
-        value: 3,
-      },
-      {
-        label: '2020-06-16',
-        group: 'B',
-        value: 3,
-      },
-      {
-        label: '2020-06-16',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'D',
-        value: 1,
-      },
-    ],
-  },
-};
+	$schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+	title: { text: 'Line Chart Example' },
+	mark: {
+		type: 'line',
+		point: true,
+		tooltip: true
+	},
+	encoding: {
+		x: {
+			field: 'label',
+			type: 'temporal',
+			axis: {
+				title: 'date',
+				format: '%d'
+			}
+		},
+		y: {
+			title: 'count',
+			field: 'value',
+			type: 'quantitative'
+		},
+		color: {
+			field: 'group',
+			type: 'nominal'
+		}
+	},
+	data: {
+		values: [
+			{
+				label: '2020-05-20',
+				group: 'A',
+				value: 8
+			},
+			{
+				label: '2020-05-20',
+				group: 'B',
+				value: 4
+			},
+			{
+				label: '2020-05-20',
+				group: 'I',
+				value: 2
+			},
+			{
+				label: '2020-05-20',
+				group: 'C',
+				value: 2
+			},
+			{
+				label: '2020-05-20',
+				group: 'D',
+				value: 2
+			},
+			{
+				label: '2020-05-20',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-05-21',
+				group: 'A',
+				value: 4
+			},
+			{
+				label: '2020-05-21',
+				group: 'F',
+				value: 4
+			},
+			{
+				label: '2020-05-21',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-05-21',
+				group: 'C',
+				value: 2
+			},
+			{
+				label: '2020-05-21',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-05-21',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-05-22',
+				group: 'B',
+				value: 6
+			},
+			{
+				label: '2020-05-23',
+				group: 'G',
+				value: 3
+			},
+			{
+				label: '2020-05-23',
+				group: 'A',
+				value: 2
+			},
+			{
+				label: '2020-05-23',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-05-23',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-05-23',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-05-23',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-05-24',
+				group: 'A',
+				value: 8
+			},
+			{
+				label: '2020-05-24',
+				group: 'G',
+				value: 3
+			},
+			{
+				label: '2020-05-24',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-05-24',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-05-25',
+				group: 'A',
+				value: 4
+			},
+			{
+				label: '2020-05-25',
+				group: 'J',
+				value: 3
+			},
+			{
+				label: '2020-05-25',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-05-25',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-05-26',
+				group: 'A',
+				value: 2
+			},
+			{
+				label: '2020-05-26',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-05-28',
+				group: 'A',
+				value: 5
+			},
+			{
+				label: '2020-05-28',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-05-28',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-05-28',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-05-28',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-05-28',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-05-29',
+				group: 'A',
+				value: 3
+			},
+			{
+				label: '2020-05-29',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-05-29',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-05-31',
+				group: 'A',
+				value: 9
+			},
+			{
+				label: '2020-05-31',
+				group: 'B',
+				value: 2
+			},
+			{
+				label: '2020-05-31',
+				group: 'I',
+				value: 2
+			},
+			{
+				label: '2020-05-31',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-05-31',
+				group: 'E',
+				value: 2
+			},
+			{
+				label: '2020-05-31',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-02',
+				group: 'A',
+				value: 1
+			},
+			{
+				label: '2020-06-02',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-06-02',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-03',
+				group: 'A',
+				value: 7
+			},
+			{
+				label: '2020-06-03',
+				group: 'G',
+				value: 5
+			},
+			{
+				label: '2020-06-03',
+				group: 'D',
+				value: 3
+			},
+			{
+				label: '2020-06-03',
+				group: 'E',
+				value: 3
+			},
+			{
+				label: '2020-06-03',
+				group: 'I',
+				value: 3
+			},
+			{
+				label: '2020-06-03',
+				group: 'F',
+				value: 2
+			},
+			{
+				label: '2020-06-03',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-04',
+				group: 'A',
+				value: 7
+			},
+			{
+				label: '2020-06-04',
+				group: 'C',
+				value: 2
+			},
+			{
+				label: '2020-06-04',
+				group: 'D',
+				value: 2
+			},
+			{
+				label: '2020-06-04',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-04',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-06-04',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-06-05',
+				group: 'A',
+				value: 14
+			},
+			{
+				label: '2020-06-05',
+				group: 'G',
+				value: 4
+			},
+			{
+				label: '2020-06-05',
+				group: 'H',
+				value: 4
+			},
+			{
+				label: '2020-06-05',
+				group: 'F',
+				value: 3
+			},
+			{
+				label: '2020-06-05',
+				group: 'B',
+				value: 2
+			},
+			{
+				label: '2020-06-05',
+				group: 'J',
+				value: 2
+			},
+			{
+				label: '2020-06-05',
+				group: 'D',
+				value: 1
+			},
+			{
+				label: '2020-06-05',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-06',
+				group: 'A',
+				value: 5
+			},
+			{
+				label: '2020-06-06',
+				group: 'D',
+				value: 3
+			},
+			{
+				label: '2020-06-06',
+				group: 'I',
+				value: 2
+			},
+			{
+				label: '2020-06-06',
+				group: 'H',
+				value: 2
+			},
+			{
+				label: '2020-06-06',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-06-06',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-06-06',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-06-07',
+				group: 'A',
+				value: 4
+			},
+			{
+				label: '2020-06-07',
+				group: 'E',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'A',
+				value: 7
+			},
+			{
+				label: '2020-06-08',
+				group: 'F',
+				value: 3
+			},
+			{
+				label: '2020-06-08',
+				group: 'D',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'C',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'E',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-08',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'A',
+				value: 7
+			},
+			{
+				label: '2020-06-09',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'D',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-10',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-06-10',
+				group: 'A',
+				value: 1
+			},
+			{
+				label: '2020-06-10',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-06-10',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-11',
+				group: 'A',
+				value: 3
+			},
+			{
+				label: '2020-06-11',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-06-11',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-11',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'A',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-13',
+				group: 'A',
+				value: 17
+			},
+			{
+				label: '2020-06-13',
+				group: 'G',
+				value: 3
+			},
+			{
+				label: '2020-06-13',
+				group: 'D',
+				value: 3
+			},
+			{
+				label: '2020-06-13',
+				group: 'B',
+				value: 2
+			},
+			{
+				label: '2020-06-13',
+				group: 'I',
+				value: 2
+			},
+			{
+				label: '2020-06-13',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-06-13',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-14',
+				group: 'A',
+				value: 26
+			},
+			{
+				label: '2020-06-14',
+				group: 'B',
+				value: 3
+			},
+			{
+				label: '2020-06-14',
+				group: 'I',
+				value: 3
+			},
+			{
+				label: '2020-06-14',
+				group: 'E',
+				value: 2
+			},
+			{
+				label: '2020-06-14',
+				group: 'H',
+				value: 2
+			},
+			{
+				label: '2020-06-14',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-06-14',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-14',
+				group: 'D',
+				value: 1
+			},
+			{
+				label: '2020-06-14',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-06-15',
+				group: 'A',
+				value: 19
+			},
+			{
+				label: '2020-06-15',
+				group: 'E',
+				value: 5
+			},
+			{
+				label: '2020-06-15',
+				group: 'H',
+				value: 4
+			},
+			{
+				label: '2020-06-15',
+				group: 'F',
+				value: 3
+			},
+			{
+				label: '2020-06-15',
+				group: 'J',
+				value: 2
+			},
+			{
+				label: '2020-06-15',
+				group: 'B',
+				value: 2
+			},
+			{
+				label: '2020-06-15',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-06-15',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'A',
+				value: 3
+			},
+			{
+				label: '2020-06-16',
+				group: 'B',
+				value: 3
+			},
+			{
+				label: '2020-06-16',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'D',
+				value: 1
+			}
+		]
+	}
+}
 
-export { multilineChartSpec };
+export { multilineChartSpec }

--- a/fixtures/rules.js
+++ b/fixtures/rules.js
@@ -1,21 +1,21 @@
 const rulesSpec = {
-  data: {
-    values: [
-      { group: 'a', value: 2 },
-      { group: 'b', value: 4 },
-      { group: 'c', value: 7 },
-    ],
-  },
-  title: { text: 'Rules' },
-  mark: 'rule',
-  encoding: {
-    y: {
-      field: 'value',
-      type: 'quantitative',
-    },
-    size: { value: 2 },
-    color: { field: 'group', type: 'nominal' },
-  },
-};
+	data: {
+		values: [
+			{ group: 'a', value: 2 },
+			{ group: 'b', value: 4 },
+			{ group: 'c', value: 7 }
+		]
+	},
+	title: { text: 'Rules' },
+	mark: 'rule',
+	encoding: {
+		y: {
+			field: 'value',
+			type: 'quantitative'
+		},
+		size: { value: 2 },
+		color: { field: 'group', type: 'nominal' }
+	}
+}
 
-export { rulesSpec };
+export { rulesSpec }

--- a/fixtures/scatter-plot.js
+++ b/fixtures/scatter-plot.js
@@ -1,47 +1,47 @@
 const scatterPlotSpec = {
-  $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
-  title: {
-    text: 'scatter plot example',
-  },
-  data: {
-    values: [
-      { price: 16, count: 21, section: 'a' },
-      { price: 19, count: 13, section: 'b' },
-      { price: 14, count: 8, section: 'c' },
-      { price: 3, count: 5, section: 'd' },
-      { price: 11, count: 3, section: 'e' },
-      { price: 20, count: 2, section: 'a' },
-      { price: 4, count: 1, section: 'b' },
-      { price: 6, count: 1, section: 'c' },
-      { price: 2, count: 14, section: 'd' },
-      { price: 12, count: 6, section: 'e' },
-      { price: 12, count: 8, section: 'a' },
-      { price: 9, count: 9, section: 'b' },
-      { price: 8, count: 1, section: 'c' },
-      { price: 11, count: 7, section: 'd' },
-      { price: 7, count: 5, section: 'e' },
-      { price: 6, count: 5, section: 'a' },
-      { price: 8, count: 15, section: 'b' },
-      { price: 4, count: 5, section: 'c' },
-      { price: 7, count: 4, section: 'd' },
-      { price: 2, count: 8, section: 'e' },
-      { price: 9, count: 1, section: 'a' },
-      { price: 12, count: 2, section: 'b' },
-      { price: 12, count: 3, section: 'c' },
-      { price: 16, count: 6, section: 'd' },
-      { price: 2, count: 6, section: 'e' },
-      { price: 6, count: 25, section: 'a' },
-      { price: 9, count: 5, section: 'b' },
-      { price: 7, count: 5, section: 'c' },
-      { price: 10, count: 6, section: 'd' },
-      { price: 15, count: 5, section: 'e' },
-    ],
-  },
-  encoding: {
-    y: { field: 'price', type: 'quantitative' },
-    x: { field: 'count', type: 'quantitative' },
-  },
-  mark: { type: 'point', tooltip: true, filled: true },
-};
+	$schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+	title: {
+		text: 'scatter plot example'
+	},
+	data: {
+		values: [
+			{ price: 16, count: 21, section: 'a' },
+			{ price: 19, count: 13, section: 'b' },
+			{ price: 14, count: 8, section: 'c' },
+			{ price: 3, count: 5, section: 'd' },
+			{ price: 11, count: 3, section: 'e' },
+			{ price: 20, count: 2, section: 'a' },
+			{ price: 4, count: 1, section: 'b' },
+			{ price: 6, count: 1, section: 'c' },
+			{ price: 2, count: 14, section: 'd' },
+			{ price: 12, count: 6, section: 'e' },
+			{ price: 12, count: 8, section: 'a' },
+			{ price: 9, count: 9, section: 'b' },
+			{ price: 8, count: 1, section: 'c' },
+			{ price: 11, count: 7, section: 'd' },
+			{ price: 7, count: 5, section: 'e' },
+			{ price: 6, count: 5, section: 'a' },
+			{ price: 8, count: 15, section: 'b' },
+			{ price: 4, count: 5, section: 'c' },
+			{ price: 7, count: 4, section: 'd' },
+			{ price: 2, count: 8, section: 'e' },
+			{ price: 9, count: 1, section: 'a' },
+			{ price: 12, count: 2, section: 'b' },
+			{ price: 12, count: 3, section: 'c' },
+			{ price: 16, count: 6, section: 'd' },
+			{ price: 2, count: 6, section: 'e' },
+			{ price: 6, count: 25, section: 'a' },
+			{ price: 9, count: 5, section: 'b' },
+			{ price: 7, count: 5, section: 'c' },
+			{ price: 10, count: 6, section: 'd' },
+			{ price: 15, count: 5, section: 'e' }
+		]
+	},
+	encoding: {
+		y: { field: 'price', type: 'quantitative' },
+		x: { field: 'count', type: 'quantitative' }
+	},
+	mark: { type: 'point', tooltip: true, filled: true }
+}
 
-export { scatterPlotSpec };
+export { scatterPlotSpec }

--- a/fixtures/single-bar.js
+++ b/fixtures/single-bar.js
@@ -1,24 +1,24 @@
 const singleBarChartSpec = {
-    "title": {
-        "text": "single bar",
-    },
-    "mark": { "type": "bar", "tooltip": true },
-    "data": {
-        "values": [
-            { "group": "a", "label": "x", "value": 100 },
-            { "group": "b", "label": "y", "value": 200 },
-            { "group": "c", "label": "x", "value": 300 },
-            { "group": "d", "label": "w", "value": 400 },
-        ]
-    },
-    "encoding": {
-        "y": {
-            "type": "quantitative",
-            "field": "value",
-            "axis": { "title": null }
-        },
-        "color": { "field": "group", "type": "nominal", "legend": { "title": null } }
-    }
-};
+	'title': {
+		'text': 'single bar'
+	},
+	'mark': { 'type': 'bar', 'tooltip': true },
+	'data': {
+		'values': [
+			{ 'group': 'a', 'label': 'x', 'value': 100 },
+			{ 'group': 'b', 'label': 'y', 'value': 200 },
+			{ 'group': 'c', 'label': 'x', 'value': 300 },
+			{ 'group': 'd', 'label': 'w', 'value': 400 }
+		]
+	},
+	'encoding': {
+		'y': {
+			'type': 'quantitative',
+			'field': 'value',
+			'axis': { 'title': null }
+		},
+		'color': { 'field': 'group', 'type': 'nominal', 'legend': { 'title': null } }
+	}
+}
 
 export { singleBarChartSpec }

--- a/fixtures/stacked-area.js
+++ b/fixtures/stacked-area.js
@@ -1,711 +1,710 @@
 const stackedAreaChartSpec = {
-    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-    "title": {"text": "area chart fixture"},
-    "data": { values: [
-        {
-            label: '2020-05-20',
-            group: 'A',
-            value: 8,
-        },
-        {
-            label: '2020-05-20',
-            group: 'B',
-            value: 4,
-        },
-        {
-            label: '2020-05-20',
-            group: 'I',
-            value: 2,
-        },
-        {
-            label: '2020-05-20',
-            group: 'C',
-            value: 2,
-        },
-        {
-            label: '2020-05-20',
-            group: 'D',
-            value: 2,
-        },
-        {
-            label: '2020-05-20',
-            group: 'E',
-            value: 1,
-        },
-        {
-            label: '2020-05-21',
-            group: 'A',
-            value: 4,
-        },
-        {
-            label: '2020-05-21',
-            group: 'F',
-            value: 4,
-        },
-        {
-            label: '2020-05-21',
-            group: 'G',
-            value: 2,
-        },
-        {
-            label: '2020-05-21',
-            group: 'C',
-            value: 2,
-        },
-        {
-            label: '2020-05-21',
-            group: 'H',
-            value: 1,
-        },
-        {
-            label: '2020-05-21',
-            group: 'E',
-            value: 1,
-        },
-        {
-            label: '2020-05-22',
-            group: 'B',
-            value: 6,
-        },
-        {
-            label: '2020-05-23',
-            group: 'G',
-            value: 3,
-        },
-        {
-            label: '2020-05-23',
-            group: 'A',
-            value: 2,
-        },
-        {
-            label: '2020-05-23',
-            group: 'H',
-            value: 1,
-        },
-        {
-            label: '2020-05-23',
-            group: 'I',
-            value: 1,
-        },
-        {
-            label: '2020-05-23',
-            group: 'E',
-            value: 1,
-        },
-        {
-            label: '2020-05-23',
-            group: 'J',
-            value: 1,
-        },
-        {
-            label: '2020-05-24',
-            group: 'A',
-            value: 8,
-        },
-        {
-            label: '2020-05-24',
-            group: 'G',
-            value: 3,
-        },
-        {
-            label: '2020-05-24',
-            group: 'H',
-            value: 1,
-        },
-        {
-            label: '2020-05-24',
-            group: 'I',
-            value: 1,
-        },
-        {
-            label: '2020-05-25',
-            group: 'A',
-            value: 4,
-        },
-        {
-            label: '2020-05-25',
-            group: 'J',
-            value: 3,
-        },
-        {
-            label: '2020-05-25',
-            group: 'B',
-            value: 1,
-        },
-        {
-            label: '2020-05-25',
-            group: 'G',
-            value: 1,
-        },
-        {
-            label: '2020-05-26',
-            group: 'A',
-            value: 2,
-        },
-        {
-            label: '2020-05-26',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-05-28',
-            group: 'A',
-            value: 5,
-        },
-        {
-            label: '2020-05-28',
-            group: 'G',
-            value: 2,
-        },
-        {
-            label: '2020-05-28',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-05-28',
-            group: 'E',
-            value: 1,
-        },
-        {
-            label: '2020-05-28',
-            group: 'H',
-            value: 1,
-        },
-        {
-            label: '2020-05-28',
-            group: 'F',
-            value: 1,
-        },
-        {
-            label: '2020-05-29',
-            group: 'A',
-            value: 3,
-        },
-        {
-            label: '2020-05-29',
-            group: 'B',
-            value: 1,
-        },
-        {
-            label: '2020-05-29',
-            group: 'F',
-            value: 1,
-        },
-        {
-            label: '2020-05-31',
-            group: 'A',
-            value: 9,
-        },
-        {
-            label: '2020-05-31',
-            group: 'B',
-            value: 2,
-        },
-        {
-            label: '2020-05-31',
-            group: 'I',
-            value: 2,
-        },
-        {
-            label: '2020-05-31',
-            group: 'G',
-            value: 2,
-        },
-        {
-            label: '2020-05-31',
-            group: 'E',
-            value: 2,
-        },
-        {
-            label: '2020-05-31',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-06-02',
-            group: 'A',
-            value: 1,
-        },
-        {
-            label: '2020-06-02',
-            group: 'F',
-            value: 1,
-        },
-        {
-            label: '2020-06-02',
-            group: 'G',
-            value: 1,
-        },
-        {
-            label: '2020-06-03',
-            group: 'A',
-            value: 7,
-        },
-        {
-            label: '2020-06-03',
-            group: 'G',
-            value: 5,
-        },
-        {
-            label: '2020-06-03',
-            group: 'D',
-            value: 3,
-        },
-        {
-            label: '2020-06-03',
-            group: 'E',
-            value: 3,
-        },
-        {
-            label: '2020-06-03',
-            group: 'I',
-            value: 3,
-        },
-        {
-            label: '2020-06-03',
-            group: 'F',
-            value: 2,
-        },
-        {
-            label: '2020-06-03',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-06-04',
-            group: 'A',
-            value: 7,
-        },
-        {
-            label: '2020-06-04',
-            group: 'C',
-            value: 2,
-        },
-        {
-            label: '2020-06-04',
-            group: 'D',
-            value: 2,
-        },
-        {
-            label: '2020-06-04',
-            group: 'H',
-            value: 1,
-        },
-        {
-            label: '2020-06-04',
-            group: 'E',
-            value: 1,
-        },
-        {
-            label: '2020-06-04',
-            group: 'J',
-            value: 1,
-        },
-        {
-            label: '2020-06-05',
-            group: 'A',
-            value: 14,
-        },
-        {
-            label: '2020-06-05',
-            group: 'G',
-            value: 4,
-        },
-        {
-            label: '2020-06-05',
-            group: 'H',
-            value: 4,
-        },
-        {
-            label: '2020-06-05',
-            group: 'F',
-            value: 3,
-        },
-        {
-            label: '2020-06-05',
-            group: 'B',
-            value: 2,
-        },
-        {
-            label: '2020-06-05',
-            group: 'J',
-            value: 2,
-        },
-        {
-            label: '2020-06-05',
-            group: 'D',
-            value: 1,
-        },
-        {
-            label: '2020-06-05',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-06-06',
-            group: 'A',
-            value: 5,
-        },
-        {
-            label: '2020-06-06',
-            group: 'D',
-            value: 3,
-        },
-        {
-            label: '2020-06-06',
-            group: 'I',
-            value: 2,
-        },
-        {
-            label: '2020-06-06',
-            group: 'H',
-            value: 2,
-        },
-        {
-            label: '2020-06-06',
-            group: 'G',
-            value: 2,
-        },
-        {
-            label: '2020-06-06',
-            group: 'F',
-            value: 1,
-        },
-        {
-            label: '2020-06-06',
-            group: 'J',
-            value: 1,
-        },
-        {
-            label: '2020-06-07',
-            group: 'A',
-            value: 4,
-        },
-        {
-            label: '2020-06-07',
-            group: 'E',
-            value: 2,
-        },
-        {
-            label: '2020-06-08',
-            group: 'A',
-            value: 7,
-        },
-        {
-            label: '2020-06-08',
-            group: 'F',
-            value: 3,
-        },
-        {
-            label: '2020-06-08',
-            group: 'D',
-            value: 2,
-        },
-        {
-            label: '2020-06-08',
-            group: 'G',
-            value: 2,
-        },
-        {
-            label: '2020-06-08',
-            group: 'C',
-            value: 2,
-        },
-        {
-            label: '2020-06-08',
-            group: 'E',
-            value: 2,
-        },
-        {
-            label: '2020-06-08',
-            group: 'H',
-            value: 1,
-        },
-        {
-            label: '2020-06-08',
-            group: 'I',
-            value: 1,
-        },
-        {
-            label: '2020-06-09',
-            group: 'A',
-            value: 7,
-        },
-        {
-            label: '2020-06-09',
-            group: 'I',
-            value: 1,
-        },
-        {
-            label: '2020-06-09',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-06-09',
-            group: 'F',
-            value: 1,
-        },
-        {
-            label: '2020-06-09',
-            group: 'D',
-            value: 1,
-        },
-        {
-            label: '2020-06-09',
-            group: 'B',
-            value: 1,
-        },
-        {
-            label: '2020-06-09',
-            group: 'J',
-            value: 1,
-        },
-        {
-            label: '2020-06-09',
-            group: 'G',
-            value: 1,
-        },
-        {
-            label: '2020-06-10',
-            group: 'G',
-            value: 2,
-        },
-        {
-            label: '2020-06-10',
-            group: 'A',
-            value: 1,
-        },
-        {
-            label: '2020-06-10',
-            group: 'I',
-            value: 1,
-        },
-        {
-            label: '2020-06-10',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-06-11',
-            group: 'A',
-            value: 3,
-        },
-        {
-            label: '2020-06-11',
-            group: 'B',
-            value: 1,
-        },
-        {
-            label: '2020-06-11',
-            group: 'G',
-            value: 1,
-        },
-        {
-            label: '2020-06-11',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-06-12',
-            group: 'A',
-            value: 1,
-        },
-        {
-            label: '2020-06-12',
-            group: 'B',
-            value: 1,
-        },
-        {
-            label: '2020-06-12',
-            group: 'G',
-            value: 1,
-        },
-        {
-            label: '2020-06-12',
-            group: 'H',
-            value: 1,
-        },
-        {
-            label: '2020-06-12',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-06-13',
-            group: 'A',
-            value: 17,
-        },
-        {
-            label: '2020-06-13',
-            group: 'G',
-            value: 3,
-        },
-        {
-            label: '2020-06-13',
-            group: 'D',
-            value: 3,
-        },
-        {
-            label: '2020-06-13',
-            group: 'B',
-            value: 2,
-        },
-        {
-            label: '2020-06-13',
-            group: 'I',
-            value: 2,
-        },
-        {
-            label: '2020-06-13',
-            group: 'E',
-            value: 1,
-        },
-        {
-            label: '2020-06-13',
-            group: 'H',
-            value: 1,
-        },
-        {
-            label: '2020-06-14',
-            group: 'A',
-            value: 26,
-        },
-        {
-            label: '2020-06-14',
-            group: 'B',
-            value: 3,
-        },
-        {
-            label: '2020-06-14',
-            group: 'I',
-            value: 3,
-        },
-        {
-            label: '2020-06-14',
-            group: 'E',
-            value: 2,
-        },
-        {
-            label: '2020-06-14',
-            group: 'H',
-            value: 2,
-        },
-        {
-            label: '2020-06-14',
-            group: 'F',
-            value: 1,
-        },
-        {
-            label: '2020-06-14',
-            group: 'G',
-            value: 1,
-        },
-        {
-            label: '2020-06-14',
-            group: 'D',
-            value: 1,
-        },
-        {
-            label: '2020-06-14',
-            group: 'J',
-            value: 1,
-        },
-        {
-            label: '2020-06-15',
-            group: 'A',
-            value: 19,
-        },
-        {
-            label: '2020-06-15',
-            group: 'E',
-            value: 5,
-        },
-        {
-            label: '2020-06-15',
-            group: 'H',
-            value: 4,
-        },
-        {
-            label: '2020-06-15',
-            group: 'F',
-            value: 3,
-        },
-        {
-            label: '2020-06-15',
-            group: 'J',
-            value: 2,
-        },
-        {
-            label: '2020-06-15',
-            group: 'B',
-            value: 2,
-        },
-        {
-            label: '2020-06-15',
-            group: 'G',
-            value: 2,
-        },
-        {
-            label: '2020-06-15',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-06-16',
-            group: 'A',
-            value: 3,
-        },
-        {
-            label: '2020-06-16',
-            group: 'B',
-            value: 3,
-        },
-        {
-            label: '2020-06-16',
-            group: 'I',
-            value: 1,
-        },
-        {
-            label: '2020-06-16',
-            group: 'C',
-            value: 1,
-        },
-        {
-            label: '2020-06-16',
-            group: 'E',
-            value: 1,
-        },
-        {
-            label: '2020-06-16',
-            group: 'H',
-            value: 1,
-        },
-        {
-            label: '2020-06-16',
-            group: 'D',
-            value: 1,
-        },
-    ]},
-    "mark": "area",
-    "encoding": {
-        "x": {
-            "timeUnit": "utcday",
-            "field": "label",
-            "axis": { "format": "%m-%d" },
-            "type": "temporal",
-        },
-        "y": {
-            "field": "value",
-            "type": "quantitative",
-        },
-        "color": {
-            "field": "group",
-            "type": "nominal",
-        },
-    }
+	'$schema': 'https://vega.github.io/schema/vega-lite/v5.json',
+	'title': { 'text': 'area chart fixture' },
+	'data': { values: [
+		{
+			label: '2020-05-20',
+			group: 'A',
+			value: 8
+		},
+		{
+			label: '2020-05-20',
+			group: 'B',
+			value: 4
+		},
+		{
+			label: '2020-05-20',
+			group: 'I',
+			value: 2
+		},
+		{
+			label: '2020-05-20',
+			group: 'C',
+			value: 2
+		},
+		{
+			label: '2020-05-20',
+			group: 'D',
+			value: 2
+		},
+		{
+			label: '2020-05-20',
+			group: 'E',
+			value: 1
+		},
+		{
+			label: '2020-05-21',
+			group: 'A',
+			value: 4
+		},
+		{
+			label: '2020-05-21',
+			group: 'F',
+			value: 4
+		},
+		{
+			label: '2020-05-21',
+			group: 'G',
+			value: 2
+		},
+		{
+			label: '2020-05-21',
+			group: 'C',
+			value: 2
+		},
+		{
+			label: '2020-05-21',
+			group: 'H',
+			value: 1
+		},
+		{
+			label: '2020-05-21',
+			group: 'E',
+			value: 1
+		},
+		{
+			label: '2020-05-22',
+			group: 'B',
+			value: 6
+		},
+		{
+			label: '2020-05-23',
+			group: 'G',
+			value: 3
+		},
+		{
+			label: '2020-05-23',
+			group: 'A',
+			value: 2
+		},
+		{
+			label: '2020-05-23',
+			group: 'H',
+			value: 1
+		},
+		{
+			label: '2020-05-23',
+			group: 'I',
+			value: 1
+		},
+		{
+			label: '2020-05-23',
+			group: 'E',
+			value: 1
+		},
+		{
+			label: '2020-05-23',
+			group: 'J',
+			value: 1
+		},
+		{
+			label: '2020-05-24',
+			group: 'A',
+			value: 8
+		},
+		{
+			label: '2020-05-24',
+			group: 'G',
+			value: 3
+		},
+		{
+			label: '2020-05-24',
+			group: 'H',
+			value: 1
+		},
+		{
+			label: '2020-05-24',
+			group: 'I',
+			value: 1
+		},
+		{
+			label: '2020-05-25',
+			group: 'A',
+			value: 4
+		},
+		{
+			label: '2020-05-25',
+			group: 'J',
+			value: 3
+		},
+		{
+			label: '2020-05-25',
+			group: 'B',
+			value: 1
+		},
+		{
+			label: '2020-05-25',
+			group: 'G',
+			value: 1
+		},
+		{
+			label: '2020-05-26',
+			group: 'A',
+			value: 2
+		},
+		{
+			label: '2020-05-26',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-05-28',
+			group: 'A',
+			value: 5
+		},
+		{
+			label: '2020-05-28',
+			group: 'G',
+			value: 2
+		},
+		{
+			label: '2020-05-28',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-05-28',
+			group: 'E',
+			value: 1
+		},
+		{
+			label: '2020-05-28',
+			group: 'H',
+			value: 1
+		},
+		{
+			label: '2020-05-28',
+			group: 'F',
+			value: 1
+		},
+		{
+			label: '2020-05-29',
+			group: 'A',
+			value: 3
+		},
+		{
+			label: '2020-05-29',
+			group: 'B',
+			value: 1
+		},
+		{
+			label: '2020-05-29',
+			group: 'F',
+			value: 1
+		},
+		{
+			label: '2020-05-31',
+			group: 'A',
+			value: 9
+		},
+		{
+			label: '2020-05-31',
+			group: 'B',
+			value: 2
+		},
+		{
+			label: '2020-05-31',
+			group: 'I',
+			value: 2
+		},
+		{
+			label: '2020-05-31',
+			group: 'G',
+			value: 2
+		},
+		{
+			label: '2020-05-31',
+			group: 'E',
+			value: 2
+		},
+		{
+			label: '2020-05-31',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-06-02',
+			group: 'A',
+			value: 1
+		},
+		{
+			label: '2020-06-02',
+			group: 'F',
+			value: 1
+		},
+		{
+			label: '2020-06-02',
+			group: 'G',
+			value: 1
+		},
+		{
+			label: '2020-06-03',
+			group: 'A',
+			value: 7
+		},
+		{
+			label: '2020-06-03',
+			group: 'G',
+			value: 5
+		},
+		{
+			label: '2020-06-03',
+			group: 'D',
+			value: 3
+		},
+		{
+			label: '2020-06-03',
+			group: 'E',
+			value: 3
+		},
+		{
+			label: '2020-06-03',
+			group: 'I',
+			value: 3
+		},
+		{
+			label: '2020-06-03',
+			group: 'F',
+			value: 2
+		},
+		{
+			label: '2020-06-03',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-06-04',
+			group: 'A',
+			value: 7
+		},
+		{
+			label: '2020-06-04',
+			group: 'C',
+			value: 2
+		},
+		{
+			label: '2020-06-04',
+			group: 'D',
+			value: 2
+		},
+		{
+			label: '2020-06-04',
+			group: 'H',
+			value: 1
+		},
+		{
+			label: '2020-06-04',
+			group: 'E',
+			value: 1
+		},
+		{
+			label: '2020-06-04',
+			group: 'J',
+			value: 1
+		},
+		{
+			label: '2020-06-05',
+			group: 'A',
+			value: 14
+		},
+		{
+			label: '2020-06-05',
+			group: 'G',
+			value: 4
+		},
+		{
+			label: '2020-06-05',
+			group: 'H',
+			value: 4
+		},
+		{
+			label: '2020-06-05',
+			group: 'F',
+			value: 3
+		},
+		{
+			label: '2020-06-05',
+			group: 'B',
+			value: 2
+		},
+		{
+			label: '2020-06-05',
+			group: 'J',
+			value: 2
+		},
+		{
+			label: '2020-06-05',
+			group: 'D',
+			value: 1
+		},
+		{
+			label: '2020-06-05',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-06-06',
+			group: 'A',
+			value: 5
+		},
+		{
+			label: '2020-06-06',
+			group: 'D',
+			value: 3
+		},
+		{
+			label: '2020-06-06',
+			group: 'I',
+			value: 2
+		},
+		{
+			label: '2020-06-06',
+			group: 'H',
+			value: 2
+		},
+		{
+			label: '2020-06-06',
+			group: 'G',
+			value: 2
+		},
+		{
+			label: '2020-06-06',
+			group: 'F',
+			value: 1
+		},
+		{
+			label: '2020-06-06',
+			group: 'J',
+			value: 1
+		},
+		{
+			label: '2020-06-07',
+			group: 'A',
+			value: 4
+		},
+		{
+			label: '2020-06-07',
+			group: 'E',
+			value: 2
+		},
+		{
+			label: '2020-06-08',
+			group: 'A',
+			value: 7
+		},
+		{
+			label: '2020-06-08',
+			group: 'F',
+			value: 3
+		},
+		{
+			label: '2020-06-08',
+			group: 'D',
+			value: 2
+		},
+		{
+			label: '2020-06-08',
+			group: 'G',
+			value: 2
+		},
+		{
+			label: '2020-06-08',
+			group: 'C',
+			value: 2
+		},
+		{
+			label: '2020-06-08',
+			group: 'E',
+			value: 2
+		},
+		{
+			label: '2020-06-08',
+			group: 'H',
+			value: 1
+		},
+		{
+			label: '2020-06-08',
+			group: 'I',
+			value: 1
+		},
+		{
+			label: '2020-06-09',
+			group: 'A',
+			value: 7
+		},
+		{
+			label: '2020-06-09',
+			group: 'I',
+			value: 1
+		},
+		{
+			label: '2020-06-09',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-06-09',
+			group: 'F',
+			value: 1
+		},
+		{
+			label: '2020-06-09',
+			group: 'D',
+			value: 1
+		},
+		{
+			label: '2020-06-09',
+			group: 'B',
+			value: 1
+		},
+		{
+			label: '2020-06-09',
+			group: 'J',
+			value: 1
+		},
+		{
+			label: '2020-06-09',
+			group: 'G',
+			value: 1
+		},
+		{
+			label: '2020-06-10',
+			group: 'G',
+			value: 2
+		},
+		{
+			label: '2020-06-10',
+			group: 'A',
+			value: 1
+		},
+		{
+			label: '2020-06-10',
+			group: 'I',
+			value: 1
+		},
+		{
+			label: '2020-06-10',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-06-11',
+			group: 'A',
+			value: 3
+		},
+		{
+			label: '2020-06-11',
+			group: 'B',
+			value: 1
+		},
+		{
+			label: '2020-06-11',
+			group: 'G',
+			value: 1
+		},
+		{
+			label: '2020-06-11',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-06-12',
+			group: 'A',
+			value: 1
+		},
+		{
+			label: '2020-06-12',
+			group: 'B',
+			value: 1
+		},
+		{
+			label: '2020-06-12',
+			group: 'G',
+			value: 1
+		},
+		{
+			label: '2020-06-12',
+			group: 'H',
+			value: 1
+		},
+		{
+			label: '2020-06-12',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-06-13',
+			group: 'A',
+			value: 17
+		},
+		{
+			label: '2020-06-13',
+			group: 'G',
+			value: 3
+		},
+		{
+			label: '2020-06-13',
+			group: 'D',
+			value: 3
+		},
+		{
+			label: '2020-06-13',
+			group: 'B',
+			value: 2
+		},
+		{
+			label: '2020-06-13',
+			group: 'I',
+			value: 2
+		},
+		{
+			label: '2020-06-13',
+			group: 'E',
+			value: 1
+		},
+		{
+			label: '2020-06-13',
+			group: 'H',
+			value: 1
+		},
+		{
+			label: '2020-06-14',
+			group: 'A',
+			value: 26
+		},
+		{
+			label: '2020-06-14',
+			group: 'B',
+			value: 3
+		},
+		{
+			label: '2020-06-14',
+			group: 'I',
+			value: 3
+		},
+		{
+			label: '2020-06-14',
+			group: 'E',
+			value: 2
+		},
+		{
+			label: '2020-06-14',
+			group: 'H',
+			value: 2
+		},
+		{
+			label: '2020-06-14',
+			group: 'F',
+			value: 1
+		},
+		{
+			label: '2020-06-14',
+			group: 'G',
+			value: 1
+		},
+		{
+			label: '2020-06-14',
+			group: 'D',
+			value: 1
+		},
+		{
+			label: '2020-06-14',
+			group: 'J',
+			value: 1
+		},
+		{
+			label: '2020-06-15',
+			group: 'A',
+			value: 19
+		},
+		{
+			label: '2020-06-15',
+			group: 'E',
+			value: 5
+		},
+		{
+			label: '2020-06-15',
+			group: 'H',
+			value: 4
+		},
+		{
+			label: '2020-06-15',
+			group: 'F',
+			value: 3
+		},
+		{
+			label: '2020-06-15',
+			group: 'J',
+			value: 2
+		},
+		{
+			label: '2020-06-15',
+			group: 'B',
+			value: 2
+		},
+		{
+			label: '2020-06-15',
+			group: 'G',
+			value: 2
+		},
+		{
+			label: '2020-06-15',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-06-16',
+			group: 'A',
+			value: 3
+		},
+		{
+			label: '2020-06-16',
+			group: 'B',
+			value: 3
+		},
+		{
+			label: '2020-06-16',
+			group: 'I',
+			value: 1
+		},
+		{
+			label: '2020-06-16',
+			group: 'C',
+			value: 1
+		},
+		{
+			label: '2020-06-16',
+			group: 'E',
+			value: 1
+		},
+		{
+			label: '2020-06-16',
+			group: 'H',
+			value: 1
+		},
+		{
+			label: '2020-06-16',
+			group: 'D',
+			value: 1
+		}
+	] },
+	'mark': 'area',
+	'encoding': {
+		'x': {
+			'timeUnit': 'utcday',
+			'field': 'label',
+			'axis': { 'format': '%m-%d' },
+			'type': 'temporal'
+		},
+		'y': {
+			'field': 'value',
+			'type': 'quantitative'
+		},
+		'color': {
+			'field': 'group',
+			'type': 'nominal'
+		}
+	}
 }
-
 
 export { stackedAreaChartSpec }

--- a/fixtures/stacked-bar.js
+++ b/fixtures/stacked-bar.js
@@ -1,723 +1,723 @@
 const stackedBarChartSpec = {
-  $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
-  title: {
-    text: 'Detections by Tactic (Last 30 days)',
-  },
-  mark: {
-    type: 'bar',
-    tooltip: true,
-  },
-  encoding: {
-    x: {
-      field: 'label',
-      type: 'temporal',
-      timeUnit: 'utcday',
-      axis: {
-        title: null,
-        format: '%m-%d',
-      },
-    },
-    y: {
-      aggregate: 'value',
-      type: 'quantitative',
-      axis: {
-        title: null,
-      },
-    },
-    color: {
-      field: 'group',
-      type: 'nominal',
-    },
-  },
-  data: {
-    values: [
-      {
-        label: '2020-05-20',
-        group: 'A',
-        value: 8,
-      },
-      {
-        label: '2020-05-20',
-        group: 'B',
-        value: 4,
-      },
-      {
-        label: '2020-05-20',
-        group: 'I',
-        value: 2,
-      },
-      {
-        label: '2020-05-20',
-        group: 'C',
-        value: 2,
-      },
-      {
-        label: '2020-05-20',
-        group: 'D',
-        value: 2,
-      },
-      {
-        label: '2020-05-20',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-05-21',
-        group: 'A',
-        value: 4,
-      },
-      {
-        label: '2020-05-21',
-        group: 'F',
-        value: 4,
-      },
-      {
-        label: '2020-05-21',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-05-21',
-        group: 'C',
-        value: 2,
-      },
-      {
-        label: '2020-05-21',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-05-21',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-05-22',
-        group: 'B',
-        value: 6,
-      },
-      {
-        label: '2020-05-23',
-        group: 'G',
-        value: 3,
-      },
-      {
-        label: '2020-05-23',
-        group: 'A',
-        value: 2,
-      },
-      {
-        label: '2020-05-23',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-05-23',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-05-23',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-05-23',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-05-24',
-        group: 'A',
-        value: 8,
-      },
-      {
-        label: '2020-05-24',
-        group: 'G',
-        value: 3,
-      },
-      {
-        label: '2020-05-24',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-05-24',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-05-25',
-        group: 'A',
-        value: 4,
-      },
-      {
-        label: '2020-05-25',
-        group: 'J',
-        value: 3,
-      },
-      {
-        label: '2020-05-25',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-05-25',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-05-26',
-        group: 'A',
-        value: 2,
-      },
-      {
-        label: '2020-05-26',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-05-28',
-        group: 'A',
-        value: 5,
-      },
-      {
-        label: '2020-05-28',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-05-28',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-05-28',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-05-28',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-05-28',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-05-29',
-        group: 'A',
-        value: 3,
-      },
-      {
-        label: '2020-05-29',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-05-29',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-05-31',
-        group: 'A',
-        value: 9,
-      },
-      {
-        label: '2020-05-31',
-        group: 'B',
-        value: 2,
-      },
-      {
-        label: '2020-05-31',
-        group: 'I',
-        value: 2,
-      },
-      {
-        label: '2020-05-31',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-05-31',
-        group: 'E',
-        value: 2,
-      },
-      {
-        label: '2020-05-31',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-02',
-        group: 'A',
-        value: 1,
-      },
-      {
-        label: '2020-06-02',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-06-02',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-03',
-        group: 'A',
-        value: 7,
-      },
-      {
-        label: '2020-06-03',
-        group: 'G',
-        value: 5,
-      },
-      {
-        label: '2020-06-03',
-        group: 'D',
-        value: 3,
-      },
-      {
-        label: '2020-06-03',
-        group: 'E',
-        value: 3,
-      },
-      {
-        label: '2020-06-03',
-        group: 'I',
-        value: 3,
-      },
-      {
-        label: '2020-06-03',
-        group: 'F',
-        value: 2,
-      },
-      {
-        label: '2020-06-03',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-04',
-        group: 'A',
-        value: 7,
-      },
-      {
-        label: '2020-06-04',
-        group: 'C',
-        value: 2,
-      },
-      {
-        label: '2020-06-04',
-        group: 'D',
-        value: 2,
-      },
-      {
-        label: '2020-06-04',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-04',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-06-04',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-06-05',
-        group: 'A',
-        value: 14,
-      },
-      {
-        label: '2020-06-05',
-        group: 'G',
-        value: 4,
-      },
-      {
-        label: '2020-06-05',
-        group: 'H',
-        value: 4,
-      },
-      {
-        label: '2020-06-05',
-        group: 'F',
-        value: 3,
-      },
-      {
-        label: '2020-06-05',
-        group: 'B',
-        value: 2,
-      },
-      {
-        label: '2020-06-05',
-        group: 'J',
-        value: 2,
-      },
-      {
-        label: '2020-06-05',
-        group: 'D',
-        value: 1,
-      },
-      {
-        label: '2020-06-05',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-06',
-        group: 'A',
-        value: 5,
-      },
-      {
-        label: '2020-06-06',
-        group: 'D',
-        value: 3,
-      },
-      {
-        label: '2020-06-06',
-        group: 'I',
-        value: 2,
-      },
-      {
-        label: '2020-06-06',
-        group: 'H',
-        value: 2,
-      },
-      {
-        label: '2020-06-06',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-06-06',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-06-06',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-06-07',
-        group: 'A',
-        value: 4,
-      },
-      {
-        label: '2020-06-07',
-        group: 'E',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'A',
-        value: 7,
-      },
-      {
-        label: '2020-06-08',
-        group: 'F',
-        value: 3,
-      },
-      {
-        label: '2020-06-08',
-        group: 'D',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'C',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'E',
-        value: 2,
-      },
-      {
-        label: '2020-06-08',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-08',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'A',
-        value: 7,
-      },
-      {
-        label: '2020-06-09',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'D',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-06-09',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-10',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-06-10',
-        group: 'A',
-        value: 1,
-      },
-      {
-        label: '2020-06-10',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-06-10',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-11',
-        group: 'A',
-        value: 3,
-      },
-      {
-        label: '2020-06-11',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-06-11',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-11',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'A',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'B',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-12',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-13',
-        group: 'A',
-        value: 17,
-      },
-      {
-        label: '2020-06-13',
-        group: 'G',
-        value: 3,
-      },
-      {
-        label: '2020-06-13',
-        group: 'D',
-        value: 3,
-      },
-      {
-        label: '2020-06-13',
-        group: 'B',
-        value: 2,
-      },
-      {
-        label: '2020-06-13',
-        group: 'I',
-        value: 2,
-      },
-      {
-        label: '2020-06-13',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-06-13',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-14',
-        group: 'A',
-        value: 26,
-      },
-      {
-        label: '2020-06-14',
-        group: 'B',
-        value: 3,
-      },
-      {
-        label: '2020-06-14',
-        group: 'I',
-        value: 3,
-      },
-      {
-        label: '2020-06-14',
-        group: 'E',
-        value: 2,
-      },
-      {
-        label: '2020-06-14',
-        group: 'H',
-        value: 2,
-      },
-      {
-        label: '2020-06-14',
-        group: 'F',
-        value: 1,
-      },
-      {
-        label: '2020-06-14',
-        group: 'G',
-        value: 1,
-      },
-      {
-        label: '2020-06-14',
-        group: 'D',
-        value: 1,
-      },
-      {
-        label: '2020-06-14',
-        group: 'J',
-        value: 1,
-      },
-      {
-        label: '2020-06-15',
-        group: 'A',
-        value: 19,
-      },
-      {
-        label: '2020-06-15',
-        group: 'E',
-        value: 5,
-      },
-      {
-        label: '2020-06-15',
-        group: 'H',
-        value: 4,
-      },
-      {
-        label: '2020-06-15',
-        group: 'F',
-        value: 3,
-      },
-      {
-        label: '2020-06-15',
-        group: 'J',
-        value: 2,
-      },
-      {
-        label: '2020-06-15',
-        group: 'B',
-        value: 2,
-      },
-      {
-        label: '2020-06-15',
-        group: 'G',
-        value: 2,
-      },
-      {
-        label: '2020-06-15',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'A',
-        value: 3,
-      },
-      {
-        label: '2020-06-16',
-        group: 'B',
-        value: 3,
-      },
-      {
-        label: '2020-06-16',
-        group: 'I',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'C',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'E',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'H',
-        value: 1,
-      },
-      {
-        label: '2020-06-16',
-        group: 'D',
-        value: 1,
-      },
-    ],
-  },
-};
+	$schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+	title: {
+		text: 'Detections by Tactic (Last 30 days)'
+	},
+	mark: {
+		type: 'bar',
+		tooltip: true
+	},
+	encoding: {
+		x: {
+			field: 'label',
+			type: 'temporal',
+			timeUnit: 'utcday',
+			axis: {
+				title: null,
+				format: '%m-%d'
+			}
+		},
+		y: {
+			aggregate: 'value',
+			type: 'quantitative',
+			axis: {
+				title: null
+			}
+		},
+		color: {
+			field: 'group',
+			type: 'nominal'
+		}
+	},
+	data: {
+		values: [
+			{
+				label: '2020-05-20',
+				group: 'A',
+				value: 8
+			},
+			{
+				label: '2020-05-20',
+				group: 'B',
+				value: 4
+			},
+			{
+				label: '2020-05-20',
+				group: 'I',
+				value: 2
+			},
+			{
+				label: '2020-05-20',
+				group: 'C',
+				value: 2
+			},
+			{
+				label: '2020-05-20',
+				group: 'D',
+				value: 2
+			},
+			{
+				label: '2020-05-20',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-05-21',
+				group: 'A',
+				value: 4
+			},
+			{
+				label: '2020-05-21',
+				group: 'F',
+				value: 4
+			},
+			{
+				label: '2020-05-21',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-05-21',
+				group: 'C',
+				value: 2
+			},
+			{
+				label: '2020-05-21',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-05-21',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-05-22',
+				group: 'B',
+				value: 6
+			},
+			{
+				label: '2020-05-23',
+				group: 'G',
+				value: 3
+			},
+			{
+				label: '2020-05-23',
+				group: 'A',
+				value: 2
+			},
+			{
+				label: '2020-05-23',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-05-23',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-05-23',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-05-23',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-05-24',
+				group: 'A',
+				value: 8
+			},
+			{
+				label: '2020-05-24',
+				group: 'G',
+				value: 3
+			},
+			{
+				label: '2020-05-24',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-05-24',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-05-25',
+				group: 'A',
+				value: 4
+			},
+			{
+				label: '2020-05-25',
+				group: 'J',
+				value: 3
+			},
+			{
+				label: '2020-05-25',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-05-25',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-05-26',
+				group: 'A',
+				value: 2
+			},
+			{
+				label: '2020-05-26',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-05-28',
+				group: 'A',
+				value: 5
+			},
+			{
+				label: '2020-05-28',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-05-28',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-05-28',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-05-28',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-05-28',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-05-29',
+				group: 'A',
+				value: 3
+			},
+			{
+				label: '2020-05-29',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-05-29',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-05-31',
+				group: 'A',
+				value: 9
+			},
+			{
+				label: '2020-05-31',
+				group: 'B',
+				value: 2
+			},
+			{
+				label: '2020-05-31',
+				group: 'I',
+				value: 2
+			},
+			{
+				label: '2020-05-31',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-05-31',
+				group: 'E',
+				value: 2
+			},
+			{
+				label: '2020-05-31',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-02',
+				group: 'A',
+				value: 1
+			},
+			{
+				label: '2020-06-02',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-06-02',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-03',
+				group: 'A',
+				value: 7
+			},
+			{
+				label: '2020-06-03',
+				group: 'G',
+				value: 5
+			},
+			{
+				label: '2020-06-03',
+				group: 'D',
+				value: 3
+			},
+			{
+				label: '2020-06-03',
+				group: 'E',
+				value: 3
+			},
+			{
+				label: '2020-06-03',
+				group: 'I',
+				value: 3
+			},
+			{
+				label: '2020-06-03',
+				group: 'F',
+				value: 2
+			},
+			{
+				label: '2020-06-03',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-04',
+				group: 'A',
+				value: 7
+			},
+			{
+				label: '2020-06-04',
+				group: 'C',
+				value: 2
+			},
+			{
+				label: '2020-06-04',
+				group: 'D',
+				value: 2
+			},
+			{
+				label: '2020-06-04',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-04',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-06-04',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-06-05',
+				group: 'A',
+				value: 14
+			},
+			{
+				label: '2020-06-05',
+				group: 'G',
+				value: 4
+			},
+			{
+				label: '2020-06-05',
+				group: 'H',
+				value: 4
+			},
+			{
+				label: '2020-06-05',
+				group: 'F',
+				value: 3
+			},
+			{
+				label: '2020-06-05',
+				group: 'B',
+				value: 2
+			},
+			{
+				label: '2020-06-05',
+				group: 'J',
+				value: 2
+			},
+			{
+				label: '2020-06-05',
+				group: 'D',
+				value: 1
+			},
+			{
+				label: '2020-06-05',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-06',
+				group: 'A',
+				value: 5
+			},
+			{
+				label: '2020-06-06',
+				group: 'D',
+				value: 3
+			},
+			{
+				label: '2020-06-06',
+				group: 'I',
+				value: 2
+			},
+			{
+				label: '2020-06-06',
+				group: 'H',
+				value: 2
+			},
+			{
+				label: '2020-06-06',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-06-06',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-06-06',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-06-07',
+				group: 'A',
+				value: 4
+			},
+			{
+				label: '2020-06-07',
+				group: 'E',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'A',
+				value: 7
+			},
+			{
+				label: '2020-06-08',
+				group: 'F',
+				value: 3
+			},
+			{
+				label: '2020-06-08',
+				group: 'D',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'C',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'E',
+				value: 2
+			},
+			{
+				label: '2020-06-08',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-08',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'A',
+				value: 7
+			},
+			{
+				label: '2020-06-09',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'D',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-06-09',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-10',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-06-10',
+				group: 'A',
+				value: 1
+			},
+			{
+				label: '2020-06-10',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-06-10',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-11',
+				group: 'A',
+				value: 3
+			},
+			{
+				label: '2020-06-11',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-06-11',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-11',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'A',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'B',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-12',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-13',
+				group: 'A',
+				value: 17
+			},
+			{
+				label: '2020-06-13',
+				group: 'G',
+				value: 3
+			},
+			{
+				label: '2020-06-13',
+				group: 'D',
+				value: 3
+			},
+			{
+				label: '2020-06-13',
+				group: 'B',
+				value: 2
+			},
+			{
+				label: '2020-06-13',
+				group: 'I',
+				value: 2
+			},
+			{
+				label: '2020-06-13',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-06-13',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-14',
+				group: 'A',
+				value: 26
+			},
+			{
+				label: '2020-06-14',
+				group: 'B',
+				value: 3
+			},
+			{
+				label: '2020-06-14',
+				group: 'I',
+				value: 3
+			},
+			{
+				label: '2020-06-14',
+				group: 'E',
+				value: 2
+			},
+			{
+				label: '2020-06-14',
+				group: 'H',
+				value: 2
+			},
+			{
+				label: '2020-06-14',
+				group: 'F',
+				value: 1
+			},
+			{
+				label: '2020-06-14',
+				group: 'G',
+				value: 1
+			},
+			{
+				label: '2020-06-14',
+				group: 'D',
+				value: 1
+			},
+			{
+				label: '2020-06-14',
+				group: 'J',
+				value: 1
+			},
+			{
+				label: '2020-06-15',
+				group: 'A',
+				value: 19
+			},
+			{
+				label: '2020-06-15',
+				group: 'E',
+				value: 5
+			},
+			{
+				label: '2020-06-15',
+				group: 'H',
+				value: 4
+			},
+			{
+				label: '2020-06-15',
+				group: 'F',
+				value: 3
+			},
+			{
+				label: '2020-06-15',
+				group: 'J',
+				value: 2
+			},
+			{
+				label: '2020-06-15',
+				group: 'B',
+				value: 2
+			},
+			{
+				label: '2020-06-15',
+				group: 'G',
+				value: 2
+			},
+			{
+				label: '2020-06-15',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'A',
+				value: 3
+			},
+			{
+				label: '2020-06-16',
+				group: 'B',
+				value: 3
+			},
+			{
+				label: '2020-06-16',
+				group: 'I',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'C',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'E',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'H',
+				value: 1
+			},
+			{
+				label: '2020-06-16',
+				group: 'D',
+				value: 1
+			}
+		]
+	}
+}
 
-export { stackedBarChartSpec };
+export { stackedBarChartSpec }

--- a/fixtures/temporal-bar.js
+++ b/fixtures/temporal-bar.js
@@ -1,22 +1,22 @@
 const temporalBarChartSpec = {
-  $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
-  title: { text: 'temporal bar chart' },
-  data: {
-    values: [
-      { value: 10, date: '2010' },
-      { value: 20, date: '2011' },
-      { value: 10, date: '2012' },
-      { value: 30, date: '2013' },
-      { value: 50, date: '2014' },
-      { value: 10, date: '2015' },
-    ],
-  },
+	$schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+	title: { text: 'temporal bar chart' },
+	data: {
+		values: [
+			{ value: 10, date: '2010' },
+			{ value: 20, date: '2011' },
+			{ value: 10, date: '2012' },
+			{ value: 30, date: '2013' },
+			{ value: 50, date: '2014' },
+			{ value: 10, date: '2015' }
+		]
+	},
 
-  mark: { type: 'bar', tooltip: true },
-  encoding: {
-    y: { field: 'value', type: 'quantitative' },
-    x: { field: 'date', type: 'temporal', timeUnit: 'utcyear', axis: { format: '%Y' } },
-  },
-};
+	mark: { type: 'bar', tooltip: true },
+	encoding: {
+		y: { field: 'value', type: 'quantitative' },
+		x: { field: 'date', type: 'temporal', timeUnit: 'utcyear', axis: { format: '%Y' } }
+	}
+}
 
-export { temporalBarChartSpec };
+export { temporalBarChartSpec }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postbuild": "yarn run archive",
     "archive": "zip -jr build/bisonica-$(npm view bisonica version).zip build/bisonica.js source/index.css",
     "lint-git": "commitlint --to=HEAD --from=11cd541",
-    "lint-js": "eslint source tests/unit tests/integration",
+    "lint-js": "eslint source tests/unit tests/integration fixtures",
     "lint-styles": "stylelint source/index.css",
     "test": "qunit --require jsdom-global/register --require ./tests/browser-shim.cjs tests/**/*.js",
     "test-serve": "testem --file ./tests/testem.cjs",


### PR DESCRIPTION
Turns out all those lint fixes from pull request #181 were not being applied to the specification fixtures because until now `fixtures/` has been accidentally omitted from the linting script in `package.json`.