### PR TITLE
transform composition

### DIFF
--- a/tests/unit/transform-test.js
+++ b/tests/unit/transform-test.js
@@ -221,6 +221,26 @@ module('unit > transform', () => {
 				}
 				assert.equal(run(s), '2,3,4,5,6')
 			})
+			test('applies multiple transforms in sequence', assert => {
+				const s = {
+					data: {
+						values: [
+							{ x: 1, _: '$' },
+							{ x: 1, _: '$' },
+							{ x: 2, _: '*' },
+							{ x: 2, _: '*' },
+							{ x: 3, _: '•' },
+							{ x: 3, _: '•' },
+							{ x: 3, _: '•' }
+						]
+					},
+					transform: [
+						{ filter: { equal: 3, field: 'x' } },
+						{ sample: 2 }
+					]
+				}
+				assert.equal(run(s), '3,3')
+			})
 		})
 	})
 })

--- a/tests/unit/transform-test.js
+++ b/tests/unit/transform-test.js
@@ -146,6 +146,32 @@ module('unit > transform', () => {
 				s.transform = [{ filter: { field: 'group', oneOf: ['A', 'B', 'C'] } }]
 				assert.equal(data(s).length, 3)
 			})
+			test('filters change scale domains', assert => {
+				const s = specificationFixture('line')
+				const max = 8
+				s.transform = [{ filter: { lte: max, field: 'value' } }]
+				const { y } = parseScales(s)
+				assert.equal(y.domain()[1], max)
+			})
+		})
+		module('sample', () => {
+			test('randomly samples from data set', assert => {
+				const n = 50
+				const s = {
+					data: {
+						values: d3.range(n * 2).map(item => {
+							return { value: item }
+						})
+					},
+					encoding: {},
+					transform: [
+						{ sample: n }
+					]
+				}
+				assert.equal(data(s).length, n)
+			})
+		})
+		module('composition', () => {
 			test('applies multiple filters in sequence', assert => {
 				const s = specification()
 				s.transform = [
@@ -194,30 +220,6 @@ module('unit > transform', () => {
 					]
 				}
 				assert.equal(run(s), '2,3,4,5,6')
-			})
-			test('filters change scale domains', assert => {
-				const s = specificationFixture('line')
-				const max = 8
-				s.transform = [{ filter: { lte: max, field: 'value' } }]
-				const { y } = parseScales(s)
-				assert.equal(y.domain()[1], max)
-			})
-		})
-		module('sample', () => {
-			test('randomly samples from data set', assert => {
-				const n = 50
-				const s = {
-					data: {
-						values: d3.range(n * 2).map(item => {
-							return { value: item }
-						})
-					},
-					encoding: {},
-					transform: [
-						{ sample: n }
-					]
-				}
-				assert.equal(data(s).length, n)
 			})
 		})
 	})


### PR DESCRIPTION
The behavior of the [sample transform](https://vega.github.io/vega-lite/docs/sample.html) introduced in pull request #252 was not quite spec compliant _when combined_ with the [filter transforms](https://vega.github.io/vega-lite/docs/filter.html) introduced in pull request #251. When there are multiple transforms, the spec [dictates](https://vega.github.io/vega-lite/docs/transform.html) that they should be applied in the order in which they appear in the `specification.transform` array.