### PR TITLE
datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ On the other hand, the standard `vega-lite.js` renderer is definitely still the 
 
 bisonica is still a work in progress and as such supports only a subset of Vega Lite functionality. The supported chart forms are listed in [`source/marks.js`](./source/marks.js).
 
-Data must be supplied [inline](https://vega.github.io/vega-lite/docs/data.html#inline) as an array of JavaScript objects attached to `specification.data.values`.
+Data must be supplied inline as an array of JavaScript objects attached to [`specification.data.values`](https://vega.github.io/vega-lite/docs/data.html#inline) or [`specification.datasets`](https://vega.github.io/vega-lite/docs/data.html#datasets).
 
 Nested fields must be looked up using dot notation (e.g. `datum.field`), not bracket notation (e.g. `datum['field']`).
 

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -21,12 +21,26 @@ const abbreviateNumbers = number => {
 }
 
 /**
+ * get values from values property
+ * @param {object} s Vega Lite specification
+ * @returns {object[]}
+ */
+const valuesInline = s => s.data?.values?.slice()
+
+/**
+ * get values from datasets property based on name
+ * @param {object} s Vega Lite specification
+ * @returns {object[]}
+ */
+const valuesTopLevel = s => s.datasets?.[s.data?.name]
+
+/**
  * look up data values attached to specification
  * @param {object} s Vega Lite specification
  * @returns {object[]}
  */
 const _values = s => {
-	return transformValues(s)(s.data?.values.slice())
+	return transformValues(s)(s.data?.values ? valuesInline(s) : valuesTopLevel(s))
 }
 const values = memoize(_values)
 

--- a/tests/unit/data-test.js
+++ b/tests/unit/data-test.js
@@ -93,4 +93,13 @@ module('unit > data', () => {
 
 		assert.ok(values, 'every item includes a value')
 	})
+	test('retrieves values from top level datasets property', assert => {
+		const s = specificationFixture('circular')
+		const name = '_'
+		s.datasets = { [name]: s.data.values }
+		delete s.data.values
+		s.data.name = name
+		const valid = item => typeof item === 'object' && typeof item.key === 'string' && typeof item.value === 'number'
+		assert.ok(data(s).every(valid))
+	})
 })


### PR DESCRIPTION
As an alternative to [`specification.data.values`](https://vega.github.io/vega-lite/docs/data.html#inline), allow data to be stored with a string key in a top level [`specification.datasets`](https://vega.github.io/vega-lite/docs/data.html#datasets) and then looked up by adding that key to `specification.data.name`.