### PR TITLE
rename tick functions

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3'
 
-import { axisTickLabelText, rotation, truncate } from './text.js'
+import { axisTicksLabelText, rotation, truncate } from './text.js'
 import { barWidth } from './marks.js'
 import { degrees, detach, isDiscrete, noop } from './helpers.js'
 import { encodingChannelCovariate, encodingChannelQuantitative, encodingType } from './encodings.js'
@@ -102,7 +102,7 @@ const tickText = (s, channel) => {
 		const ticks = selection.selectAll('.tick').select('text')
 
 		if (hasLabels) {
-			ticks.call(axisTickLabelText(s, channel))
+			ticks.call(axisTicksLabelText(s, channel))
 		} else {
 			ticks.text('')
 		}
@@ -349,10 +349,10 @@ const axisTicks = (s, dimensions) => {
 			.call(axisTicksExtensionY(s, dimensions))
 		selection.selectAll('.x .tick')
 			.call(axisTicksRotationX(s, dimensions))
-			.call(axisTickStyles(s, 'x'))
+			.call(axisTicksStyles(s, 'x'))
 		selection.selectAll('.y .tick')
 			.call(axisTicksRotationY(s, dimensions))
-			.call(axisTickStyles(s, 'y'))
+			.call(axisTicksStyles(s, 'y'))
 	}
 }
 
@@ -385,7 +385,7 @@ const tickStyles = {
  * @param {string} channel encoding channel
  * @returns {function(object)} tick style rendering function
  */
-const axisTickStyles = (s, channel) => renderStyles(tickStyles, s.encoding[channel].axis)
+const axisTicksStyles = (s, channel) => renderStyles(tickStyles, s.encoding[channel].axis)
 
 /**
  * run functions that require a live DOM node

--- a/source/text.js
+++ b/source/text.js
@@ -147,7 +147,7 @@ const truncate = memoize(_truncate)
  * @param {object} [styles] styles to incorporate when measuring text width
  * @returns {string} text processing function
  */
-const _axisTickLabelTextContent = (s, channel, textContent, styles = defaultStyles) => {
+const _axisTicksLabelTextContent = (s, channel, textContent, styles = defaultStyles) => {
 	let text = textContent
 
 	text = format(s, channel)(text)
@@ -160,7 +160,7 @@ const _axisTickLabelTextContent = (s, channel, textContent, styles = defaultStyl
 
 	return text
 }
-const axisTickLabelTextContent = memoize(_axisTickLabelTextContent)
+const axisTicksLabelTextContent = memoize(_axisTicksLabelTextContent)
 
 /**
  * compute margin values based on chart type
@@ -172,7 +172,7 @@ const _longestAxisTickLabelTextWidth = s => {
 
 	const channels = ['x', 'y']
 	const tickLabels = channels.map(channel => {
-		const processText = tick => axisTickLabelTextContent(s, channel, tick)
+		const processText = tick => axisTicksLabelTextContent(s, channel, tick)
 
 		if (isContinuous(s, channel)) {
 			return scales[channel].ticks(ticks(s, channel)).map(processText)
@@ -204,7 +204,7 @@ const longestAxisTickLabelTextWidth = memoize(_longestAxisTickLabelTextWidth)
  * @param {'x'|'y'} channel encoding channel
  * @returns {function} text processing function
  */
-const axisTickLabelText = (s, channel) => {
+const axisTicksLabelText = (s, channel) => {
 	let styles = {}
 
 	return selection => {
@@ -216,7 +216,7 @@ const axisTickLabelText = (s, channel) => {
 			styles[channel] = fontStyles(node)
 		}
 
-		selection.text(label => axisTickLabelTextContent(s, channel, label, styles[channel]))
+		selection.text(label => axisTicksLabelTextContent(s, channel, label, styles[channel]))
 	}
 }
 
@@ -225,7 +225,7 @@ export {
 	rotation,
 	format,
 	truncate,
-	axisTickLabelTextContent,
-	axisTickLabelText,
+	axisTicksLabelTextContent,
+	axisTicksLabelText,
 	longestAxisTickLabelTextWidth
 }


### PR DESCRIPTION
Consistently refer to plural ticks in function names.