### PR TITLE
rename chartName() function to chartLabel()

### DIFF
--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -201,7 +201,7 @@ const instructions = s => {
  * @param {object} s Vega Lite specification
  * @returns {string} chart title
  */
-const chartName = s => {
+const chartLabel = s => {
 	if (!s.title.text) {
 		throw new Error('specification title is required')
 	}
@@ -212,4 +212,4 @@ const chartName = s => {
 	}
 }
 
-export { markDescription, chartName, chartDescription }
+export { markDescription, chartLabel, chartDescription }

--- a/source/init.js
+++ b/source/init.js
@@ -1,7 +1,7 @@
 import { WRAPPER_CLASS } from './config.js'
 import { feature } from './feature.js'
 import { extension } from './extensions.js'
-import { chartName, chartDescription } from './descriptions.js'
+import { chartLabel, chartDescription } from './descriptions.js'
 import { detach } from './helpers.js'
 
 /**
@@ -38,7 +38,7 @@ const init = (s, dimensions) => {
 			throw new Error('specification title is required')
 		}
 
-		svg.attr('aria-label', chartName(s))
+		svg.attr('aria-label', chartLabel(s))
 		svg.attr('aria-description', chartDescription(s))
 
 		if (feature(s).hasAxis()) {


### PR DESCRIPTION
The function for computing the top level `aria-label` was originally called `chartName()`, but the subtitle was added in pull request #150 and instructions for using the keyboard navigation were appended in pull request #196, so "name" no longer seems appropriate.