### PR TITLE
reorganize table dom setup

### DIFF
--- a/source/chart.js
+++ b/source/chart.js
@@ -37,9 +37,9 @@ const chart = (s, panelDimensions) => {
 
 		initializeInteractions(chartNode.node(), s)
 
-		// render legend
 		chartNode.call(tableRenderer(s, tableOptions(s)))
 
+		// render legend
 		if (feature(s).hasLegend()) {
 			chartNode.select('.legend').call(legend(s))
 		}

--- a/source/chart.js
+++ b/source/chart.js
@@ -37,7 +37,9 @@ const chart = (s, panelDimensions) => {
 
 		initializeInteractions(chartNode.node(), s)
 
-		chartNode.call(tableRenderer(s, tableOptions(s)))
+		if (feature(s).hasTable()) {
+			chartNode.select('.table').call(tableRenderer(s, tableOptions(s)))
+		}
 
 		// render legend
 		if (feature(s).hasLegend()) {

--- a/source/feature.js
+++ b/source/feature.js
@@ -49,6 +49,7 @@ const _feature = s => {
 		hasAxisTitleX: s => s.encoding?.x?.axis?.title !== null,
 		hasAxisTitleY: s => s.encoding?.y?.axis?.title !== null,
 		hasStaticText: s => s.mark?.text && !s.encoding?.text,
+		hasTable: s => s.usermeta?.table !== null,
 		isCartesian: s => (s.encoding?.x && s.encoding?.y),
 		isLinear: s => (s.encoding?.x && !s.encoding?.y) || (s.encoding?.y && !s.encoding?.x),
 		isRadial: s => s.encoding?.theta,

--- a/source/init.js
+++ b/source/init.js
@@ -21,6 +21,10 @@ const init = (s, dimensions) => {
 			chartNode.append('div').classed('legend', true)
 		}
 
+		if (feature(s).hasTable()) {
+			chartNode.append('div').classed('table', true)
+		}
+
 		const svg = graphic.append('svg')
 
 		svg.attr('tabindex', 0)

--- a/source/table.js
+++ b/source/table.js
@@ -12,7 +12,8 @@ import { parseScales } from './scales.js'
  */
 const setup = s => {
 	return selection => {
-		selection.append('table')
+		selection
+			.append('table')
 			.append('caption')
 			.text(s.title.text)
 	}
@@ -112,10 +113,7 @@ const table = (_s, options) => {
 		return noop
 	}
 	return selection => {
-		const table = selection
-			.append('div')
-			.classed('table', true)
-		table
+		selection
 			.call(setup(_s))
 			.call(header(s))
 			.call(rows(s))


### PR DESCRIPTION
When the table view was introduced in pull request #189, it set up its own DOM from inside the module scope. That works well enough, but really the life cycle should be handled by `init.js` as with the rest of the library.