### PR TITLE
remove extra color encoding from categorical bar fixture

### DIFF
--- a/fixtures/categorical-bar.js
+++ b/fixtures/categorical-bar.js
@@ -13,8 +13,7 @@ const categoricalBarChartSpec = {
 	mark: { type: 'bar', tooltip: true },
 	encoding: {
 		x: { field: 'animal', type: 'nominal' },
-		y: { title: 'count', field: 'value', type: 'quantitative' },
-		color: { field: null, type: 'nominal' }
+		y: { title: 'count', field: 'value', type: 'quantitative' }
 	}
 }
 

--- a/tests/integration/legend-test.js
+++ b/tests/integration/legend-test.js
@@ -14,7 +14,7 @@ module('integration > legend', function() {
 	test('renders a chart with legend automatically omitted', assert => {
 		const spec = specificationFixture('categoricalBar')
 		const element = render(spec)
-		assert.equal(element.querySelector(testSelector('legend')).textContent, '')
+		assert.notOk(element.querySelector(testSelector('legend')))
 	})
 
 	test('renders a chart with legend explicitly omitted', assert => {


### PR DESCRIPTION
This is useless extra syntax which doesn't do anything, or shouldn't – the renderer should use the default color for single-color charts without requiring this phantom encoding property to trigger it, as was once the case long ago.