### PR TITLE
field type conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ bisonica is still a work in progress and as such supports only a subset of Vega 
 
 Data loading will not [parse inline strings](https://vega.github.io/vega-lite/docs/data.html#inline).
 
-Remote data will be loaded as is after being fetched; `parse` is not supported.
-
 Nested fields must be looked up using dot notation (e.g. `datum.field`), not bracket notation (e.g. `datum['field']`).
 
 [Predicates](https://vega.github.io/vega-lite/docs/predicate.html) do not support expressions.

--- a/tests/unit/data-test.js
+++ b/tests/unit/data-test.js
@@ -26,6 +26,24 @@ module('unit > data', () => {
 			assert.equal(data[0].a, 1)
 			assert.equal(data[0].b, 2)
 		})
+		test('parses field types', assert => {
+			const s = {
+				data: {
+					values: [{ a: null, b: 0, c: 2020 }],
+					format: {
+						parse: {
+							a: 'number',
+							b: 'boolean',
+							c: 'date'
+						}
+					}
+				}
+			}
+			const parsed = values(s)[0]
+			assert.strictEqual(parsed.a, 0)
+			assert.strictEqual(parsed.b, false)
+			assert.equal(typeof parsed.c.getFullYear, 'function')
+		})
 	})
 	module('sources', () => {
 		test('retrieves values from top level datasets property', assert => {


### PR DESCRIPTION
Adds an implementation of [`data.format.parse`](https://vega.github.io/vega-lite/docs/data.html#format) to dynamically convert datum field types as part of the `values()` function.