### PR TITLE
specify values for legend

### DIFF
--- a/source/legend.js
+++ b/source/legend.js
@@ -134,14 +134,15 @@ const color = _s => {
 
 			let target = main
 
-			const items = color.domain().map((label, index) => {
-				const itemConfig = {
-					group: label,
-					color: color.range()[index]
-				}
+			const items = color.domain()
+				.map((label, index) => {
+					const itemConfig = {
+						group: label,
+						color: color.range()[index]
+					}
 
-				return createLegendItem(itemConfig)
-			})
+					return createLegendItem(itemConfig)
+				})
 
 			target.node().append(...items)
 

--- a/source/legend.js
+++ b/source/legend.js
@@ -135,6 +135,9 @@ const color = _s => {
 			let target = main
 
 			const items = color.domain()
+				.filter(item => {
+					return s.encoding.color?.legend?.values ? s.encoding.color.legend.values.includes(item) : true
+				})
 				.map((label, index) => {
 					const itemConfig = {
 						group: label,


### PR DESCRIPTION
Allows the specification to provide a list of data values which will be used in the legend using [`legend.values`](https://vega.github.io/vega-lite/docs/legend.html#properties). Other values found in the data set will still be plotted but they won't get a corresponding entry in the legend. It's usually a better idea to filter the data more thoroughly upstream so both the plotting area and the legend are simplified, but in some cases it can be useful to continue to render all the noisy data as context and only restrict the legend content.