### PR TITLE
text mark content, size, and data join

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -673,6 +673,7 @@ const ruleMarks = (s, dimensions) => {
 }
 
 const textMarks = (s, dimensions) => {
+	const defaultFontSize = 11
 	return selection => {
 		const marks = selection.append('g').attr('class', 'marks')
 		const encoders = createEncoders(s, dimensions, createAccessors(s))
@@ -685,6 +686,9 @@ const textMarks = (s, dimensions) => {
 		} else if (s.mark.text) {
 			text = marks.append('text').classed('mark', true)
 		}
+
+		// default font size
+		text.style('font-size', defaultFontSize)
 
 		// text content
 		if (s.mark.text) {

--- a/source/marks.js
+++ b/source/marks.js
@@ -712,6 +712,9 @@ const textMarks = (s, dimensions) => {
 
 		// styles with aliases
 		const styles = {
+			// mark.fontSize will override mark.size since
+			// it is probably a more specialized case
+			size: 'font-size',
 			fontSize: 'font-size',
 			font: 'font-family',
 			fontStyle: 'font-style',

--- a/source/marks.js
+++ b/source/marks.js
@@ -681,10 +681,14 @@ const textMarks = (s, dimensions) => {
 
 		if (feature(s).hasData()) {
 			text = marks.selectAll('text').data(markData(s)).enter().append('text').attr('class', 'mark')
-			text.text(encoders.text)
 		} else if (s.mark.text) {
 			text = marks.append('text').classed('mark', true)
+		}
+
+		if (s.mark.text) {
 			text.text(s.mark.text)
+		} else {
+			text.text(encoders.text)
 		}
 
 		// encoded attributes

--- a/source/marks.js
+++ b/source/marks.js
@@ -679,12 +679,14 @@ const textMarks = (s, dimensions) => {
 
 		let text
 
+		// data binding
 		if (feature(s).hasData()) {
 			text = marks.selectAll('text').data(markData(s)).enter().append('text').attr('class', 'mark')
 		} else if (s.mark.text) {
 			text = marks.append('text').classed('mark', true)
 		}
 
+		// text content
 		if (s.mark.text) {
 			text.text(s.mark.text)
 		} else {


### PR DESCRIPTION
Changes related to properties of the `mark` object as used for text:

- separates text content from data binding so static text content can still be used when there is a data join
- interprets `mark.size` from [point marks](https://github.com/vijithassar/bisonica/pull/207) as font size
- handles potential conflicts between `mark.size` and `mark.fontSize`
- uses [default font size of 11px](https://vega.github.io/vega-lite/docs/point.html#properties) when another size is not specified