### PR TITLE
encoding type property access cleanup

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -1,5 +1,5 @@
 import { layoutDirection } from './marks.js'
-import { encodingChannelCovariateCartesian, encodingChannelQuantitative, encodingValue } from './encodings.js'
+import { encodingChannelCovariateCartesian, encodingChannelQuantitative, encodingType, encodingValue } from './encodings.js'
 import { feature } from './feature.js'
 import { mark } from './helpers.js'
 import { memoize } from './memoize.js'
@@ -99,8 +99,8 @@ const _createAccessors = (s, type = null) => {
 		}
 	})
 
-	Object.entries(s.encoding).forEach(([channel, encoding]) => {
-		if (encoding?.type === 'temporal') {
+	Object.keys(s.encoding).forEach(channel => {
+		if (encodingType(s, channel) === 'temporal') {
 			const originalAccessor = accessors[channel]
 
 			accessors[channel] = d => parseTime(originalAccessor(d))

--- a/source/axes.js
+++ b/source/axes.js
@@ -363,7 +363,7 @@ const axes = (_s, dimensions) => {
 		if (feature(_s).hasLayers()) {
 			return s
 		} else {
-			return s.encoding?.x?.type && s.encoding?.y?.type
+			return s.encoding?.x && s.encoding?.y
 		}
 	}
 	let s = layerMatch(_s, test)

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -10,11 +10,8 @@ import { extension } from './extensions.js'
 const delimiter = '; '
 
 const quantitativeChannels = s => {
-	const result = Object.entries(s.encoding)
-		.filter(([_, definition]) => {
-			return definition.type === 'quantitative'
-		})
-		.map(([channel]) => channel)
+	const result = Object.keys(s.encoding)
+		.filter(channel => encodingType(s, channel) === 'quantitative')
 	return result
 }
 

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3'
 import { datum } from './helpers.js'
-import { encodingField, encodingValue, encodingChannelQuantitative, encodingChannelCovariateCartesian } from './encodings.js'
+import { encodingField, encodingType, encodingValue, encodingChannelQuantitative, encodingChannelCovariateCartesian } from './encodings.js'
 import { memoize } from './memoize.js'
 import { getTooltipField, tooltipContent } from './tooltips.js'
 import { data } from './data.js'

--- a/source/feature.js
+++ b/source/feature.js
@@ -1,4 +1,4 @@
-import { encodingValue } from './encodings.js'
+import { encodingType, encodingValue } from './encodings.js'
 import { layerTestRecursive } from './views.js'
 import { mark, values } from './helpers.js'
 import { memoize } from './memoize.js'
@@ -21,7 +21,7 @@ const _feature = s => {
 	const isMulticolor = layerTestRecursive(s, multicolorTest)
 
 	const temporalTest = s => {
-		return Object.values(s.encoding || {}).some(encoding => encoding.type === 'temporal')
+		return Object.keys(s.encoding || {}).some(channel => encodingType(s, channel) === 'temporal')
 	}
 	const isTemporal = layerTestRecursive(s, temporalTest)
 

--- a/source/marks.js
+++ b/source/marks.js
@@ -159,9 +159,9 @@ const markInteractionSelector = _s => {
  * @param {object} s Vega Lite specification
  */
 const layoutDirection = s => {
-	if (s.encoding.x?.type === 'quantitative') {
+	if (encodingType(s, 'x') === 'quantitative') {
 		return 'horizontal'
-	} else if (s.encoding.y?.type === 'quantitative') {
+	} else if (encodingType(s, 'y') === 'quantitative') {
 		return 'vertical'
 	}
 }
@@ -530,7 +530,7 @@ const lineMarks = (s, dimensions) => {
 	const renderer = selection => {
 		const marks = selection.append('g').attr('class', 'marks')
 		const markTransforms = ['x', 'y'].map(channel => {
-			const offset = ['nominal', 'ordinal'].includes(s.encoding[channel].type)
+			const offset = ['nominal', 'ordinal'].includes(encodingType(s, channel))
 
 			if (offset) {
 				const scale = parseScales(s, dimensions)[channel]

--- a/source/scales.js
+++ b/source/scales.js
@@ -265,9 +265,9 @@ const coreScales = (s, dimensions) => {
 		}
 	})
 
-	Object.entries(s.encoding)
-		.filter(([channel]) => !isTextChannel(channel) && !scales[channel])
-		.forEach(([channel]) => {
+	Object.keys(s.encoding)
+		.filter(channel => !isTextChannel(channel) && !scales[channel])
+		.forEach(channel => {
 			try {
 				const method = scaleMethod(s, channelRoot(s, channel))
 				if (method === null) {


### PR DESCRIPTION
This is a follow up to [pull request 233](https://github.com/vijithassar/bisonica/pull/233), which added the ability to intuit default values for encoding types. With that feature now in place, it's now prudent to also clean up the rest of the library and remove any cases of direct access to the `.type` property, because every lookup creates a potential point of failure when the chart is relying on those defaults.