### PR TITLE
remove tick alternation

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -2,7 +2,7 @@ import * as d3 from 'd3'
 
 import { axisTickLabelText, rotation } from './text.js'
 import { barWidth } from './marks.js'
-import { degrees, isDiscrete, noop, overlap } from './helpers.js'
+import { degrees, isDiscrete, noop } from './helpers.js'
 import { encodingChannelCovariate, encodingChannelQuantitative, encodingType } from './encodings.js'
 import { feature } from './feature.js'
 import { layerMatch } from './views.js'
@@ -75,30 +75,6 @@ const title = (s, channel) => {
 	const encoding = s.encoding[channel]
 
 	return encoding.axis?.title || encoding.field
-}
-
-/**
- * alternate ticks
- * @param {object} s Vega Lite specification
- * @returns {function} alternation function
- */
-const alternate = s => {
-	return selection => {
-		['x', 'y'].forEach(channel => {
-			if (s.encoding[channel] === undefined) {
-				return
-			}
-
-			const axisSelector = `.${channel}`
-			const ticks = selection.select(axisSelector).selectAll('.tick')
-
-			if (!isDiscrete(s, channel)) {
-				if (overlap([...ticks.nodes()])) {
-					selection.select(axisSelector).classed('alternate-ticks', true)
-				}
-			}
-		})
-	}
 }
 
 /**
@@ -307,8 +283,6 @@ const axes = (_s, dimensions) => {
 		if (feature(s).hasEncodingX()) {
 			axes.call(x(s, dimensions))
 		}
-
-		axes.call(alternate(s))
 	}
 
 	return renderer

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -154,24 +154,6 @@ const isDiscrete = (s, channel) => {
 }
 
 /**
- * determine whether DOM nodes overlap
- * @param {array} nodes DOM nodes
- * @returns {boolean} overlap
- */
-const overlap = nodes => {
-	return [...nodes].some((node, index) => {
-		if (index === nodes.length - 1) {
-			return false
-		}
-		const a = node.getBoundingClientRect()
-		const b = nodes[index + 1]?.getBoundingClientRect()
-		const overlap = !(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom)
-
-		return overlap
-	})
-}
-
-/**
  * convert polar coordinates to Cartesian
  * @param {number} radius radius
  * @param {number} angle angle in radians
@@ -216,7 +198,6 @@ export {
 	degrees,
 	isContinuous,
 	isDiscrete,
-	overlap,
 	polarToCartesian,
 	detach
 }

--- a/source/index.css
+++ b/source/index.css
@@ -137,14 +137,6 @@ path.mark {
   text-anchor: middle;
 }
 
-.axes .x.alternate-ticks .tick {
-  opacity: 0;
-}
-
-.axes .y.alternate-ticks .tick {
-  opacity: 0;
-}
-
 .axes .x .axis .tick line {
   stroke: var(--medium-grey);
 }
@@ -155,14 +147,6 @@ path.mark {
 
 .axes:not(.angled) .x .tick text {
   text-anchor: middle;
-}
-
-.axes .x.alternate-ticks .tick:nth-of-type(4n) {
-  opacity: 1;
-}
-
-.axes .y.alternate-ticks .tick:nth-of-type(odd) {
-  opacity: 1;
 }
 
 .axes .axis.nominal.angled .tick text {


### PR DESCRIPTION
Stops trying to detect the cases where axis ticks should be removed automatically, and leaves it to the caller to decide via the instructions in the specification.

The `overlap()` helper function for testing whether nodes are running into each other might be worth bringing back in the future, but it's slow (see the previous optimization in pull request #162 – it's a hassle!) and now it is unused.