### PR TITLE
convert inline primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ On the other hand, the standard `vega-lite.js` renderer is definitely still the 
 
 bisonica is still a work in progress and as such supports only a subset of Vega Lite functionality. The supported chart forms are listed in [`source/marks.js`](./source/marks.js).
 
-Data must be supplied inline as an array of JavaScript objects attached to [`specification.data.values`](https://vega.github.io/vega-lite/docs/data.html#inline) or [`specification.datasets`](https://vega.github.io/vega-lite/docs/data.html#datasets).
+Data must be supplied inline as an array attached to [`specification.data.values`](https://vega.github.io/vega-lite/docs/data.html#inline) or [`specification.datasets`](https://vega.github.io/vega-lite/docs/data.html#datasets).
 
 Nested fields must be looked up using dot notation (e.g. `datum.field`), not bracket notation (e.g. `datum['field']`).
 

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -35,12 +35,32 @@ const valuesInline = s => s.data?.values?.slice()
 const valuesTopLevel = s => s.datasets?.[s.data?.name]
 
 /**
+ * get values from datasets property based on name
+ * @param {number[]} arr array of numbers
+ * @returns {object[]} array of objects
+ */
+const wrapNumbers = arr => {
+	if (!arr || typeof arr[0] === 'object') {
+		return arr
+	} else {
+		try {
+			return arr.map(item => {
+				return { data: item }
+			})
+		} catch (error) {
+			error.message = `could not convert raw numbers to objects - ${error.message}`
+			throw error
+		}
+	}
+}
+
+/**
  * look up data values attached to specification
  * @param {object} s Vega Lite specification
  * @returns {object[]}
  */
 const _values = s => {
-	return transformValues(s)(s.data?.values ? valuesInline(s) : valuesTopLevel(s))
+	return transformValues(s)(wrapNumbers(s.data?.values ? valuesInline(s) : valuesTopLevel(s)))
 }
 const values = memoize(_values)
 

--- a/tests/unit/data-test.js
+++ b/tests/unit/data-test.js
@@ -102,4 +102,12 @@ module('unit > data', () => {
 		const valid = item => typeof item === 'object' && typeof item.key === 'string' && typeof item.value === 'number'
 		assert.ok(data(s).every(valid))
 	})
+	test('wraps primitives in objects', assert => {
+		const s = {
+			data: { values: [1, 2, 3] },
+			mark: { type: 'point' },
+			encoding: { x: { field: 'data', type: 'quantitative' } }
+		}
+		assert.ok(data(s).every(item => typeof item.data === 'number'))
+	})
 })


### PR DESCRIPTION
When the input data is an array of primitives (like `[1, 2, 3]`), [convert it](https://vega.github.io/vega-lite/docs/data.html#inline) into objects with the original value stored under a `.data` property (like `[{data: 1}, {data: 2}, {data: 3}]`). This makes the input flexible enough to accept incoming raw data while also allowing all further downstream logic to continue to expect an array of objects as usual.