### PR TITLE
use native matchAll with regular expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/vijithassar/bisonica.git"
   },
   "scripts": {
-    "build": "esbuild --bundle --format=esm --external:d3 --external:string.prototype.matchall --outfile=build/bisonica.js source/chart.js",
+    "build": "esbuild --bundle --format=esm --external:d3 --outfile=build/bisonica.js source/chart.js",
     "postbuild": "yarn run archive",
     "archive": "zip -jr build/bisonica-$(npm view bisonica version).zip build/bisonica.js source/index.css",
     "lint-git": "commitlint --to=HEAD --from=11cd541",
@@ -45,14 +45,12 @@
     "nanobench": "^3.0.0",
     "qunit": "^2.19.3",
     "standard-version": "^9.5.0",
-    "string.prototype.matchall": "^4.0.7",
     "stylelint": "^14.9.1",
     "stylelint-config-standard": "^26.0.0",
     "testem": "^3.8.0",
     "typescript": "^4.7.3"
   },
   "peerDependencies": {
-    "d3": "^6.7.0 || ^7.0.0",
-    "string.prototype.matchall": "^4.0.7"
+    "d3": "^6.7.0 || ^7.0.0"
   }
 }

--- a/source/time.js
+++ b/source/time.js
@@ -4,8 +4,6 @@ import { memoize } from './memoize.js'
 import { feature } from './feature.js'
 import { barWidth } from './marks.js'
 
-import matchAll from 'string.prototype.matchall'
-
 const UTC = 'utc'
 const TIME = 'time'
 
@@ -109,7 +107,7 @@ const findTimePeriod = new RegExp(`(?:${TIME}|${UTC})(\\w+)`, 'gi')
  * @returns {string} camelcased time specifier string
  */
 const camelCaseTimePeriod = timeSpecifier => {
-	let matches = [...matchAll(timeSpecifier, findTimePeriod)]
+	let matches = [...timeSpecifier.matchAll(findTimePeriod)]
 
 	if (!matches.length) {
 		return timeSpecifier

--- a/tests/index.mustache
+++ b/tests/index.mustache
@@ -6,8 +6,7 @@
     {
       "imports": {
         "d3": "https://esm.run/d3",
-        "qunit": "https://esm.run/qunit",
-        "string.prototype.matchall": "https://esm.run/string.prototype.matchall"
+        "qunit": "https://esm.run/qunit"
       }
     }
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,7 +1798,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.5:
+es-abstract@^1.19.0, es-abstract@^1.19.5:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
   integrity sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==
@@ -4183,7 +4183,7 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-regexp.prototype.flags@^1.4.1, regexp.prototype.flags@^1.4.3:
+regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
   integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
@@ -4546,20 +4546,6 @@ statuses@2.0.1:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
-
-string.prototype.matchall@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz#8e6ecb0d8a1fb1fda470d81acecb2dba057a481d"
-  integrity sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    es-abstract "^1.19.1"
-    get-intrinsic "^1.1.1"
-    has-symbols "^1.0.3"
-    internal-slot "^1.0.3"
-    regexp.prototype.flags "^1.4.1"
-    side-channel "^1.0.4"
 
 string.prototype.trimend@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
There's no longer any need to shim this – just use the [native version](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll).