### PR TITLE
improve tick formatting

### DIFF
--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -14,7 +14,7 @@ import { feature } from './feature.js'
 import { extension } from './extensions.js'
 import { axisTitle } from './axes.js'
 import { scaleType, parseScales } from './scales.js'
-import { getTimeFormatter } from './time.js'
+import { formatAxis } from './format.js'
 import { list } from './text.js'
 
 const delimiter = '; '
@@ -227,7 +227,7 @@ const chartLabel = s => {
  */
 const axisValuesText = (s, channel) => {
 	const values = parseScales(s)[channel].domain()
-	const formatter = encodingType(s, channel) === 'temporal' ? getTimeFormatter(s, channel) : identity
+	const formatter = encodingType(s, channel) === 'temporal' ? formatAxis(s, channel) : identity
 	if (isContinuous(s, channel)) {
 		return `with values from ${d3.extent(values).map(formatter).join(' to ')}`
 	} else {

--- a/source/format.js
+++ b/source/format.js
@@ -1,5 +1,5 @@
 import { memoize } from './memoize.js'
-import { identity } from './helpers.js'
+import { identity, noop } from './helpers.js'
 import { encodingType } from './encodings.js'
 
 import * as d3 from 'd3'
@@ -81,6 +81,9 @@ const formatChannel = (s, channel) => {
  */
 const formatAxis = (s, channel) => {
 	const config = s.encoding[channel].axis
+	if (config === null) {
+		return noop
+	}
 	// sidestep the format() wrapper function in cases where
 	// the time encoding is specified at the channel level
 	// instead of with axis.type

--- a/source/format.js
+++ b/source/format.js
@@ -1,5 +1,7 @@
 import { memoize } from './memoize.js'
 import { identity } from './helpers.js'
+import { encodingType } from './encodings.js'
+
 import * as d3 from 'd3'
 
 /**
@@ -61,4 +63,31 @@ const _format = config => {
 }
 const format = memoize(_format)
 
-export { format }
+/**
+ * get formatting function for an encoding channel
+ * @param {object} s Vega Lite specification
+ * @param {'text'|'tooltip'} channel encoding channel
+ */
+const formatChannel = (s, channel) => {
+	return format(s.encoding[channel])
+}
+
+/**
+ * get formatting function for an axis, and fall back
+ * to the encoding channel definition if necessary
+ * @param {object} s Vega Lite specification
+ * @param {string} channel encoding channel
+ */
+const formatAxis = (s, channel) => {
+	const config = s.encoding[channel].axis
+	// sidestep the format() wrapper function in cases where
+	// the time encoding is specified at the channel level
+	// instead of with axis.type
+	if (encodingType(s, channel) === 'temporal' && !config.formatType) {
+		return timeFormat(config)
+	} else {
+		return format(config)
+	}
+}
+
+export { format, formatChannel, formatAxis }

--- a/source/format.js
+++ b/source/format.js
@@ -84,6 +84,9 @@ const formatAxis = (s, channel) => {
 	if (config === null) {
 		return noop
 	}
+	if (config === undefined) {
+		return identity
+	}
 	// sidestep the format() wrapper function in cases where
 	// the time encoding is specified at the channel level
 	// instead of with axis.type

--- a/source/format.js
+++ b/source/format.js
@@ -3,6 +3,42 @@ import { identity } from './helpers.js'
 import * as d3 from 'd3'
 
 /**
+ * create a time formatting function
+ * @param {object} config encoding or axis definition object
+ * @returns {function(Date)} date formatting function
+ */
+const timeFormat = config => {
+	if (!config?.format) {
+		return date => date.toString()
+	}
+	return d3.timeFormat(config.format)
+}
+
+/**
+ * create a time formatting function in UTC
+ * @param {object} config encoding or axis definition object
+ * @returns {function(Date)} UTC date formatting function
+ */
+const utcFormat = config => {
+	if (!config?.format) {
+		return date => date.toUTCString()
+	}
+	return d3.utcFormat(config.format)
+}
+
+/**
+ * create a number formatting function
+ * @param {object} config encoding or axis definition object
+ * @returns {function(number)} number formatting function
+ */
+const numberFormat = config => {
+	if (!config?.format) {
+		return number => number.toString()
+	}
+	return d3.format(config.format)
+}
+
+/**
  * create a formatting function
  * @param {object} config encoding or axis definition object
  * @returns {function(string|number|Date)} formatting function
@@ -13,9 +49,14 @@ const _format = config => {
 	}
 	const time = config.type === 'temporal' || config.formatType === 'time' || config.timeUnit
 	if (time) {
-		return d3.timeFormat(config.format)
+		const utc = !!config.timeUnit?.startsWith('utc')
+		if (utc) {
+			return utcFormat(config)
+		} else {
+			return timeFormat(config)
+		}
 	} else {
-		return d3.format(config.format)
+		return numberFormat(config)
 	}
 }
 const format = memoize(_format)

--- a/source/format.js
+++ b/source/format.js
@@ -1,0 +1,23 @@
+import { memoize } from './memoize.js'
+import { identity } from './helpers.js'
+import * as d3 from 'd3'
+
+/**
+ * create a formatting function
+ * @param {object} config encoding or axis definition object
+ * @returns {function(string|number|Date)} formatting function
+ */
+const _format = config => {
+	if (!config || (!config.format && !config.axis?.format)) {
+		return identity
+	}
+	const time = config.type === 'temporal' || config.formatType === 'time' || config.timeUnit
+	if (time) {
+		return d3.timeFormat(config.format)
+	} else {
+		return d3.format(config.format)
+	}
+}
+const format = memoize(_format)
+
+export { format }

--- a/source/format.js
+++ b/source/format.js
@@ -6,38 +6,38 @@ import * as d3 from 'd3'
 
 /**
  * create a time formatting function
- * @param {object} config encoding or axis definition object
+ * @param {object|undefined} format d3 time format string
  * @returns {function(Date)} date formatting function
  */
-const timeFormat = config => {
-	if (!config?.format) {
+const timeFormat = format => {
+	if (!format) {
 		return date => date.toString()
 	}
-	return d3.timeFormat(config.format)
+	return d3.timeFormat(format)
 }
 
 /**
  * create a time formatting function in UTC
- * @param {object} config encoding or axis definition object
+ * @param {object|undefined} format d3 time format string
  * @returns {function(Date)} UTC date formatting function
  */
-const utcFormat = config => {
-	if (!config?.format) {
+const utcFormat = format => {
+	if (!format) {
 		return date => date.toUTCString()
 	}
-	return d3.utcFormat(config.format)
+	return d3.utcFormat(format)
 }
 
 /**
  * create a number formatting function
- * @param {object} config encoding or axis definition object
+ * @param {object|undefined} format d3 number format string
  * @returns {function(number)} number formatting function
  */
-const numberFormat = config => {
-	if (!config?.format) {
+const numberFormat = format => {
+	if (!format) {
 		return number => number.toString()
 	}
-	return d3.format(config.format)
+	return d3.format(format)
 }
 
 /**
@@ -50,15 +50,16 @@ const _format = config => {
 		return identity
 	}
 	const time = config.type === 'temporal' || config.formatType === 'time' || config.timeUnit
+	const format = config.format || config.axis.format
 	if (time) {
 		const utc = !!config.timeUnit?.startsWith('utc')
 		if (utc) {
-			return utcFormat(config)
+			return utcFormat(format)
 		} else {
-			return timeFormat(config)
+			return timeFormat(format)
 		}
 	} else {
-		return numberFormat(config)
+		return numberFormat(format)
 	}
 }
 const format = memoize(_format)
@@ -84,7 +85,7 @@ const formatAxis = (s, channel) => {
 	// the time encoding is specified at the channel level
 	// instead of with axis.type
 	if (encodingType(s, channel) === 'temporal' && !config.formatType) {
-		return timeFormat(config)
+		return timeFormat(config.format)
 	} else {
 		return format(config)
 	}

--- a/source/text.js
+++ b/source/text.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3'
 import { MINIMUM_TICK_COUNT } from './config.js'
 import { encodingType } from './encodings.js'
-import { getTimeFormatter } from './time.js'
+import { formatAxis } from './format.js'
 import { memoize } from './memoize.js'
 import { parseScales } from './scales.js'
 import { ticks } from './axes.js'
@@ -95,7 +95,7 @@ const abbreviate = memoize(_abbreviate)
  * @returns {function} formatting function
  */
 const format = (s, channel) => {
-	const formatter = encodingType(s, channel) === 'temporal' ? getTimeFormatter(s, channel) : label => label.toString()
+	const formatter = encodingType(s, channel) === 'temporal' ? formatAxis(s, channel) : label => label.toString()
 
 	return text => formatter(text)
 }
@@ -150,7 +150,7 @@ const truncate = memoize(_truncate)
 const _axisTicksLabelTextContent = (s, channel, textContent, styles = defaultStyles) => {
 	let text = textContent
 
-	text = format(s, channel)(text)
+	text = formatAxis(s, channel)(text)
 
 	text = abbreviate(s, channel)(text)
 

--- a/source/time.js
+++ b/source/time.js
@@ -1,5 +1,5 @@
 import * as d3 from 'd3'
-import { encodingChannelCovariateCartesian, encodingType, encodingValue } from './encodings.js'
+import { encodingChannelCovariateCartesian, encodingValue } from './encodings.js'
 import { memoize } from './memoize.js'
 import { feature } from './feature.js'
 import { barWidth } from './marks.js'
@@ -127,36 +127,6 @@ const timePeriod = (s, channel) => {
 }
 
 /**
- * default date format
- * @param {object} date Date object
- * @returns {string} string representation
- */
-const defaultTimeFormatter = date => date.toUTCString()
-
-/**
- * string key for controlling date functionality
- * @param {object} s Vega Lite specification
- * @param {string} channel temporal channel
- * @returns {function} date string formatting function
- */
-const _getTimeFormatter = (s, channel) => {
-	const type = encodingType(s, channel)
-	const format = s.encoding?.[channel]?.axis?.format
-	const timeUnit = s.encoding?.[channel]?.timeUnit
-	const utc = !!timeUnit?.startsWith('utc')
-	if (type === 'temporal' && format) {
-		if (utc) {
-			return d3.utcFormat(format)
-		} else {
-			return d3.timeFormat(format)
-		}
-	}
-
-	return defaultTimeFormatter
-}
-const getTimeFormatter = memoize(_getTimeFormatter)
-
-/**
  * alter dimensions object to subtract the bar width
  * for a temporal bar chart
  * @param {object} s Vega Lite specification
@@ -172,4 +142,4 @@ const temporalBarDimensions = (s, dimensions) => {
 	}
 }
 
-export { getTimeParser, parseTime, timePeriod, getTimeFormatter, timeMethod, temporalBarDimensions }
+export { getTimeParser, parseTime, timePeriod, timeMethod, temporalBarDimensions }

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -4,7 +4,7 @@ import { category } from './marks.js'
 import { createAccessors } from './accessors.js'
 import { encodingChannelQuantitative, encodingField, encodingType, encodingValue } from './encodings.js'
 import { feature } from './feature.js'
-import { getTimeFormatter } from './time.js'
+import { formatAxis } from './format.js'
 import { memoize } from './memoize.js'
 import { noop } from './helpers.js'
 import { parseScales } from './scales.js'
@@ -143,7 +143,7 @@ const _getTooltipField = (s, type) => {
 		}
 
 		if (encodingType(s, channel) === 'temporal') {
-			value = getTimeFormatter(s, channel)(value)
+			value = formatAxis(s, channel)(value)
 		}
 
 		if (!key && !value) {

--- a/tests/unit/format-test.js
+++ b/tests/unit/format-test.js
@@ -1,0 +1,36 @@
+import { format } from '../../source/format.js'
+import qunit from 'qunit'
+
+const { module, test } = qunit
+
+const date = new Date(2000, 1, 1)
+const number = 1000
+
+module('format', () => {
+	module('types', () => {
+		test('number', assert => {
+			const config = {
+				format: '~s',
+				formatType: 'number'
+			}
+			assert.equal(format(config)(number), '1k')
+		})
+		test('time', assert => {
+			const config = {
+				format: '%Y',
+				formatType: 'time'
+			}
+			assert.equal(format(config)(date), '2000')
+		})
+	})
+	module('contexts', () => {
+		test('channel definition', assert => {
+			const channel = { field: 'x', type: 'temporal', format: '%Y' }
+			assert.equal(format(channel)(date), '2000')
+		})
+		test('axis definition', assert => {
+			const channel = { field: 'x', type: 'temporal', axis: { format: '%Y' } }
+			assert.equal(format(channel)(date), '2000')
+		})
+	})
+})


### PR DESCRIPTION
Axis tick formatting was only ever half implemented, even after pull request #216 added local time zones, because it only handled timestamp formatting with [`d3-time-format`](https://github.com/d3/d3-time-format) – formatting of normal numbers with [`d3-format`](https://github.com/d3/d3-format) was omitted entirely. This pull request more thoroughly implements Vega Lite's [`format`](https://vega.github.io/vega-lite/docs/format.html) instruction.