### PR TITLE
correct encoding aggregates

### DIFF
--- a/fixtures/stacked-bar.js
+++ b/fixtures/stacked-bar.js
@@ -18,7 +18,7 @@ const stackedBarChartSpec = {
 			}
 		},
 		y: {
-			aggregate: 'value',
+			field: 'value',
 			type: 'quantitative',
 			axis: {
 				title: null

--- a/source/axes.js
+++ b/source/axes.js
@@ -74,7 +74,7 @@ const ticks = (s, channel) => {
 const title = (s, channel) => {
 	const encoding = s.encoding[channel]
 
-	return encoding.axis?.title || encoding.aggregate || encoding.field
+	return encoding.axis?.title || encoding.field
 }
 
 /**

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -12,9 +12,7 @@ import { nested } from './helpers.js'
  * @returns {string} encoding field
  */
 const encodingField = (s, channel) => {
-	return (
-		s.encoding?.[channel]?.aggregate || s.encoding?.[channel]?.field || s.facet?.[channel]?.field
-	)
+	return s.encoding?.[channel]?.field || s.facet?.[channel]?.field
 }
 
 /**

--- a/source/feature.js
+++ b/source/feature.js
@@ -34,7 +34,6 @@ const _feature = s => {
 		isCircular: s => mark(s) === 'arc',
 		isRule: s => mark(s) === 'rule',
 		isText: s => mark(s) === 'text',
-		isAggregate: s => ['x', 'y'].some(channel => s.encoding?.[channel]?.aggregate),
 		hasColor: s => s.encoding?.color,
 		hasLinks: s => s.encoding?.href || s.mark?.href,
 		hasData: s => s.data?.values.length,

--- a/tests/unit/feature-test.js
+++ b/tests/unit/feature-test.js
@@ -9,16 +9,6 @@ module('unit > feature', () => {
 		assert.ok(feature({ mark: { type: 'arc' } }).isCircular(), 'identifies circular charts')
 	})
 
-	test('detects aggregate encodings', assert => {
-		const x = { encoding: { x: { aggregate: 'a' }, y: { field: 'b' } } }
-		const y = { encoding: { x: { field: 'a' }, y: { aggregate: 'b' } } }
-		const neither = { encoding: { x: { field: 'a' }, y: { field: 'b' } } }
-
-		assert.ok(feature(x).isAggregate(), 'detects x axis aggregates')
-		assert.ok(feature(y).isAggregate(), 'detects y axis aggregates')
-		assert.notOk(feature(neither).isAggregate(), 'identifies the absence of aggregates')
-	})
-
 	test('always creates feature test methods', assert => {
 		const s = {}
 		const tests = feature(s)

--- a/tests/unit/metadata-test.js
+++ b/tests/unit/metadata-test.js
@@ -78,7 +78,7 @@ module('unit > metadata', () => {
 				color: { field: 'group', type: 'nominal' },
 				href: { field: 'url' },
 				x: { field: 'label', type: 'temporal' },
-				y: { aggregate: 'value', type: 'quantitative' }
+				y: { field: 'value', type: 'quantitative' }
 			}
 		}
 
@@ -105,7 +105,7 @@ module('unit > metadata', () => {
 				color: { field: 'group', type: 'nominal' },
 				href: { field: 'url' },
 				x: { field: 'label', type: 'temporal' },
-				y: { aggregate: 'value', type: 'quantitative' }
+				y: { field: 'value', type: 'quantitative' }
 			}
 		}
 


### PR DESCRIPTION
This property was previously misused. Cleaning it up now clears the way for a correct implementation of [aggregates](https://vega.github.io/vega-lite/docs/aggregate.html) in the future.