### PR TITLE
separate expression module

### DIFF
--- a/source/expression.js
+++ b/source/expression.js
@@ -1,3 +1,5 @@
+const datumPrefix = 'datum.'
+
 /**
  * create a function to perform a single calculate expression
  * @param {string} str a calculate expression describing string interpolation
@@ -8,7 +10,7 @@ const expression = str => {
 		.split('+')
 		.map(item => item.trim())
 		.map(item => {
-			const interpolate = typeof item === 'string' && item.startsWith('datum.')
+			const interpolate = typeof item === 'string' && item.startsWith(datumPrefix)
 			const literal = item.startsWith("'") && item.endsWith("'")
 
 			if (literal) {
@@ -22,8 +24,8 @@ const expression = str => {
 	return d =>
 		segments
 			.map(segment => {
-				if (segment.startsWith('datum.')) {
-					const key = segment.slice(6)
+				if (segment.startsWith(datumPrefix)) {
+					const key = segment.slice(datumPrefix.length)
 
 					return d[key]
 				} else {

--- a/source/expression.js
+++ b/source/expression.js
@@ -1,0 +1,36 @@
+/**
+ * create a function to perform a single calculate expression
+ * @param {string} str a calculate expression describing string interpolation
+ * @returns {function} string interpolation function
+ */
+const expression = str => {
+	const segments = str
+		.split('+')
+		.map(item => item.trim())
+		.map(item => {
+			const interpolate = typeof item === 'string' && item.startsWith('datum.')
+			const literal = item.startsWith("'") && item.endsWith("'")
+
+			if (literal) {
+				return item.slice(1, -1)
+			} else if (interpolate) {
+				return item
+			}
+		})
+		.filter(item => !!item)
+
+	return d =>
+		segments
+			.map(segment => {
+				if (segment.startsWith('datum.')) {
+					const key = segment.slice(6)
+
+					return d[key]
+				} else {
+					return segment
+				}
+			})
+			.join('')
+}
+
+export { expression }

--- a/source/transform.js
+++ b/source/transform.js
@@ -1,42 +1,15 @@
 import { identity } from './helpers.js'
 import { memoize } from './memoize.js'
 import { predicate } from './predicate.js'
+import { expression } from './expression.js'
 import * as d3 from 'd3'
 
 /**
  * create a function to perform a single calculate expression
- * @param {string} expression a calculate expression describing string interpolation
+ * @param {string} str a calculate expression describing string interpolation
  * @returns {function} string interpolation function
  */
-const calculate = str => {
-	const segments = str
-		.split('+')
-		.map(item => item.trim())
-		.map(item => {
-			const interpolate = typeof item === 'string' && item.startsWith('datum.')
-			const literal = item.startsWith("'") && item.endsWith("'")
-
-			if (literal) {
-				return item.slice(1, -1)
-			} else if (interpolate) {
-				return item
-			}
-		})
-		.filter(item => !!item)
-
-	return d =>
-		segments
-			.map(segment => {
-				if (segment.startsWith('datum.')) {
-					const key = segment.slice(6)
-
-					return d[key]
-				} else {
-					return segment
-				}
-			})
-			.join('')
-}
+const calculate = str => expression(str)
 
 /**
  * compose all calculate transforms

--- a/source/transform.js
+++ b/source/transform.js
@@ -8,8 +8,8 @@ import * as d3 from 'd3'
  * @param {string} expression a calculate expression describing string interpolation
  * @returns {function} string interpolation function
  */
-const calculate = expression => {
-	const segments = expression
+const calculate = str => {
+	const segments = str
 		.split('+')
 		.map(item => item.trim())
 		.map(item => {

--- a/tests/unit/expression-test.js
+++ b/tests/unit/expression-test.js
@@ -1,0 +1,22 @@
+import qunit from 'qunit'
+import { expression } from '../../source/expression.js'
+
+const { module, test } = qunit
+
+module('expression', () => {
+	test('interpolates properties', assert => {
+		const exp = "'>-' + datum.a"
+		const datum = { a: '•' }
+		assert.equal(expression(exp)(datum), '>-•')
+	})
+	test('interpolates multiple properties', assert => {
+		const exp = "'>-' + datum.a + '-' + datum.b"
+		const datum = { a: '•', b: '*' }
+		assert.equal(expression(exp)(datum), '>-•-*')
+	})
+	test('omits malformed string interpolations', assert => {
+		const exp = "'>' + '-' + datum.a + '-*"
+		const datum = { a: '•' }
+		assert.equal(expression(exp)(datum), '>-•')
+	})
+})

--- a/tests/unit/transform-test.js
+++ b/tests/unit/transform-test.js
@@ -65,24 +65,6 @@ module('unit > transform', () => {
 		test('returns a string', assert => {
 			assert.equal(calculate(expressions.naive)({}), 'https://www.example.com/test')
 		})
-		test('interpolates properties', assert => {
-			assert.equal(
-				calculate(expressions.interpolate)({ a: 'test' }),
-				'https://www.example.com/test'
-			)
-		})
-		test('interpolates multiple properties', assert => {
-			assert.equal(
-				calculate(expressions.multiple)({ a: '1', b: '2' }),
-				'https://www.example.com/12'
-			)
-		})
-		test('omits malformed string interpolations', assert => {
-			assert.equal(
-				calculate("'https://www.example.com' + '/' + datum.a + '/test")({ a: '1' }),
-				'https://www.example.com/1'
-			)
-		})
 	})
 	module('filter', () => {
 		const specification = () => {


### PR DESCRIPTION
Support for [expressions](https://vega.github.io/vega/docs/expressions/) remains limited, but they should be stored in a separate module rather than conflated with [transforms](https://vega.github.io/vega-lite/docs/calculate.html) now that additional transforms beyond `calculate` have been introduced in pull requests #251 and #252.