### PR TITLE
colored markers in table

### DIFF
--- a/source/index.css
+++ b/source/index.css
@@ -198,3 +198,11 @@ table td {
 table td.quantitative {
   text-align: right;
 }
+
+table td div {
+  border-radius: 100%;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-left: 0.5rem;
+  display: inline-block;
+}


### PR DESCRIPTION
Adds a colored marker to each row of the tables from #189 if the chart uses a color encoding, like this:

![colored-table-markers](https://user-images.githubusercontent.com/3488572/205106571-f545c905-3a97-4bae-8478-e9ba75aa0df7.png)

This makes it cognitively easier to associate the table rows with the related content in the chart and the legend.