### PR TITLE
detach axis rendering

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -2,7 +2,7 @@ import * as d3 from 'd3'
 
 import { axisTickLabelText, rotation } from './text.js'
 import { barWidth } from './marks.js'
-import { degrees, isDiscrete, noop } from './helpers.js'
+import { degrees, detach, isDiscrete, noop } from './helpers.js'
 import { encodingChannelCovariate, encodingChannelQuantitative, encodingType } from './encodings.js'
 import { feature } from './feature.js'
 import { layerMatch } from './views.js'
@@ -344,11 +344,11 @@ const axes = (_s, dimensions) => {
 		const axes = selection.select('g.axes')
 
 		if (feature(s).hasEncodingY()) {
-			axes.select('.y').call(createY(s, dimensions))
+			axes.select('.y').call(detach(createY(s, dimensions)))
 		}
 
 		if (feature(s).hasEncodingX()) {
-			axes.select('.x').call(createX(s, dimensions))
+			axes.select('.x').call(detach(createX(s, dimensions)))
 		}
 
 		selection.call(postAxisRender(s, dimensions))

--- a/source/axes.js
+++ b/source/axes.js
@@ -255,11 +255,19 @@ const axisTitleY = (s, dimensions) => {
 				.attr('transform', `rotate(270 ${yTitlePosition.x} ${yTitlePosition.y})`)
 				.text(title(s, 'y'))
 		}
+	}
+}
 
-		// extend y axis ticks across the whole chart
+/**
+ * extend ticks across the chart
+ * @param {object} s Vega Lite specification
+ * @param {object} dimensions chart dimensions
+ */
+const axisTicksY = (s, dimensions) => {
+	return selection => {
 		if ((feature(s).isBar() || feature(s).isLine()) && encodingChannelQuantitative(s) === 'y' && feature(s).hasEncodingX()) {
 			const offset = feature(s).isTemporalBar() && encodingType(s, 'x') === 'temporal' ? barWidth(s, dimensions) : 0
-			const tickEnd = parseScales(s).x.range()[1] + offset
+			const tickEnd = parseScales(s, dimensions).x.range()[1] + offset
 			selection
 				.select('.y .axis')
 				.selectAll('.tick')
@@ -279,6 +287,18 @@ const axisTitles = (s, dimensions) => {
 	return selection => {
 		selection.select('.y').call(axisTitleY(s, dimensions))
 		selection.select('.x').call(axisTitleX(s, dimensions))
+	}
+}
+
+/**
+ * adjust axis ticks based on a live DOM node
+ * @param {object} s Vega Lite specification
+ * @param {object} dimensions chart dimensions
+ * @returns {function(object)} axis tick adjustment function
+ */
+const axisTicks = (s, dimensions) => {
+	return selection => {
+		selection.select('.y').call(axisTicksY(s, dimensions))
 	}
 }
 
@@ -319,6 +339,7 @@ const axes = (_s, dimensions) => {
 
 		if (feature(s).hasAxis()) {
 			selection.select('.axes').call(axisTitles(s, dimensions))
+			selection.select('.axes').call(axisTicks(s, dimensions))
 		}
 	}
 

--- a/source/axes.js
+++ b/source/axes.js
@@ -123,16 +123,16 @@ const createX = (s, dimensions) => {
 		const x = selection.select('g.x').attr('class', 'x')
 		const classes = ['axis', encodingType(s, 'x'), rotation(s, 'x') ? 'angled' : ''].join(' ')
 
-		const xAxis = x
+		const xAxis = selection
 			.append('g')
 			.attr('class', classes)
 			.classed(encodingType(s, 'x'), true)
 
 		xAxis.call(axis)
-		x.call(tickText(s, 'x'))
+		selection.call(tickText(s, 'x'))
 
 		const shift = feature(s).isBar() && encodingType(s, 'x') === 'temporal'
-		x.attr('transform', () => {
+		selection.attr('transform', () => {
 			const bar = feature(s).isBar() ? barWidth(s, dimensions) : 0
 			const xOffset = shift ? bar * 0.5 : 0
 			let yOffset
@@ -187,11 +187,10 @@ const createY = (s, dimensions) => {
 
 		axis.ticks(ticks(s, 'y'))
 
-		const y = selection.select('g.y')
-		const yAxis = y.append('g').classed('axis', true).classed(encodingType(s, 'y'), true)
+		const yAxis = selection.append('g').classed('axis', true).classed(encodingType(s, 'y'), true)
 
 		yAxis.call(axis).select('.domain').attr('stroke-width', 0)
-		y.call(tickText(s, 'y'))
+		selection.call(tickText(s, 'y'))
 
 		const angle = degrees(rotation(s, 'y'))
 
@@ -331,11 +330,11 @@ const axes = (_s, dimensions) => {
 		const axes = selection.select('g.axes')
 
 		if (feature(s).hasEncodingY()) {
-			axes.call(createY(s, dimensions))
+			axes.select('.y').call(createY(s, dimensions))
 		}
 
 		if (feature(s).hasEncodingX()) {
-			axes.call(createX(s, dimensions))
+			axes.select('.x').call(createX(s, dimensions))
 		}
 
 		if (feature(s).hasAxis()) {

--- a/source/axes.js
+++ b/source/axes.js
@@ -302,6 +302,21 @@ const axisTicks = (s, dimensions) => {
 }
 
 /**
+ * run functions that require a live DOM node
+ * @param {object} s Vega Lite specification
+ * @param {object} dimensions chart dimensions
+ * @returns {function(object)} axis adjustment function
+ */
+const postAxisRender = (s, dimensions) => {
+	return selection => {
+		if (feature(s).hasAxis()) {
+			selection.select('.axes').call(axisTitles(s, dimensions))
+			selection.select('.axes').call(axisTicks(s, dimensions))
+		}
+	}
+}
+
+/**
  * render chart axes
  * @param {object} _s Vega Lite specification
  * @param {object} dimensions chart dimensions
@@ -336,10 +351,7 @@ const axes = (_s, dimensions) => {
 			axes.select('.x').call(createX(s, dimensions))
 		}
 
-		if (feature(s).hasAxis()) {
-			selection.select('.axes').call(axisTitles(s, dimensions))
-			selection.select('.axes').call(axisTicks(s, dimensions))
-		}
+		selection.call(postAxisRender(s, dimensions))
 	}
 
 	return renderer

--- a/source/axes.js
+++ b/source/axes.js
@@ -97,12 +97,12 @@ const tickText = (s, channel) => {
 }
 
 /**
- * render x axis
+ * create x axis
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} x axis renderer
+ * @returns {function(object)} x axis creator
  */
-const x = (s, dimensions) => {
+const createX = (s, dimensions) => {
 	if (!feature(s).hasAxisX()) {
 		return noop
 	}
@@ -186,12 +186,12 @@ const x = (s, dimensions) => {
 }
 
 /**
- * render y axis
+ * create y axis
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} y axis renderer
+ * @returns {function(object)} y axis creator
  */
-const y = (s, dimensions) => {
+const createY = (s, dimensions) => {
 	if (!feature(s).hasAxisY()) {
 		return noop
 	}
@@ -277,11 +277,11 @@ const axes = (_s, dimensions) => {
 		const axes = selection.select('g.axes')
 
 		if (feature(s).hasEncodingY()) {
-			axes.call(y(s, dimensions))
+			axes.call(createY(s, dimensions))
 		}
 
 		if (feature(s).hasEncodingX()) {
-			axes.call(x(s, dimensions))
+			axes.call(createX(s, dimensions))
 		}
 	}
 

--- a/source/axes.js
+++ b/source/axes.js
@@ -262,8 +262,9 @@ const axisTitleY = (s, dimensions) => {
  * extend ticks across the chart
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
+ * @returns {function(object)} y axis tick extension adjustment function
  */
-const axisTicksY = (s, dimensions) => {
+const axisTicksExtensionY = (s, dimensions) => {
 	return selection => {
 		if ((feature(s).isBar() || feature(s).isLine()) && encodingChannelQuantitative(s) === 'y' && feature(s).hasEncodingX()) {
 			const offset = feature(s).isTemporalBar() && encodingType(s, 'x') === 'temporal' ? barWidth(s, dimensions) : 0
@@ -298,7 +299,7 @@ const axisTitles = (s, dimensions) => {
  */
 const axisTicks = (s, dimensions) => {
 	return selection => {
-		selection.select('.y').call(axisTicksY(s, dimensions))
+		selection.select('.y').call(axisTicksExtensionY(s, dimensions))
 	}
 }
 

--- a/source/axes.js
+++ b/source/axes.js
@@ -14,6 +14,7 @@ import { timeMethod, timePeriod } from './time.js'
  * tick count specifier
  * @param {object} s Vega Lite specification
  * @param {string} channel encoding channel
+ * @returns {number|function} tick count
  */
 const ticks = (s, channel) => {
 	const tickCount = s.encoding[channel].axis?.tickCount
@@ -81,7 +82,7 @@ const title = (s, channel) => {
  * render axis tick text content
  * @param {object} s Vega Lite specification
  * @param {'x'|'y'} channel encoding channel
- * @returns {function} tick text renderer
+ * @returns {function(object)} tick text renderer
  */
 const tickText = (s, channel) => {
 	return selection => {
@@ -355,7 +356,7 @@ const postAxisRender = (s, dimensions) => {
  * render chart axes
  * @param {object} _s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} renderer
+ * @returns {function(object)} renderer
  */
 const axes = (_s, dimensions) => {
 	const test = s => {

--- a/source/axes.js
+++ b/source/axes.js
@@ -120,7 +120,6 @@ const createX = (s, dimensions) => {
 			axis.tickSize(0)
 		}
 
-		const x = selection.select('g.x').attr('class', 'x')
 		const classes = ['axis', encodingType(s, 'x'), rotation(s, 'x') ? 'angled' : ''].join(' ')
 
 		const xAxis = selection


### PR DESCRIPTION
Increase performance by rendering axes into detached nodes in memory before attaching to the live chart node.

Depending on the input specification and the exact circumstances, axis rendering can sometimes be a performance sink relative to rendering the chart data, particularly when there are a lot of ticks and not a lot of marks, and thus most of the DOM node weight is in the axes.

However, detaching requires adding a _significant_ amount of new structure to the axis module, because some operations related to axis rendering will always fundamentally require live DOM nodes to measure. Those bits need to be retained but factored out into dedicated functions which are then run as part of a sort of "life cycle" stage at the end, once the otherwise-detached render has completed. The resulting performance improvement is frankly much more modest than I'd hoped while working this up, and this change introduces _quite_ a lot of additional code and complexity, so it may make sense to mash it all back together at some point if this doesn't ultimately pay off. For the time being, the additional functions are certainly more organized albeit less intuitive, and will hopefully open up more paths forward in the future.