### PR TITLE
default encoding types

### DIFF
--- a/source/encodings.js
+++ b/source/encodings.js
@@ -161,7 +161,7 @@ const encodingChannelCovariate = s => {
 		)
 
 		if (covariate.length !== 1) {
-			throw new Error('could not identify independent variable')
+			throw new Error(`could not identify independent variable between ${covariate.join(', ')}`)
 		}
 
 		return covariate.pop()[0]

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -55,7 +55,7 @@ const encodingValue = (s, channel) => {
  * @returns {string} visual encoding channel
  */
 const encodingChannelQuantitative = s => {
-	const test = (channel, definition) => definition.type === 'quantitative'
+	const test = channel => encodingType(s, channel) === 'quantitative'
 
 	return encodingTest(s, test)
 }
@@ -155,10 +155,12 @@ const encodingChannelCovariate = s => {
 	if ((feature(s).isCircular() || feature(s).isLinear()) && feature(s).hasColor()) {
 		return 'color'
 	} else if (feature(s).isCartesian()) {
-		const covariate = Object.entries(s.encoding).filter(
-			([channel, definition]) =>
-				channel !== 'color' && definition.type && definition.type !== 'quantitative'
-		)
+		const filter = channel => {
+			return isTextChannel(channel) === false &&
+				channel !== 'color' &&
+				encodingType(s, channel) !== 'quantitative'
+		}
+		const covariate = Object.keys(s.encoding).filter(filter)
 
 		if (covariate.length !== 1) {
 			throw new Error(`could not identify independent variable between ${covariate.join(', ')}`)

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -3,7 +3,7 @@ import { memoize } from './memoize.js'
 import { isTemporalScale, isOrdinalScale, isQuantitativeScale, parseScales } from './scales.js'
 import { parseTime } from './time.js'
 import { transform } from './transform.js'
-import { nested } from './helpers.js'
+import { isTextChannel, nested } from './helpers.js'
 
 /**
  * look up the field used for a visual encoding

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -154,6 +154,15 @@ const isDiscrete = (s, channel) => {
 }
 
 /**
+ * determine whether a given channel is text based
+ * @param {string} channel encoding parameter
+ * @returns {boolean} whether the field is text based
+ */
+const isTextChannel = channel => {
+	return ['href', 'text', 'tooltip', 'description', 'url'].includes(channel)
+}
+
+/**
  * convert polar coordinates to Cartesian
  * @param {number} radius radius
  * @param {number} angle angle in radians
@@ -198,6 +207,7 @@ export {
 	degrees,
 	isContinuous,
 	isDiscrete,
+	isTextChannel,
 	polarToCartesian,
 	detach
 }

--- a/source/scales.js
+++ b/source/scales.js
@@ -375,6 +375,39 @@ const _parseScales = (s, dimensions = defaultDimensions) => {
 }
 
 /**
+ * determine whether an encoding uses a time scale
+ * @param {object} s Vega Lite specification
+ * @param {string} channel encoding channel
+ * @returns {boolean}
+ */
+const isTemporalScale = (s, channel) => {
+	const scale = s.encoding[channel].scale?.type
+	return ['time', 'utc'].includes(scale)
+}
+
+/**
+ * determine whether an encoding uses an ordinal scale
+ * @param {object} s Vega Lite specification
+ * @param {string} channel encoding channel
+ * @returns {boolean}
+ */
+const isOrdinalScale = (s, channel) => {
+	const scale = s.encoding[channel].scale?.type
+	return ['ordinal', 'point', 'band'].includes(scale)
+}
+
+/**
+ * determine whether an encoding uses an ordinal scale
+ * @param {object} s Vega Lite specification
+ * @param {string} channel encoding channel
+ * @returns {boolean}
+ */
+const isQuantitativeScale = (s, channel) => {
+	const scale = s.encoding[channel].scale?.type
+	return ['linear', 'pow', 'sqrt', 'symlog', 'log'].includes(scale)
+}
+
+/**
  * generate all scale functions necessary to render a s
  * @param {object} s Vega Lite specification
  * @param {object} [dimensions] chart dimensions
@@ -382,4 +415,4 @@ const _parseScales = (s, dimensions = defaultDimensions) => {
  */
 const parseScales = memoize(_parseScales)
 
-export { colors, parseScales }
+export { colors, isTemporalScale, isOrdinalScale, isQuantitativeScale, parseScales }

--- a/source/scales.js
+++ b/source/scales.js
@@ -3,7 +3,7 @@ import { data, sumByCovariates } from './data.js'
 import { colors } from './color.js'
 import { encodingChannelQuantitative, encodingType, encodingValue } from './encodings.js'
 import { feature } from './feature.js'
-import { identity, isDiscrete, values } from './helpers.js'
+import { identity, isDiscrete, isTextChannel, values } from './helpers.js'
 import { memoize } from './memoize.js'
 import { parseTime, temporalBarDimensions } from './time.js'
 import { sorter } from './sort.js'
@@ -91,15 +91,6 @@ const customDomain = (s, channel) => {
 			return domain
 		}
 	}
-}
-
-/**
- * determine whether a given channel is text based
- * @param {string} channel encoding parameter
- * @returns {boolean} whether the field is text based
- */
-const isTextChannel = channel => {
-	return ['href', 'text', 'tooltip', 'description', 'url'].includes(channel)
 }
 
 /**

--- a/tests/unit/encodings-test.js
+++ b/tests/unit/encodings-test.js
@@ -10,7 +10,8 @@ import { data } from '../../source/data.js'
 import { dimensions } from './support.js'
 import qunit from 'qunit'
 import { parseTime } from '../../source/time.js'
-import { specificationFixture } from '../test-helpers.js'
+import { render, specificationFixture } from '../test-helpers.js'
+import { chart } from '../../source/chart.js'
 
 const { module, test } = qunit
 
@@ -235,6 +236,14 @@ module('unit > encoders', () => {
 				const s = { encoding: { x: { datum: { year: 2000 } } } }
 				assert.equal(encodingType(s, 'x'), 'temporal')
 			})
+		})
+		test('successfully creates charts with default encoding types', assert => {
+			const s = specificationFixture('circular')
+			delete s.encoding.color.type
+			delete s.encoding.theta.type
+			s.encoding.theta.scale = { type: 'linear' }
+			assert.equal(typeof chart(s), 'function', 'generates a chart function from default encoding types')
+			assert.equal(render(s).querySelectorAll('.chart').length, 1, 'chart function with default encoding types does not throw error')
 		})
 	})
 })

--- a/tests/unit/encodings-test.js
+++ b/tests/unit/encodings-test.js
@@ -168,4 +168,73 @@ module('unit > encoders', () => {
 
 		assert.ok(getValue(target), 1)
 	})
+
+	module('default encoding types', () => {
+		module('nominal', () => {
+			test('field property', assert => {
+				const s = { encoding: { x: { field: 'a' } } }
+				assert.equal(encodingType(s, 'x'), 'nominal')
+			})
+		})
+		module('quantitative', () => {
+			test('aggregate property', assert => {
+				const s = { encoding: { x: { aggregate: 'a' } } }
+				assert.equal(encodingType(s, 'x'), 'quantitative')
+			})
+			test('argmin aggregate', assert => {
+				const s = { encoding: { x: { aggregate: 'argmin' } } }
+				assert.notEqual(encodingType(s, 'x'), 'quantitative')
+			})
+			test('argmax aggregate', assert => {
+				const s = { encoding: { x: { aggregate: 'argmax' } } }
+				assert.notEqual(encodingType(s, 'x'), 'quantitative')
+			})
+			test('bin property', assert => {
+				const s = { encoding: { x: { bin: 'a' } } }
+				assert.equal(encodingType(s, 'x'), 'quantitative')
+			})
+			test('quantitative scale', assert => {
+				const s = { encoding: { x: { scale: { type: 'linear' } } } }
+				assert.equal(encodingType(s, 'x'), 'quantitative')
+			})
+		})
+		module('temporal', () => {
+			test('timeUnit property', assert => {
+				const s = { encoding: { x: { timeUnit: 'a' } } }
+				assert.equal(encodingType(s, 'x'), 'temporal')
+			})
+			test('temporal scale', assert => {
+				const s = { encoding: { x: { scale: { type: 'utc' } } } }
+				assert.equal(encodingType(s, 'x'), 'temporal')
+			})
+		})
+		module('ordinal', () => {
+			test('sort property', assert => {
+				const s = { encoding: { x: { sort: 'a' } } }
+				assert.equal(encodingType(s, 'x'), 'ordinal')
+			})
+			test('order encoding field', assert => {
+				const s = { encoding: { x: { field: 'order' } } }
+				assert.equal(encodingType(s, 'x'), 'ordinal')
+			})
+			test('ordinal scale', assert => {
+				const s = { encoding: { x: { scale: { type: 'ordinal' } } } }
+				assert.equal(encodingType(s, 'x'), 'ordinal')
+			})
+		})
+		module('datum encoding', () => {
+			test('number implies quantitative encoding', assert => {
+				const s = { encoding: { x: { datum: 1 } } }
+				assert.equal(encodingType(s, 'x'), 'quantitative')
+			})
+			test('string implies nominal encoding', assert => {
+				const s = { encoding: { x: { datum: 'a' } } }
+				assert.equal(encodingType(s, 'x'), 'nominal')
+			})
+			test('datetime object implies temporal encoding', assert => {
+				const s = { encoding: { x: { datum: { year: 2000 } } } }
+				assert.equal(encodingType(s, 'x'), 'temporal')
+			})
+		})
+	})
 })


### PR DESCRIPTION
Implements the [encoding type defaults](https://vega.github.io/vega-lite/docs/type.html), thereby adding support for more concise specification objects which can intuit the encoding type based on other characteristics of the JSON instead of always requiring a `channel.type` property.