### PR TITLE
predicates and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Data must be supplied [inline](https://vega.github.io/vega-lite/docs/data.html#i
 
 Nested fields must be looked up using dot notation (e.g. `datum.field`), not bracket notation (e.g. `datum['field']`).
 
+[Predicates](https://vega.github.io/vega-lite/docs/predicate.html) do not support expressions.
+
 Escaping special characters in field names is not supported. Instead, you should mutate your data before rendering to clean up the affected field names.
 
 Advanced Vega Lite features like [`facet`](https://vega.github.io/vega-lite/docs/composition.html#faceting) and [`parameters`](https://vega.github.io/vega-lite/docs/parameter.html) are not yet available.

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -2,7 +2,7 @@ import { feature } from './feature.js'
 import { memoize } from './memoize.js'
 import { isTemporalScale, isOrdinalScale, isQuantitativeScale, parseScales } from './scales.js'
 import { parseTime } from './time.js'
-import { transform } from './transform.js'
+import { transformDatum } from './transform.js'
 import { isTextChannel, nested } from './helpers.js'
 
 /**
@@ -44,7 +44,7 @@ const encodingValue = (s, channel) => {
 		}
 
 		if (s.transform) {
-			return transform(s)(d)[key]
+			return transformDatum(s)(d)[key]
 		}
 	}
 }

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -2,6 +2,8 @@ import * as d3 from 'd3'
 
 import { encodingField, encodingType, encodingValue } from './encodings.js'
 import { feature } from './feature.js'
+import { transformValues } from './transform.js'
+import { memoize } from './memoize.js'
 
 /**
  * round number based on significant digits
@@ -23,9 +25,10 @@ const abbreviateNumbers = number => {
  * @param {object} s Vega Lite specification
  * @returns {array}
  */
-const values = s => {
-	return s.data?.values.slice()
+const _values = s => {
+	return transformValues(s)(s.data?.values.slice())
 }
+const values = memoize(_values)
 
 /**
  * return the original data object if it has been nested

--- a/source/predicate.js
+++ b/source/predicate.js
@@ -1,0 +1,87 @@
+import { memoize } from './memoize.js'
+
+const value = (config, datum) => datum[config.field]
+
+/**
+ * equal to predicate
+ * @param {object} config predicate definition
+ * @returns {function(object)} filter predicate
+ */
+const equal = config => datum => value(config, datum) === config.equal
+
+/**
+ * less than predicate
+ * @param {object} config predicate definition
+ * @returns {function(object)} filter predicate
+ */
+const lt = config => datum => value(config, datum) < config.lt
+
+/**
+ * less than or equal to predicate
+ * @param {object} config predicate definition
+ * @returns {function(object)} filter predicate
+ */
+const lte = config => datum => value(config, datum) <= config.lte
+
+/**
+ * greater than predicate
+ * @param {object} config predicate definition
+ * @returns {function(object)} filter predicate
+ */
+const gt = config => datum => value(config, datum) > config.gt
+
+/**
+ * greater than or equal to predicate
+ * @param {object} config predicate definition
+ * @returns {function(object)} filter predicate
+ */
+const gte = config => datum => value(config, datum) >= config.gte
+
+/**
+ * range predicate
+ * @param {object} config predicate definition
+ * @returns {function(object)} filter predicate
+ */
+const range = config => datum => value(config, datum) >= config.range[0] && value(config, datum) <= config.range[1]
+
+/**
+ * oneOf predicate
+ * @param {object} config predicate definition
+ * @returns {function(object)} filter predicate
+ */
+const oneOf = config => datum => config.oneOf.includes(value(config, datum))
+
+/**
+ * valid predicate
+ * @param {object} config predicate definition
+ * @returns {function(object)} filter predicate
+ */
+const valid = config => datum => config.valid ? !Number.isNaN(value(config, datum)) && value(config, datum) !== null : true
+
+const predicates = {
+	equal,
+	lt,
+	lte,
+	gt,
+	gte,
+	range,
+	oneOf,
+	valid
+}
+
+/**
+ * generate a predicate test function
+ * @param {object} config predicate definition
+ * @returns {function(object)} predicate test function
+ */
+const _predicate = config => {
+	const [key, create] = Object.entries(predicates).find(([key]) => config[key])
+	if (typeof create === 'function') {
+		return create(config)
+	} else {
+		throw new Error(`could not create ${key} predicate function for data field ${config.field}`)
+	}
+}
+const predicate = memoize(_predicate)
+
+export { predicate }

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -8,7 +8,7 @@ import { getTimeFormatter } from './time.js'
 import { memoize } from './memoize.js'
 import { noop } from './helpers.js'
 import { parseScales } from './scales.js'
-import { transform } from './transform.js'
+import { transformDatum } from './transform.js'
 
 /**
  * format field description
@@ -148,7 +148,7 @@ const _getTooltipField = (s, type) => {
 
 		if (!key && !value) {
 			key = type // key may be a field, not a channel
-			value = transform(s)()(d)[key]
+			value = transformDatum(s)()(d)[key]
 		}
 
 		return { key, value }

--- a/source/transform.js
+++ b/source/transform.js
@@ -66,12 +66,12 @@ const _composeCalculateTransforms = transforms => {
 const composeCalculateTransforms = memoize(_composeCalculateTransforms)
 
 /**
- * create a function to run transforms on a specification
+ * create a function to run transforms on a single datum
  * @param {object} s Vega Lite specification
- * @returns {function} transform function
+ * @returns {function(object)} transform function for a single datum
  */
-const transform = s => {
+const transformDatum = s => {
 	return composeCalculateTransforms(s.transform)
 }
 
-export { calculate, transform }
+export { calculate, transformDatum }

--- a/source/transform.js
+++ b/source/transform.js
@@ -84,10 +84,14 @@ const filters = s => {
 	const configs = s.transform
 		.filter(transform => transform.filter)
 		.map(item => item.filter)
-	const predicates = configs.map(predicate)
+	const predicates = configs
+		.map(predicate)
+		.map(fn => {
+			return datum => fn(datum) || fn(transformDatum(s)(datum))
+		})
 	return data => {
 		return predicates.reduce((accumulator, current) => {
-			return accumulator.map(transformDatum(s)).filter(current)
+			return accumulator.filter(current)
 		}, data)
 	}
 }

--- a/source/transform.js
+++ b/source/transform.js
@@ -42,12 +42,13 @@ const calculate = expression => {
  * @param {object[]} transforms
  * @returns {function(object)}
  */
-const _composeTransforms = transforms => {
+const _composeCalculateTransforms = transforms => {
+	if (!transforms) {
+		return () => identity
+	}
 	return d => {
-		if (!transforms?.length) {
-			return identity
-		}
 		return transforms
+			.filter(transform => transform.calculate)
 			.reduce((previous, current) => {
 				return {
 					...previous,
@@ -62,7 +63,7 @@ const _composeTransforms = transforms => {
  * @param {array} transforms an array of calculate expressions
  * @returns {function} transform function
  */
-const composeTransforms = memoize(_composeTransforms)
+const composeCalculateTransforms = memoize(_composeCalculateTransforms)
 
 /**
  * create a function to run transforms on a specification
@@ -70,7 +71,7 @@ const composeTransforms = memoize(_composeTransforms)
  * @returns {function} transform function
  */
 const transform = s => {
-	return composeTransforms(s.transform)
+	return composeCalculateTransforms(s.transform)
 }
 
 export { calculate, transform }

--- a/source/transform.js
+++ b/source/transform.js
@@ -47,20 +47,13 @@ const _composeTransforms = transforms => {
 		if (!transforms?.length) {
 			return identity
 		}
-
-		return transforms.reduce(
-			(previous, current) => {
-				if (!current.calculate) {
-					throw new Error('only calculate transforms are currently supported')
-				}
-
+		return transforms
+			.reduce((previous, current) => {
 				return {
 					...previous,
 					[current.as]: calculate(current.calculate)({ ...d })
 				}
-			},
-			{ ...d }
-		)
+			}, { ...d })
 	}
 }
 

--- a/source/transform.js
+++ b/source/transform.js
@@ -87,7 +87,7 @@ const filters = s => {
 	const predicates = configs.map(predicate)
 	return data => {
 		return predicates.reduce((accumulator, current) => {
-			return accumulator.filter(current)
+			return accumulator.map(transformDatum(s)).filter(current)
 		}, data)
 	}
 }

--- a/tests/unit/transform-test.js
+++ b/tests/unit/transform-test.js
@@ -1,7 +1,9 @@
 import {
 	calculate,
-	transformDatum
+	transformDatum,
+	transformValues
 } from '../../source/transform.js'
+import { parseScales } from '../../source/scales.js'
 import { encodingValue } from '../../source/encodings.js'
 import qunit from 'qunit'
 
@@ -20,7 +22,7 @@ module('unit > transform', () => {
 
 			assert.equal(transformDatum(s)({}).a, 'https://www.example.com/test')
 		})
-		test('runs multiple transforms', assert => {
+		test('runs multiple calculate transforms', assert => {
 			const datum = {
 				a: 1,
 				b: 2
@@ -46,8 +48,6 @@ module('unit > transform', () => {
 
 			assert.equal(encodingValue(s, 'x')(s.data.values[0]), 'value: 1')
 		})
-	})
-	module('calculate', () => {
 		test('is a function factory', assert => {
 			assert.equal(typeof calculate, 'function')
 			assert.equal(typeof calculate(expressions.naive), 'function')
@@ -79,6 +79,101 @@ module('unit > transform', () => {
 				calculate("'https://www.example.com' + '/' + datum.a + '/test")({ a: '1' }),
 				'https://www.example.com/1'
 			)
+		})
+	})
+	module('filter', () => {
+		const specification = () => {
+			return { data: { values: [
+				{ x: 1 },
+				{ x: 2 },
+				{ x: 3 },
+				{ x: 4 },
+				{ x: 5 },
+				{ x: 6 },
+				{ x: 7 }
+			] } }
+		}
+		const run = s => {
+			return transformValues(s)(s.data.values)
+				.map(item => item.x)
+				.join(',')
+		}
+		const setup = (s, key, value) => {
+			s.transform = [{ filter: { [key]: value, field: 'x' } }]
+			return s
+		}
+		module('predicates', () => {
+			test('lt', assert => {
+				const s = setup(specification(), 'lt', 5)
+				assert.equal(run(s), '1,2,3,4')
+			})
+			test('lte', assert => {
+				const s = setup(specification(), 'lte', 5)
+				assert.equal(run(s), '1,2,3,4,5')
+			})
+			test('gt', assert => {
+				const s = setup(specification(), 'gt', 5)
+				assert.equal(run(s), '6,7')
+			})
+			test('gte', assert => {
+				const s = setup(specification(), 'gte', 5)
+				assert.equal(run(s), '5,6,7')
+			})
+			test('equal', assert => {
+				const s = setup(specification(), 'equal', 5)
+				assert.equal(run(s), '5')
+			})
+			test('oneOf', assert => {
+				const s = setup(specification(), 'oneOf', [5, 7])
+				assert.equal(run(s), '5,7')
+			})
+			test('range', assert => {
+				const s = setup(specification(), 'range', [3, 5])
+				assert.equal(run(s), '3,4,5')
+			})
+			test('valid', assert => {
+				const s = setup(specification(), 'valid', [3, 5])
+				s.data.values.push({ x: null })
+				assert.equal(run(s), '1,2,3,4,5,6,7')
+			})
+		})
+		module('mechanics', () => {
+			test('applies multiple filters in sequence', assert => {
+				const s = specification()
+				s.transform = [
+					{ filter: { lte: 4, field: 'x' } },
+					{ filter: { oneOf: [1, 2, 3], field: 'x' } },
+					{ filter: { oneOf: [2, 3], field: 'x' } }
+				]
+				assert.equal(run(s), '2,3')
+			})
+			test('filters on multiple fields', assert => {
+				const s = {
+					data: {
+						values: [
+							{ x: 1, _: '$' },
+							{ x: 2, _: '•' },
+							{ x: 3, _: '*' },
+							{ x: 4, _: '•' },
+							{ x: 5, _: '*' },
+							{ x: 6, _: '•' },
+							{ x: 7, _: '$' }
+						]
+					},
+					transform: [
+						{ filter: { lte: 4, field: 'x' } },
+						{ filter: { oneOf: ['•', '*'], field: '_' } }
+					]
+				}
+				assert.equal(run(s), '2,3,4')
+			})
+			test('filters change scale domains', assert => {
+				const s = specificationFixture('line')
+				const max = 8
+				s.transform = [{ filter: { lte: max, field: 'value' } }]
+				const { y } = parseScales(s)
+				assert.equal(y.domain()[1], max)
+			})
 		})
 	})
 })

--- a/tests/unit/transform-test.js
+++ b/tests/unit/transform-test.js
@@ -4,8 +4,10 @@ import {
 	transformValues
 } from '../../source/transform.js'
 import { parseScales } from '../../source/scales.js'
+import { data } from '../../source/data.js'
 import { encodingValue } from '../../source/encodings.js'
 import qunit from 'qunit'
+import { specificationFixture } from '../test-helpers.js'
 
 const { module, test } = qunit
 
@@ -138,6 +140,11 @@ module('unit > transform', () => {
 			})
 		})
 		module('mechanics', () => {
+			test('data functions apply filters', assert => {
+				const s = specificationFixture('circular')
+				s.transform = [{ filter: { field: 'group', oneOf: ['A', 'B', 'C'] } }]
+				assert.equal(data(s).length, 3)
+			})
 			test('applies multiple filters in sequence', assert => {
 				const s = specification()
 				s.transform = [

--- a/tests/unit/transform-test.js
+++ b/tests/unit/transform-test.js
@@ -15,11 +15,6 @@ const expressions = {
 
 module('unit > transform', () => {
 	module('transform', () => {
-		test('requires a calculate transform', assert => {
-			const s = { transform: [{ filter: null }] }
-
-			assert.throws(() => transform(s)({}))
-		})
 		test('adds derived fields to a data point', assert => {
 			const s = { transform: [{ calculate: expressions.naive, as: 'a' }] }
 

--- a/tests/unit/transform-test.js
+++ b/tests/unit/transform-test.js
@@ -174,6 +174,26 @@ module('unit > transform', () => {
 				}
 				assert.equal(run(s), '2,3,4')
 			})
+			test('filters on derived fields created with the calculate transform', assert => {
+				const s = {
+					data: {
+						values: [
+							{ x: 1, _: '$' },
+							{ x: 2, _: '•' },
+							{ x: 3, _: '*' },
+							{ x: 4, _: '•' },
+							{ x: 5, _: '*' },
+							{ x: 6, _: '•' },
+							{ x: 7, _: '$' }
+						]
+					},
+					transform: [
+						{ calculate: "'>' + datum._", as: '__' },
+						{ filter: { oneOf: ['>•', '>*'], field: '__' } }
+					]
+				}
+				assert.equal(run(s), '2,3,4,5,6')
+			})
 			test('filters change scale domains', assert => {
 				const s = specificationFixture('line')
 				const max = 8

--- a/tests/unit/transform-test.js
+++ b/tests/unit/transform-test.js
@@ -1,6 +1,6 @@
 import {
 	calculate,
-	transform
+	transformDatum
 } from '../../source/transform.js'
 import { encodingValue } from '../../source/encodings.js'
 import qunit from 'qunit'
@@ -14,11 +14,11 @@ const expressions = {
 }
 
 module('unit > transform', () => {
-	module('transform', () => {
+	module('calculate', () => {
 		test('adds derived fields to a data point', assert => {
 			const s = { transform: [{ calculate: expressions.naive, as: 'a' }] }
 
-			assert.equal(transform(s)({}).a, 'https://www.example.com/test')
+			assert.equal(transformDatum(s)({}).a, 'https://www.example.com/test')
 		})
 		test('runs multiple transforms', assert => {
 			const datum = {
@@ -33,9 +33,9 @@ module('unit > transform', () => {
 				]
 			}
 
-			assert.equal(transform(s)(datum).c, 'https://www.example.com/test')
-			assert.equal(transform(s)(datum).d, 'https://www.example.com/1')
-			assert.equal(transform(s)(datum).e, 'https://www.example.com/12')
+			assert.equal(transformDatum(s)(datum).c, 'https://www.example.com/test')
+			assert.equal(transformDatum(s)(datum).d, 'https://www.example.com/1')
+			assert.equal(transformDatum(s)(datum).e, 'https://www.example.com/12')
 		})
 		test('falls back to transform lookups', assert => {
 			const s = {


### PR DESCRIPTION
Implements [predicates](https://vega.github.io/vega-lite/docs/predicate.html#one-of-predicate) and then uses the predicates to implement [filter transforms](https://vega.github.io/vega-lite/docs/filter.html). This is logically equivalent to running `specification.data.values.filter()`, but it's all controlled through JSON configuration.