### PR TITLE
nested property lookup for data sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bisonica is still a work in progress and as such supports only a subset of Vega 
 
 Data loading will not [parse inline strings](https://vega.github.io/vega-lite/docs/data.html#inline).
 
-Remote data will be loaded as is after being fetched; `parse` and `property` are not yet supported.
+Remote data will be loaded as is after being fetched; `parse` is not supported.
 
 Nested fields must be looked up using dot notation (e.g. `datum.field`), not bracket notation (e.g. `datum['field']`).
 

--- a/source/data.js
+++ b/source/data.js
@@ -49,12 +49,12 @@ const valuesSequence = s => {
  * @returns {object[]} generated data set
  */
 const valuesBase = s => {
-	if (s.data?.values) {
-		return valuesInline(s)
-	} else if (s.data?.name) {
+	if (s.data?.name) {
 		return valuesTopLevel(s)
 	} else if (s.data?.sequence) {
 		return valuesSequence(s)
+	} else {
+		return valuesInline(s)
 	}
 }
 

--- a/source/data.js
+++ b/source/data.js
@@ -44,11 +44,11 @@ const valuesSequence = s => {
 }
 
 /**
- * switch between lookup options for raw values
+ * look up data values attached to specification
  * @param {object} s Vega Lite specification
- * @returns {object[]} generated data set
+ * @returns {object[]|object}
  */
-const valuesBase = s => {
+const valuesStatic = s => {
 	if (s.data?.name) {
 		return valuesTopLevel(s)
 	} else if (s.data?.sequence) {
@@ -92,13 +92,6 @@ const lookup = s => {
 		return nested(data, s.data.format?.property)
 	}
 }
-
-/**
- * look up data values attached to specification
- * @param {object} s Vega Lite specification
- * @returns {object[]}
- */
-const valuesStatic = s => valuesBase(s)
 
 /**
  * get remote data from the cache

--- a/source/data.js
+++ b/source/data.js
@@ -101,12 +101,14 @@ const valuesCached = s => transformValues(s)(wrap(cached(s.data)))
  * @returns {object[]} data set
  */
 const _values = s => {
-	if (s.data?.values) {
-		return valuesStatic(s)
-	} else if (s.data?.url) {
+	if (!s.data) {
+		return
+	}
+	const url = !!s.data.url
+	if (url) {
 		return valuesCached(s)
 	} else {
-		return valuesBase(s)
+		return valuesStatic(s)
 	}
 }
 const values = memoize(_values)

--- a/source/data.js
+++ b/source/data.js
@@ -83,17 +83,26 @@ const wrap = arr => {
  * @param {object} s Vega Lite specification
  * @returns {object[]}
  */
-const _valuesStatic = s => {
-	return transformValues(s)(wrap(valuesBase(s)))
-}
-const valuesStatic = memoize(_valuesStatic)
+const valuesStatic = s => valuesBase(s)
 
 /**
  * get remote data from the cache
  * @param {object} s Vega Lite specification
  * @returns {array} data set
  */
-const valuesCached = s => transformValues(s)(wrap(cached(s.data)))
+const valuesCached = s => cached(s.data)
+
+/**
+ * run all data transformation and utility functions
+ * on an input data set
+ * @param {object} s Vega Lite specification
+ * @returns {function(object[])} data processing function
+ */
+const dataUtilities = s => {
+	return data => {
+		return transformValues(s)(wrap(data))
+	}
+}
 
 /**
  * look up data values
@@ -105,11 +114,7 @@ const _values = s => {
 		return
 	}
 	const url = !!s.data.url
-	if (url) {
-		return valuesCached(s)
-	} else {
-		return valuesStatic(s)
-	}
+	return dataUtilities(s)(url ? valuesCached(s) : valuesStatic(s))
 }
 const values = memoize(_values)
 

--- a/source/data.js
+++ b/source/data.js
@@ -20,7 +20,7 @@ import { transformValues } from './transform.js'
  * @param {object} s Vega Lite specification
  * @returns {object[]}
  */
-const valuesInline = s => s.data.values.slice()
+const valuesInline = s => s.data.values
 
 /**
  * get values from datasets property based on name
@@ -100,7 +100,7 @@ const valuesCached = s => cached(s.data)
  */
 const dataUtilities = s => {
 	return data => {
-		return transformValues(s)(wrap(data))
+		return transformValues(s)(wrap(data)).slice()
 	}
 }
 

--- a/tests/unit/data-test.js
+++ b/tests/unit/data-test.js
@@ -14,6 +14,18 @@ module('unit > data', () => {
 
 			assert.equal(values(s).pop(), value)
 		})
+		test('looks up nested data', assert => {
+			const nestedData = { first: { second: [{ a: 1, b: 2 }] } }
+			const s = {
+				data: nestedData
+			}
+			s.data.format = { property: 'first.second', type: 'json' }
+			const data = values(s)
+			assert.ok(Array.isArray(data))
+			assert.equal(data.length, 1)
+			assert.equal(data[0].a, 1)
+			assert.equal(data[0].b, 2)
+		})
 	})
 	module('sources', () => {
 		test('retrieves values from top level datasets property', assert => {


### PR DESCRIPTION
When [loading json data](https://vega.github.io/vega-lite/docs/data.html#json), allow the specification to dictate traversal of a nested object with `data.property` instead of assuming the desired array of values will always be stored at `data.values`.