### PR TITLE
simplify link handling

### DIFF
--- a/source/config.js
+++ b/source/config.js
@@ -8,23 +8,10 @@ const MINIMUM_TICK_COUNT = 3
 
 const RENDER_FREQUENCY = 32
 
-/**
- * custom behavior for opening links when mark nodes are
- * clicked
- *
- * - false uses window.open()
- * - true disables window.open()
- * - function disables window.open() and then executes
- * with the url and the node as the arguments
- * @type {boolean|function}
- */
-const customLinkHandler = true
-
 export {
 	WRAPPER_CLASS,
 	GRID,
 	MINIMUM_TICK_COUNT,
 	BAR_WIDTH_MINIMUM,
-	RENDER_FREQUENCY,
-	customLinkHandler
+	RENDER_FREQUENCY
 }

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -88,9 +88,6 @@ const markMouseoverSelector = s => {
  * @param {string} url url
  */
 const handleUrl = url => {
-	if (typeof url !== 'string') {
-		console.error(`cannot link to url of type ${typeof url}`)
-	}
 	window.open(url)
 }
 

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -1,7 +1,6 @@
 import * as d3 from 'd3'
 
 import { category, markInteractionSelector, markSelector } from './marks.js'
-import { customLinkHandler } from './config.js'
 import { feature } from './feature.js'
 import { getUrl, key, noop } from './helpers.js'
 import { layerCall, layerNode } from './views.js'
@@ -86,23 +85,13 @@ const markMouseoverSelector = s => {
 
 /**
  * dispatch a CustomEvent with a URL from a node
- * @param {object} node node
  * @param {string} url url
  */
-const handleUrl = (url, node) => {
+const handleUrl = url => {
 	if (typeof url !== 'string') {
 		console.error(`cannot link to url of type ${typeof url}`)
 	}
-
-	if (typeof customLinkHandler === 'function') {
-		customLinkHandler(url, node)
-	} else if (!customLinkHandler) {
-		window.open(url)
-	}
-
-	const event = new CustomEvent('link', { bubbles: true, detail: { url } })
-
-	node.dispatchEvent(event)
+	window.open(url)
 }
 
 /**
@@ -192,7 +181,7 @@ const _interactions = s => {
 				// pivot links
 				dispatcher.on('link', function (url) {
 					if (url) {
-						handleUrl(url, this)
+						handleUrl(url)
 					}
 				})
 				click.on('click', function () {


### PR DESCRIPTION
Remove the convoluted configurable link handling and instead just open links using `window.open()`.