### PR TITLE
configurable point marks

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -68,7 +68,7 @@ const _createAccessors = (s, type = null) => {
 		standard('x', 'y', 'color')
 	}
 
-	if (key === 'point') {
+	if (['point', 'square', 'circle'].includes(key)) {
 		standard('x', 'y', 'color')
 	}
 

--- a/source/feature.js
+++ b/source/feature.js
@@ -29,7 +29,7 @@ const _feature = s => {
 		isBar: s => mark(s) === 'bar',
 		isLine: s => mark(s) === 'line',
 		isArea: s => mark(s) === 'area',
-		hasPoints: s => mark(s) === 'point' || s.mark?.point === true,
+		hasPoints: s => ['point', 'circle', 'square'].includes(mark(s)) || s.mark?.point === true,
 		hasPointsFilled: s => (mark(s) !== 'point') && (s.mark?.filled !== false),
 		hasLayers: s => s.layer,
 		isCircular: s => mark(s) === 'arc',

--- a/source/feature.js
+++ b/source/feature.js
@@ -30,6 +30,7 @@ const _feature = s => {
 		isLine: s => mark(s) === 'line',
 		isArea: s => mark(s) === 'area',
 		hasPoints: s => mark(s) === 'point' || s.mark?.point === true,
+		hasPointsFilled: s => (mark(s) !== 'point') && (s.mark?.filled !== false),
 		hasLayers: s => s.layer,
 		isCircular: s => mark(s) === 'arc',
 		isRule: s => mark(s) === 'rule',

--- a/source/marks.js
+++ b/source/marks.js
@@ -448,12 +448,27 @@ const pointMarks = (s, dimensions) => {
 
 		marks
 			.selectAll(pointMarkSelector(s))
-			.style('stroke', encoders.color)
-			.style('fill', feature(s).hasPointsFilled() ? encoders.color : null)
-			.style('fill-opacity', feature(s).hasPointsFilled() ? 1 : 0.001)
 			.data(getPointData)
 			.enter()
 			.call(pointMark(s, dimensions))
+
+		// style the point mark directly when they are standalone
+		if (!feature(s).isLine()) {
+			const { color } = parseScales(s)
+			const points = marks.selectAll(pointMarkSelector(s))
+			points
+				.style('stroke', feature(s).isMulticolor() ? encoders.color : color)
+				.style('stroke-width', 1)
+			points
+				.style('fill', feature(s).isMulticolor() ? encoders.color : color)
+				.style('fill-opacity', feature(s).hasPointsFilled() ? 1 : 0.001)
+		// style the series node when point marks are on top of line marks
+		} else {
+			marks
+				.style('stroke', encoders.color)
+				.style('fill', feature(s).hasPointsFilled() ? encoders.color : null)
+				.style('fill-opacity', feature(s).hasPointsFilled() ? 1 : 0.001)
+		}
 	}
 
 	return renderer

--- a/source/marks.js
+++ b/source/marks.js
@@ -344,8 +344,10 @@ const areaMarks = (s, dimensions) => {
  * @returns {function(object)} point rendering function
  */
 const pointMark = (s, dimensions) => {
+	const defaultSize = 30
+	const size = s.mark.size || defaultSize
+	const radius = Math.sqrt(size / Math.PI)
 	const encoders = createEncoders(s, dimensions, createAccessors(s))
-	const radius = stroke * 1.2
 	const renderer = selection => {
 		const point = selection
 			.append('circle')

--- a/source/marks.js
+++ b/source/marks.js
@@ -712,6 +712,8 @@ const _marks = (s, dimensions) => {
 			return pointMarks(s, dimensions)
 		} else if (feature(s).isText()) {
 			return textMarks(s, dimensions)
+		} else {
+			throw new Error('could not determine mark rendering function')
 		}
 	} catch (error) {
 		error.message = `could not render marks - ${error.message}`

--- a/source/marks.js
+++ b/source/marks.js
@@ -111,6 +111,8 @@ const pointMarkSelector = s => {
 		return defaultPointMark
 	} else if (mark(s) === 'square') {
 		return 'rect'
+	} else if (mark(s) === 'circle') {
+		return 'circle'
 	}
 }
 

--- a/source/marks.js
+++ b/source/marks.js
@@ -339,15 +339,30 @@ const areaMarks = (s, dimensions) => {
 }
 
 /**
+ * render a circular point mark
+ * @param {object} s Vega Lite specification
+ * @returns {function(object)} circular point mark rendering function
+ */
+const pointMarkCircle = (s, dimensions) => {
+	const defaultSize = 30
+	const size = s.mark.size || defaultSize
+	const radius = Math.sqrt(size / Math.PI)
+	const encoders = createEncoders(s, dimensions, createAccessors(s))
+	const renderer = selection => {
+		selection
+			.attr('cx', encoders.x)
+			.attr('cy', encoders.y)
+			.attr('r', radius)
+	}
+	return renderer
+}
+
+/**
  * render a single point mark
  * @param {object} s Vega Lite specification
  * @returns {function(object)} point rendering function
  */
 const pointMark = (s, dimensions) => {
-	const defaultSize = 30
-	const size = s.mark.size || defaultSize
-	const radius = Math.sqrt(size / Math.PI)
-	const encoders = createEncoders(s, dimensions, createAccessors(s))
 	const renderer = selection => {
 		const point = selection
 			.append('circle')
@@ -363,10 +378,8 @@ const pointMark = (s, dimensions) => {
 				}
 			})
 			.attr('aria-label', markDescription(s))
-			.attr('cx', encoders.x)
-			.attr('cy', encoders.y)
-			.attr('r', radius)
 			.classed('link', encodingValue(s, 'href'))
+			.call(pointMarkCircle(s, dimensions))
 			.call(tooltips(s))
 		if (!feature(s).isLine()) {
 			point.attr('aria-label', markDescription(s))

--- a/source/marks.js
+++ b/source/marks.js
@@ -100,9 +100,23 @@ const _barWidth = (s, dimensions) => {
 const barWidth = memoize(_barWidth)
 
 /**
+ * point mark tagName
+ * @param {object} s Vega Lite specification
+ * @returns {'circle'|'square'} point mark tag name
+ */
+const pointMarkSelector = s => {
+	const defaultPointMark = 'circle'
+	if (feature(s).isLine() || mark(s) === 'point') {
+		return defaultPointMark
+	} else {
+		return s.mark.type
+	}
+}
+
+/**
  * mark tagName
  * @param {object} s Vega Lite specification
- * @returns {('rect'|'path'|'circle'|'line'|'text')} tagName to use in DOM for mark
+ * @returns {('rect'|'path'|'circle'|'square'|'line'|'text')} tagName to use in DOM for mark
  */
 const markSelector = s => {
 	if (feature(s).isBar()) {
@@ -110,7 +124,7 @@ const markSelector = s => {
 	} else if (feature(s).isLine() || feature(s).isCircular() || feature(s).isArea()) {
 		return 'path'
 	} else if (!feature(s).isLine() && feature(s).hasPoints()) {
-		return 'circle'
+		return pointMarkSelector(s)
 	} else if (feature(s).isRule()) {
 		return 'line'
 	} else if (feature(s).isText()) {
@@ -127,7 +141,7 @@ const markInteractionSelector = _s => {
 	const s = !feature(_s).hasLayers() ? _s : _s.layer.find(layer => !feature(layer).isRule())
 
 	if (feature(s).isLine()) {
-		return '.marks circle.point.mark'
+		return `.marks ${pointMarkSelector(s)}.point.mark`
 	} else {
 		return `.marks ${markSelector(s)}`
 	}
@@ -365,7 +379,7 @@ const pointMarkCircle = (s, dimensions) => {
 const pointMark = (s, dimensions) => {
 	const renderer = selection => {
 		const point = selection
-			.append('circle')
+			.append(pointMarkSelector(s))
 		point
 			.classed('point', true)
 			.classed('mark', true)
@@ -410,7 +424,7 @@ const pointMarks = (s, dimensions) => {
 		const getPointData = feature(s).isLine() ? d => d.values : pointData(s)
 
 		marks
-			.selectAll('circle')
+			.selectAll(pointMarkSelector(s))
 			.style('stroke', encoders.color)
 			.style('fill', feature(s).hasPointsFilled() ? encoders.color : null)
 			.style('fill-opacity', feature(s).hasPointsFilled() ? 1 : 0.001)

--- a/tests/unit/marks-test.js
+++ b/tests/unit/marks-test.js
@@ -1,4 +1,4 @@
-import { barWidth } from '../../source/marks.js'
+import { barWidth, markSelector } from '../../source/marks.js'
 import qunit from 'qunit'
 import { specificationFixture } from '../test-helpers.js'
 
@@ -71,6 +71,19 @@ module('unit > marks', () => {
 			customSpec.encoding.x.scale = { domain: ['2010', '2020'] }
 			const customWidth = barWidth(customSpec, dimensions)
 			assert.ok(standardWidth > customWidth)
+		})
+	})
+	module('point marks', () => {
+		test('point', assert => {
+			assert.equal(markSelector(specificationFixture('scatterPlot')), 'circle')
+		})
+		test('circle', assert => {
+			assert.equal(markSelector(specificationFixture('scatterPlot')), 'circle')
+		})
+		test('square', assert => {
+			const s = specificationFixture('scatterPlot')
+			s.mark.type = 'square'
+			assert.equal(markSelector(s), 'rect')
 		})
 	})
 })


### PR DESCRIPTION
Adds several features for [point marks](https://vega.github.io/vega-lite/docs/point.html):

- square and circle shapes
- configurable size
- configurable fill
- empty fill for `mark.type: "point"`