### PR TITLE
description list format language

### DIFF
--- a/source/legend.js
+++ b/source/legend.js
@@ -31,6 +31,21 @@ function createLegendItem(config) {
 }
 
 /**
+ * format legend content as a readable string
+ * @param {string[]|number[]} items domain
+ * @returns {string} domain with string formatting
+ */
+const list = items => {
+	if (items.length === 1) {
+		return `${items[0]}`
+	} else {
+		const rest = items.slice(0, -1)
+		const last = items.slice().pop()
+		return `${rest.join(', ')} and ${last}`
+	}
+}
+
+/**
  * look up the title of the legend
  * @param {object} s Vega Lite specification
  * @returns {string} legend title
@@ -50,7 +65,7 @@ const legendDescription = s => {
 		return description
 	}
 	const domain = parseScales(s).color.domain()
-	return `${mark(s)} legend titled '${legendTitle(s)}' with ${domain.length} values: ${domain.join(', ')}`
+	return `${mark(s)} legend titled '${legendTitle(s)}' with ${domain.length} values: ${list(domain)}`
 }
 
 /**


### PR DESCRIPTION
Following the example set by the standard [`vega-lite.js`](https://vega.github.io/vega-lite/) renderer, the domain values are turned into a comma separated list ("apple, banana, cantaloupe") by [`Array.prototype.join`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join) when [adding the description to the legend](https://github.com/vijithassar/bisonica/pull/217). This constitutes a mildly unpleasant experience for users who access the legend through a screen reader, for whom we can improve things by adding a small string formatting function to insert the word "and" before the final item ("apple, banana, and cantaloupe"). Doing so makes the text more intuitive when it is read aloud.