### PR TITLE
require timestamps to be numbers

### DIFF
--- a/source/time.js
+++ b/source/time.js
@@ -48,21 +48,13 @@ const timeParseIso = d3.isoParse
  */
 const timeParseMilliseconds = date => new Date(date)
 
-/**
- * convert date in milliseconds as string to date object
- * @param {string} date number of milliseconds
- * @returns {object} date object
- */
-const timeParseMillisecondsString = date => timeParseMilliseconds(+date)
-
 const _getTimeParser = date => {
 	const parsers = [
 		timeParseYYYYMMDD,
 		timeParseIso,
 		timeParseIsoRange,
 		timeParseYYYYMM,
-		timeParseMilliseconds,
-		timeParseMillisecondsString
+		timeParseMilliseconds
 	]
 	const isDate = parser => {
 		const parsed = parser(date)


### PR DESCRIPTION
Removes a function to handle timestamps which had previously been converted from integers to strings for some unknown reason. This is noncompliant off-spec behavior, and it is a fundamentally nonsensical data type. Begone!