### PR TITLE
allow local time zone for axis tick formatting

### DIFF
--- a/source/time.js
+++ b/source/time.js
@@ -1,5 +1,5 @@
 import * as d3 from 'd3'
-import { encodingChannelCovariateCartesian, encodingValue } from './encodings.js'
+import { encodingChannelCovariateCartesian, encodingType, encodingValue } from './encodings.js'
 import { memoize } from './memoize.js'
 import { feature } from './feature.js'
 import { barWidth } from './marks.js'
@@ -140,9 +140,9 @@ const defaultTimeFormatter = date => date.toUTCString()
  * @returns {function} date string formatting function
  */
 const _getTimeFormatter = (s, channel) => {
+	const type = encodingType(s, channel)
 	const format = s.encoding?.[channel]?.axis?.format
-
-	if (format) {
+	if (type === 'temporal' && format) {
 		return d3.utcFormat(format)
 	}
 

--- a/source/time.js
+++ b/source/time.js
@@ -142,8 +142,14 @@ const defaultTimeFormatter = date => date.toUTCString()
 const _getTimeFormatter = (s, channel) => {
 	const type = encodingType(s, channel)
 	const format = s.encoding?.[channel]?.axis?.format
+	const timeUnit = s.encoding?.[channel]?.timeUnit
+	const utc = !!timeUnit?.startsWith('utc')
 	if (type === 'temporal' && format) {
-		return d3.utcFormat(format)
+		if (utc) {
+			return d3.utcFormat(format)
+		} else {
+			return d3.timeFormat(format)
+		}
 	}
 
 	return defaultTimeFormatter


### PR DESCRIPTION
Allow specifications to use the local time zone when formatting text for axis ticks instead of always assuming UTC.