### PR TITLE
linting unused variables and arguments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
             "smart-tabs"
         ],
         "arrow-parens": ["error", "as-needed"],
-        "no-return-assign": "off"
+        "no-return-assign": "off",
+        "no-unused-vars": ["error", {"destructuredArrayIgnorePattern": "^_"}]
     }
 }

--- a/source/axes.js
+++ b/source/axes.js
@@ -307,10 +307,9 @@ const axisTicksRotationY = (s, dimensions) => {
 /**
  * adjust y axis tick rotation based on a live DOM node
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
  * @returns {function(object)} x axis tick rotation adjustment function
  */
-const axisTicksRotationX = (s, dimensions) => {
+const axisTicksRotationX = s => {
 	return selection => {
 		const angle = degrees(rotation(s, 'x'))
 
@@ -352,7 +351,7 @@ const axisTicks = (s, dimensions) => {
 		selection.selectAll('.y .tick')
 			.call(axisTicksExtensionY(s, dimensions))
 		selection.selectAll('.x .tick')
-			.call(axisTicksRotationX(s, dimensions))
+			.call(axisTicksRotationX(s))
 			.call(axisTicksStyles(s, 'x'))
 		selection.selectAll('.y .tick')
 			.call(axisTicksRotationY(s, dimensions))

--- a/source/table.js
+++ b/source/table.js
@@ -107,7 +107,7 @@ const tableOptions = s => {
  * @param {object} _s Vega Lite specification
  * @returns {function(object)} table renderer
  */
-const table = (_s, options) => {
+const table = (_s, options) => { // eslint-disable-line no-unused-vars
 	const s = layerPrimary(_s)
 	if (extension(s, 'table') === null) {
 		return noop


### PR DESCRIPTION
A few small fixes to linting behavior related to ESLint's [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) rule.