### PR TITLE
data module cleanup

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -245,11 +245,11 @@ const pointData = values
 const genericData = values
 
 /**
- * wrapper function around data preprocessing functionality
+ * wrapper function around chart-specific data preprocessing functionality
  * @param {object} s Vega Lite specification
  * @returns {array} sorted and aggregated data
  */
-const data = s => {
+const chartData = s => {
 	if (feature(s).isBar() || feature(s).isArea()) {
 		return stackData(s)
 	} else if (feature(s).isLine()) {
@@ -260,5 +260,15 @@ const data = s => {
 		return genericData(s)
 	}
 }
+
+/**
+ * wrapper function around data preprocessing functionality
+ * @param {object} s Vega Lite specification
+ * @returns {array} sorted and aggregated data
+ */
+const _data = s => {
+	return chartData(s)
+}
+const data = memoize(_data)
 
 export { data, pointData, sumByCovariates }

--- a/source/data.js
+++ b/source/data.js
@@ -169,7 +169,7 @@ const stackData = s => {
 		})
 	}
 
-	return metadata(s, sort(stacked))
+	return sort(stacked)
 }
 
 /**
@@ -187,7 +187,7 @@ const circularData = s => {
 		return { key, value: d3.sum(values, encodingValue(s, 'theta')) }
 	})
 
-	return metadata(s, summed)
+	return summed
 }
 
 /**
@@ -221,7 +221,7 @@ const lineData = s => {
 		}
 	})
 
-	return metadata(s, results)
+	return results
 }
 
 /**
@@ -261,7 +261,7 @@ const chartData = s => {
  * @returns {array} sorted and aggregated data
  */
 const _data = s => {
-	return chartData(s)
+	return metadata(s, chartData(s))
 }
 const data = memoize(_data)
 

--- a/source/data.js
+++ b/source/data.js
@@ -132,7 +132,13 @@ const sort = data => {
  */
 const stackValue = (d, key) => d[key]?.value || 0
 
-const _stackData = s => {
+/**
+ * reorganize data from specification into array
+ * of values used to render a stacked bar chart
+ * @param {object} s Vega Lite specification
+ * @returns {array} stacked data series
+ */
+const stackData = s => {
 	const covariate = encodingField(s, encodingChannelCovariateCartesian(s))
 	const quantitative = encodingField(s, encodingChannelQuantitative(s))
 	const group = encodingField(s, 'color')
@@ -167,14 +173,12 @@ const _stackData = s => {
 }
 
 /**
- * reorganize data from specification into array
- * of values used to render a stacked bar chart
+ * reorganize data from specification into totals
+ * used to render a circular chart
  * @param {object} s Vega Lite specification
- * @returns {array} stacked data series
+ * @returns {array} totals by group
  */
-const stackData = memoize(_stackData)
-
-const _circularData = s => {
+const circularData = s => {
 	const grouped = Array.from(d3.group(values(s), encodingValue(s, 'color'))).map(
 		([key, values]) => ({ key, values })
 	)
@@ -187,14 +191,12 @@ const _circularData = s => {
 }
 
 /**
- * reorganize data from specification into totals
- * used to render a circular chart
+ * reorganize data from a specification into
+ * array of values used to render a line chart.
  * @param {object} s Vega Lite specification
- * @returns {array} totals by group
+ * @returns {array} summed values for line chart
  */
-const circularData = memoize(_circularData)
-
-const _lineData = s => {
+const lineData = s => {
 	const quantitative = encodingField(s, encodingChannelQuantitative(s))
 	const covariate = encodingField(s, encodingChannelCovariateCartesian(s)) || missingSeries()
 	const color = encodingField(s, 'color')
@@ -221,14 +223,6 @@ const _lineData = s => {
 
 	return metadata(s, results)
 }
-
-/**
- * reorganize data from a specification into
- * array of values used to render a line chart.
- * @param {object} s Vega Lite specification
- * @returns {array} summed values for line chart
- */
-const lineData = memoize(_lineData)
 
 /**
  * retrieve data points used for point marks

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -241,10 +241,10 @@ const transplantFields = (s, aggregated, raw) => {
  * @returns {object[]} aggregated data with metadata
  */
 const metadata = (s, data) => {
-	if (!hasMetadata(s)) {
+	const aggregate = feature(s).isBar() || feature(s).isArea() || feature(s).isCircular() || feature(s).isLine()
+	if (!hasMetadata(s) || !aggregate) {
 		return data
 	}
-	const aggregate = feature(s).isBar() || feature(s).isArea() || feature(s).isCircular() || feature(s).isLine()
 	if (aggregate) {
 		return transplantFields(s, data, values(s))
 	}


### PR DESCRIPTION
Adds a new outer wrapper function for data preprocessing and then moves the [metadata handling](https://github.com/vijithassar/bisonica/pull/123) and memoization out to that layer so they are no longer intertwined with the chart-specific functionality.