### PR TITLE
additional explicit scales

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -26,17 +26,14 @@ const syntheticScale = (scale, domain, range) => {
  * parse scale types which have been explicitly specified
  * @param {object} s Vega Lite specification
  * @param {string} channel encoding parameter
- * @returns {'scaleSymlog'|null}
+ * @returns {string|null}
  */
 const explicitScale = (s, channel) => {
 	if (s.encoding[channel]?.scale === null) {
 		return null
-	}
-	if (
-		s.encoding[channel]?.scale?.type === 'symlog' &&
-    encodingType(s, channel) === 'quantitative'
-	) {
-		return 'scaleSymlog'
+	} else {
+		const type = s.encoding[channel]?.scale.type
+		return `scale${type.slice(0, 1).toUpperCase() + type.slice(1)}`
 	}
 }
 

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -357,4 +357,30 @@ module('unit > scales', hooks => {
 			'symmetric log scales should handle zero'
 		)
 	})
+
+	module('explicit scales', () => {
+		const scales = [
+			'sqrt',
+			'pow',
+			'linear',
+			'log',
+			'symlog',
+			'time',
+			'utc',
+			'ordinal',
+			'band',
+			'point',
+			'quantile',
+			'quantize',
+			'threshold'
+		]
+		scales.forEach(scale => {
+			test(`${scale} scale`, assert => {
+				const s = specificationFixture('line')
+				s.encoding.y.scale = { type: scale }
+				const { y } = parseScales(s)
+				assert.equal(typeof y, 'function', `generates d3 scale function for ${scale} scale type`)
+			})
+		})
+	})
 })


### PR DESCRIPTION
Support for symmetric log scales was introduced in [pull request 57](https://github.com/vijithassar/bisonica/pull/57/), and then in [pull request 74](https://github.com/vijithassar/bisonica/pull/74/) that was restructured into a separate `explicitScale()` function to make it clearer when all the elegant encoding and data type logic was being skipped due to the `encoding.scale.type` instruction. However, `explicitScale()` still only handled symmetric log scales – the literal string `scaleSymlog` was in the return type.

This pull request finally makes the function abstraction actually-abstract, so it can now handle a whole bunch of different D3 scale types and presumably use them during chart rendering. Tests ensure that the scale function is successfully created from the Vega Lite JSON, but after that the specific behaviors of those scales aren't yet tested so for now they should be used with a drop of caution.