### PR TITLE
add type declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export function chart(s: object, panelDimensions: object): Function;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/vijithassar/bisonica.git"
   },
+  "types": "index.d.ts",
   "scripts": {
     "build": "esbuild --bundle --format=esm --external:d3 --outfile=build/bisonica.js source/chart.js",
     "postbuild": "yarn run archive",


### PR DESCRIPTION
Generate type declaration files with `tsc --declaration`, then add the type signature for the `chart()` function to `index.d.ts`. This makes type information for the public interface available to TypeScript consumers. Prior to this, type checking was only used internally.