### PR TITLE
categorical color palettes for different forms of color blindness

### DIFF
--- a/source/color.js
+++ b/source/color.js
@@ -6,9 +6,11 @@ const defaultColor = 'steelblue'
 /**
  * alternate luminance on a set of color objects
  * @param {object} color color
+ * @param {number} index position of the color in the palette
+ * @param {number} k severity of luminance adjustment
  * @returns {object} color
  */
-const alternateLuminance = (color, index) => color[index % 2 ? 'brighter' : 'darker']()
+const alternateLuminance = (color, index, k = 1) => color[index % 2 ? 'brighter' : 'darker'](k)
 
 const stops = {
 	deuteranopia: ['#e1daae', '#ff934f', '#cc2d35', '#058ed9', '#2d3142'],
@@ -31,8 +33,17 @@ const accessibleColors = (count, variant) => {
 	const step = 1 / count
 	const values = Array.from({ length: count }).map((_, index) => {
 		return interpolator(index * step)
+	}).map(item => {
+		return d3.hsl(item)
 	})
-	return values.map(d3.color).map(alternateLuminance)
+
+	let k
+	if (variant === 'tritanopia') {
+		k = 0.1
+	} else {
+		k = 0.5
+	}
+	return values.map((item, index) => alternateLuminance(item, index, k))
 }
 
 /**
@@ -51,7 +62,7 @@ const standardColors = count => {
 	})
 	const swatch = hues
 		.map(hue => d3.hcl(hue, 100, 50))
-		.map(alternateLuminance)
+		.map((color, index) => alternateLuminance(color, index))
 		.map(item => item.toString())
 	const midpoint = Math.floor(count * 0.5)
 	const a = swatch.slice(0, midpoint)

--- a/source/color.js
+++ b/source/color.js
@@ -1,4 +1,5 @@
 import * as d3 from 'd3'
+import { extension } from './extensions.js'
 
 const defaultColor = 'steelblue'
 
@@ -23,6 +24,9 @@ const stops = {
  * @returns {string[]} color palette
  */
 const accessibleColors = (count, variant) => {
+	if (!stops[variant]) {
+		throw new Error(`unknown color palette "${variant}"`)
+	}
 	const interpolator = d3.piecewise(d3.interpolateRgb.gamma(2.2), stops[variant])
 	const step = 1 / count
 	const values = Array.from({ length: count }).map((_, index) => {
@@ -32,12 +36,12 @@ const accessibleColors = (count, variant) => {
 }
 
 /**
- * create a color palette from the available hue range
- * for use as a categorical scale
+ * create a standard color palette from the entire
+ * available hue range for use as a categorical scale
  * @param {number} count number of colors
  * @returns {array} color palette
  */
-const colors = count => {
+const standardColors = count => {
 	if (!count || count === 1) {
 		return [defaultColor]
 	}
@@ -54,6 +58,20 @@ const colors = count => {
 	const b = swatch.slice(midpoint)
 	const ordered = d3.zip(a, b).flat()
 	return ordered
+}
+
+/**
+ * generate a categorical color scale
+ * @param {object} s Vega Lite specification
+ * @param {number} count number of colors
+ */
+const colors = (s, count) => {
+	const variant = extension(s, 'color')?.variant
+	if (variant) {
+		return accessibleColors(count, variant)
+	} else {
+		return standardColors(count)
+	}
 }
 
 export { colors }

--- a/source/color.js
+++ b/source/color.js
@@ -9,6 +9,12 @@ const defaultColor = 'steelblue'
  */
 const alternateLuminance = (color, index) => color[index % 2 ? 'brighter' : 'darker']()
 
+const stops = {
+	deuteranopia: ['#e1daae', '#ff934f', '#cc2d35', '#058ed9', '#2d3142'],
+	protanopia: ['#e8f086', '#6fde6e', '#ff4242', '#a691ae', '#235fa4'],
+	tritanopia: ['#dd4444', '#f48080', '#ffdcdc', '#2d676f', '#194b4f']
+}
+
 /**
  * create a color palette from the available hue range
  * for use as a categorical scale

--- a/source/color.js
+++ b/source/color.js
@@ -32,7 +32,7 @@ const accessibleColors = (count, variant) => {
 	const values = Array.from({ length: count }).map((_, index) => {
 		return interpolator(index * step)
 	})
-	return values
+	return values.map(d3.color).map(alternateLuminance)
 }
 
 /**

--- a/source/color.js
+++ b/source/color.js
@@ -61,6 +61,23 @@ const standardColors = count => {
 }
 
 /**
+ * alternate colors
+ * @param {string[]} colors color palette
+ * @returns {string[]} alternating color palette
+ */
+const alternate = colors => {
+	if (colors.length === 1) {
+		return colors
+	}
+	const count = colors.length
+	const midpoint = Math.floor(count * 0.5)
+	const a = colors.slice(0, midpoint)
+	const b = colors.slice(midpoint)
+	const ordered = d3.zip(a, b).flat()
+	return ordered
+}
+
+/**
  * generate a categorical color scale
  * @param {object} s Vega Lite specification
  * @param {number} count number of colors
@@ -68,9 +85,9 @@ const standardColors = count => {
 const colors = (s, count) => {
 	const variant = extension(s, 'color')?.variant
 	if (variant) {
-		return accessibleColors(count, variant)
+		return alternate(accessibleColors(count, variant))
 	} else {
-		return standardColors(count)
+		return alternate(standardColors(count))
 	}
 }
 

--- a/source/color.js
+++ b/source/color.js
@@ -16,6 +16,22 @@ const stops = {
 }
 
 /**
+ * generate a palette of accessible colors for use
+ * as a categorical scale
+ * @param {number} count number of colors
+ * @param {string} variant palette variant
+ * @returns {string[]} color palette
+ */
+const accessibleColors = (count, variant) => {
+	const interpolator = d3.piecewise(d3.interpolateRgb.gamma(2.2), stops[variant])
+	const step = 1 / count
+	const values = Array.from({ length: count }).map((_, index) => {
+		return interpolator(index * step)
+	})
+	return values
+}
+
+/**
  * create a color palette from the available hue range
  * for use as a categorical scale
  * @param {number} count number of colors

--- a/source/scales.js
+++ b/source/scales.js
@@ -244,7 +244,7 @@ const range = (s, dimensions, _channel) => {
 
 			return (
 				s.encoding.color?.scale?.range ||
-        colors((customDomain(s, channel) || colorRangeProcessor(s)).length)
+        colors(s, (customDomain(s, channel) || colorRangeProcessor(s)).length)
 			)
 		},
 		theta: () => [0, Math.PI * 2]
@@ -300,7 +300,7 @@ const coreScales = (s, dimensions) => {
 		})
 
 	if (!scales.color && !feature(s).isMulticolor()) {
-		scales.color = () => colors(1).pop()
+		scales.color = () => colors(s, 1).pop()
 	}
 
 	return scales

--- a/tests/unit/color-test.js
+++ b/tests/unit/color-test.js
@@ -18,4 +18,13 @@ module('unit > color', () => {
 		const { color } = parseScales(s)
 		assert.equal(color(), newColor)
 	})
+	test('generates accessible color palettes', assert => {
+		const range = s => parseScales(s).color.range().join(' ')
+		const standard = range(specificationFixture('circular'));
+		['tritanopia', 'deuteranopia', 'protanopia'].forEach(variant => {
+			const s = specificationFixture('circular')
+			s.usermeta = { color: { variant } }
+			assert.notEqual(range(s), standard, variant)
+		})
+	})
 })


### PR DESCRIPTION
Adds alternate categorical color palettes which are more readable for users with different kinds of color vision deficiencies.

To invoke, specify the kind of color blindness using the [`usermeta` property](https://vega.github.io/vega-lite/docs/spec.html#top-level):

```javascript
specification.usermeta.color = { variant: "protanopia"};
```

Color vision deficiencies addressed include:

**protanopia**

<img width="748" alt="protanopia" src="https://user-images.githubusercontent.com/3488572/210453532-3a8447ab-34bb-41af-90de-2fa7283ecb20.png">

**deuteranopia**

<img width="748" alt="deuteranopia" src="https://user-images.githubusercontent.com/3488572/210453557-6249d652-aec1-458c-b577-2835a17e4c3f.png">

**tritanopia**

<img width="748" alt="tritanopia" src="https://user-images.githubusercontent.com/3488572/210453509-1336fd5d-a4f5-48b8-9784-acfd8fc9d59b.png">

It took me a long time to figure out how to approach this problem!

Canned color palettes that work well for each of these conditions are easy enough to find, but static palettes will work only for the specific number of colors or data categories provided. If your color palette has five colors but you have ten data categories, you're out of luck. Even if you have more color palettes than categories, it's still a problem because you won't be using the available perceptual space effectively, and will end up with colors that appear to be clustered together and consequently are hard to read – not ideal when you want it to work for users who already have vision issues.

A more straightforward approach to this would involve tricky vision modeling. After pondering it for a while, though, I realized that I didn't really need to do all that and could instead generate them naively! The color logic can operate at the data level so it doesn't actually need to understand how the underlying biology works.

Start with a discrete color palette:

```javascript
// discrete color palette for protanopia
['#e8f086', '#6fde6e', '#ff4242', '#a691ae', '#235fa4']
```

Trusting that these color stops are equidistant across the target spectrum, you can then use a `d3.piecewise()` interpolator from the [`d3-interpolate`](https://github.com/d3/d3-interpolate) package to create a continuous gradient, and that will largely follow whatever perceptual curves are implicit in the original discrete palette.

This means appropriately spaced intermediate color values become available for an infinite number of additional points. Then all you have to do is sample from the interpolator to retrieve the quantity of points you actually need from the generated spectrum. It never matters what the spectrum is under the hood.

This then means you can start with five discrete points and sample any number of stops from the spectrum, including more than five. The example images above have ten data categories, but alternate color palettes will be generated effectively for any number of data categories.

It creates an algorithm out of the absence of an algorithm!