### PR TITLE
axis title text truncation

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3'
 
-import { axisTickLabelText, rotation } from './text.js'
+import { axisTickLabelText, rotation, truncate } from './text.js'
 import { barWidth } from './marks.js'
 import { degrees, detach, isDiscrete, noop } from './helpers.js'
 import { encodingChannelCovariate, encodingChannelQuantitative, encodingType } from './encodings.js'
@@ -74,8 +74,19 @@ const ticks = (s, channel) => {
  */
 const title = (s, channel) => {
 	const encoding = s.encoding[channel]
-
 	return encoding.axis?.title || encoding.field
+}
+
+/**
+ * retrieve axis title and possibly truncate
+ * @param {object} s Vega Lite specification
+ * @param {'x'|'y'} channel encoding channel
+ * @returns {string} title text, potentially truncated
+ */
+const titleText = (s, channel) => {
+	const limit = s.encoding[channel].axis?.titleLimit
+	const text = title(s, channel)
+	return limit ? truncate(text, limit) : text
 }
 
 /**
@@ -213,7 +224,7 @@ const axisTitleX = (s, dimensions) => {
 					return yPosition
 				})
 				.attr('transform', `translate(0,${axisOffsetY(s, dimensions).y})`)
-				.text(title(s, 'x'))
+				.text(titleText(s, 'x'))
 		}
 	}
 }
@@ -240,7 +251,7 @@ const axisTitleY = (s, dimensions) => {
 				.attr('x', yTitlePosition.x)
 				.attr('y', yTitlePosition.y)
 				.attr('transform', `rotate(270 ${yTitlePosition.x} ${yTitlePosition.y})`)
-				.text(title(s, 'y'))
+				.text(titleText(s, 'y'))
 		}
 	}
 }

--- a/source/text.js
+++ b/source/text.js
@@ -10,6 +10,8 @@ import { isContinuous, isDiscrete } from './helpers.js'
 const canvas = document.createElement('canvas')
 const context = canvas.getContext('2d')
 
+const maxWidth = 180
+
 const defaultStyles = {}
 
 /**
@@ -113,28 +115,25 @@ const rotation = (s, channel) => (s.encoding?.[channel]?.axis?.labelAngle * Math
  * so it's particularly helpful to be able to memoize
  * all the arguments at once.
  *
- * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
  * @param {string} text text to truncate
+ * @param {number} limit maximum width
  * @param {object} [styles] styles to incorporate when measuring text width
  * @returns {string} truncated string
  */
-const _truncate = (s, channel, text, styles = defaultStyles) => {
-	const max = 180
-
-	let limit = d3.min([s.encoding[channel].axis?.labelLimit, max])
-
+const _truncate = (text, limit, styles = defaultStyles) => {
 	if (limit === 0) {
 		return text
 	}
+	let change = false
 
 	let substring = text
 
 	while (measureText(`${substring}…`, styles) > limit && substring.length > 0) {
+		change = true
 		substring = substring.slice(0, -1)
 	}
 
-	const suffix = substring.length < text.length ? '…' : ''
+	const suffix = change ? '…' : ''
 
 	return `${substring}${suffix}`
 }
@@ -155,7 +154,9 @@ const _axisTickLabelTextContent = (s, channel, textContent, styles = defaultStyl
 
 	text = abbreviate(s, channel)(text)
 
-	text = truncate(s, channel, text, styles)
+	const limit = d3.min([s.encoding[channel].axis?.labelLimit, maxWidth])
+
+	text = truncate(text, limit, styles)
 
 	return text
 }

--- a/tests/unit/axes-test.js
+++ b/tests/unit/axes-test.js
@@ -52,19 +52,8 @@ module('unit > axes', () => {
 		assert.equal(format(s, 'y')(value), '1', 'casts numbers to strings')
 	})
 	test('truncates axis tick label text', assert => {
-		const s = {
-			encoding: {
-				x: {
-					field: 'label',
-					type: 'nominal',
-					axis: {
-						labelLimit: 15
-					}
-				}
-			}
-		}
 		const text = 'aaaaaaaaaaaaaaaaaaaaaaaaaa'
-		const truncated = truncate(s, 'x', text, [])
+		const truncated = truncate(text, 15, [])
 
 		assert.ok(truncated.length < text.length, 'truncated text is shorter than original text')
 		assert.ok(truncated.endsWith('…'), 'truncated text ends with ellipsis')


### PR DESCRIPTION
Generalizes the text truncation function used for `axis.labelLimit`, then reuses it to implement truncation of axis title text based on [`axis.titleLimit`](https://vega.github.io/vega-lite/docs/axis.html#title).