### PR TITLE
prohibit console.log()

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
         ],
         "arrow-parens": ["error", "as-needed"],
         "no-return-assign": "off",
+        "no-console": ["error", { "allow": ["warn", "error"] }],
         "no-unused-vars": ["error", {"destructuredArrayIgnorePattern": "^_"}]
     }
 }

--- a/tests/unit/interactions-test.js
+++ b/tests/unit/interactions-test.js
@@ -36,7 +36,7 @@ module('unit > interactions', function() {
 			},
 			usermeta: {
 				customTooltipHandler: event => {
-					console.log(event)
+					alert(event)
 				}
 			},
 			layer: [


### PR DESCRIPTION
Stricter linting to prevent a likely artifact of the debugging process from ever slipping into production code.