### PR TITLE
stricter types

### DIFF
--- a/source/audio.js
+++ b/source/audio.js
@@ -142,7 +142,7 @@ const notes = (values, dispatcher, s) => {
 /**
  * audio sonification
  * @param {object} s Vega Lite specification
- * @returns {function} audio sonification function
+ * @returns {function(object)} audio sonification function
  */
 const audio = s => {
 	if (s.layer) {

--- a/source/chart.js
+++ b/source/chart.js
@@ -20,7 +20,7 @@ import { copyMethods } from './helpers.js'
  * a Vega Lite specification
  * @param {object} s Vega Lite specification
  * @param {object} panelDimensions chart dimensions
- * @returns {function} renderer
+ * @returns {function(object)} renderer
  */
 const render = (s, panelDimensions) => {
 	let tooltipHandler
@@ -139,7 +139,7 @@ const asyncRender = (s, dimensions) => {
  * a chart rendering function
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} renderer
+ * @returns {function(object, object)} renderer
  */
 const chart = (s, dimensions) => {
 	if (s.data?.url || s.layer?.find(layer => layer.data?.url)) {

--- a/source/color.js
+++ b/source/color.js
@@ -50,7 +50,7 @@ const accessibleColors = (count, variant) => {
  * create a standard color palette from the entire
  * available hue range for use as a categorical scale
  * @param {number} count number of colors
- * @returns {array} color palette
+ * @returns {string[]} color palette
  */
 const standardColors = count => {
 	if (!count || count === 1) {

--- a/source/data.js
+++ b/source/data.js
@@ -96,7 +96,7 @@ const lookup = s => {
 /**
  * get remote data from the cache
  * @param {object} s Vega Lite specification
- * @returns {array} data set
+ * @returns {object[]} data set
  */
 const valuesCached = s => cached(s.data)
 
@@ -154,9 +154,9 @@ const values = memoize(_values)
 
 /**
  * nest data points in a hierarchy according to property name
- * @param {array} data individual data points
+ * @param {object[]} data individual data points
  * @param {string} property property name under which to nest
- * @returns {array} nested data points
+ * @returns {object[]} nested data points
  */
 const groupByProperty = (data, property) => {
 	return Array.from(d3.group(data, d => d[property])).map(([key, values]) => ({ key, values }))
@@ -199,11 +199,11 @@ const sumByProperty = (datum, property, valueKey) => {
 
 /**
  * sum individual values into totals by group
- * @param {array} values individual data points
+ * @param {object[]} values individual data points
  * @param {string} groupBy property to group by
  * @param {string} sumBy property to sum by
  * @param {string} valueKey property to sum
- * @returns {array} nested group sums
+ * @returns {object[]} nested group sums
  */
 const groupAndSumByProperties = (values, groupBy, sumBy, valueKey) => {
 	return groupByProperty(values, groupBy).map(item => sumByProperty(item, sumBy, valueKey))
@@ -211,8 +211,8 @@ const groupAndSumByProperties = (values, groupBy, sumBy, valueKey) => {
 
 /**
  * string keys used to compute stack layout
- * @param {array} data data set
- * @returns {array} keys
+ * @param {object[]} data data set
+ * @returns {object[]} keys
  */
 const stackKeys = data => {
 	const keys = data
@@ -228,7 +228,7 @@ const stackKeys = data => {
 /**
  * sum values across the time period specified on the x axis
  * @param {object} s Vega Lite specification
- * @returns {array} values summed across time period
+ * @returns {object[]} values summed across time period
  */
 const sumByCovariates = s => {
 	const quantitative = encodingField(s, encodingChannelQuantitative(s))
@@ -246,8 +246,8 @@ const sumByCovariates = s => {
 
 /**
  * sort nested data by date and series category
- * @param {array} data unsorted data set
- * @returns {array} sorted data set
+ * @param {object[]} data unsorted data set
+ * @returns {object[]} sorted data set
  */
 const sort = data => {
 	const keys = stackKeys(data)
@@ -275,7 +275,7 @@ const stackValue = (d, key) => d[key]?.value || 0
  * reorganize data from specification into array
  * of values used to render a stacked bar chart
  * @param {object} s Vega Lite specification
- * @returns {array} stacked data series
+ * @returns {object[]} stacked data series
  */
 const stackData = s => {
 	const covariate = encodingField(s, encodingChannelCovariateCartesian(s))
@@ -315,7 +315,7 @@ const stackData = s => {
  * reorganize data from specification into totals
  * used to render a circular chart
  * @param {object} s Vega Lite specification
- * @returns {array} totals by group
+ * @returns {object[]} totals by group
  */
 const circularData = s => {
 	const grouped = Array.from(d3.group(values(s), encodingValue(s, 'color'))).map(
@@ -333,7 +333,7 @@ const circularData = s => {
  * reorganize data from a specification into
  * array of values used to render a line chart.
  * @param {object} s Vega Lite specification
- * @returns {array} summed values for line chart
+ * @returns {object[]} summed values for line chart
  */
 const lineData = s => {
 	const quantitative = encodingField(s, encodingChannelQuantitative(s))
@@ -366,21 +366,21 @@ const lineData = s => {
 /**
  * retrieve data points used for point marks
  * @param {object} s Vega Lite specification
- * @returns {array} data points for point marks
+ * @returns {object[]} data points for point marks
  */
 const pointData = values
 
 /**
  * retrieve data points used for generic marks
  * @param {object} s Vega Lite specification
- * @returns {array} data points for generic marks
+ * @returns {object[]} data points for generic marks
  */
 const genericData = values
 
 /**
  * wrapper function around chart-specific data preprocessing functionality
  * @param {object} s Vega Lite specification
- * @returns {array} sorted and aggregated data
+ * @returns {object[]} sorted and aggregated data
  */
 const chartData = s => {
 	if (feature(s).isBar() || feature(s).isArea()) {
@@ -397,7 +397,7 @@ const chartData = s => {
 /**
  * wrapper function around data preprocessing functionality
  * @param {object} s Vega Lite specification
- * @returns {array} sorted and aggregated data
+ * @returns {object[]} sorted and aggregated data
  */
 const _data = s => {
 	return metadata(s, chartData(s))

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -193,7 +193,7 @@ const encodingChannelCovariateCartesian = s => {
  * @param {string} channel encoding channel
  * @param {function} accessor accessor function
  * @param {object} dimensions chart dimensions
- * @returns {function} encoder function
+ * @returns {function(object)} encoder function
  */
 const _encoder = (s, channel, accessor, dimensions) => {
 	const scales = parseScales(s, dimensions)

--- a/source/expression.js
+++ b/source/expression.js
@@ -3,7 +3,7 @@ const datumPrefix = 'datum.'
 /**
  * create a function to perform a single calculate expression
  * @param {string} str a calculate expression describing string interpolation
- * @returns {function} string interpolation function
+ * @returns {function(object)} string interpolation function
  */
 const expression = str => {
 	const segments = str

--- a/source/fetch.js
+++ b/source/fetch.js
@@ -5,7 +5,7 @@ const cache = new WeakMap()
 /**
  * retrieve data from the cache
  * @param {object} data data definition
- * @returns {array} data set
+ * @returns {object[]} data set
  */
 const cached = data => {
 	if (data.url) {

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -94,7 +94,7 @@ const handleUrl = url => {
 /**
  * attach event listeners to a layer
  * @param {object} s Vega Lite specification
- * @returns {function} user interactions
+ * @returns {function(object)} user interactions
  */
 const _interactions = s => {
 	const fn = wrapper => {

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -12,7 +12,7 @@ const charts = d3.local()
 /**
  * events to listen for
  * @param {object} s Vega Lite specification
- * @returns {array} list of event names
+ * @returns {string[]} list of event names
  */
 const events = s => {
 	if (

--- a/source/keyboard.js
+++ b/source/keyboard.js
@@ -46,7 +46,7 @@ const x = {
  * generate a listener for an arrow key
  * @param {object} s Vega Lite specification
  * @param {('up'|'right'|'down'|'left')} direction arrow direction
- * @returns {function} key listener
+ * @returns {function(object)} key listener
  */
 const key = (s, direction) => {
 	return (mark, state) => {
@@ -204,7 +204,7 @@ const keyMap = key => {
 /**
  * attach keyboard navigation to a chart DOM
  * @param {object} _s Vega Lite specification
- * @returns {function}
+ * @returns {function(object)}
  */
 const keyboard = _s => {
 	try {

--- a/source/legend.js
+++ b/source/legend.js
@@ -80,7 +80,7 @@ const legendStyle = s => renderStyles(legendStyles, s.encoding?.color?.legend)
 /**
  * color scale legend
  * @param {object} _s Vega Lite specification
- * @returns {function} renderer
+ * @returns {function(object)} renderer
  */
 const color = _s => {
 	let s = feature(_s).hasLayers() ? layerPrimary(_s) : _s
@@ -177,7 +177,7 @@ const color = _s => {
 /**
  * render chart legend
  * @param {object} s Vega Lite specification
- * @returns {function} renderer
+ * @returns {function(object)} renderer
  */
 const legend = s => {
 	if (feature(s).hasLegend() && (feature(s).isMulticolor() || feature(s).isCircular())) {

--- a/source/marks.js
+++ b/source/marks.js
@@ -24,7 +24,7 @@ const transparent = 0.001
 /**
  * aggregate and sort mark data
  * @param {object} s Vega Lite specification
- * @returns {array} aggregated and sorted data for data join
+ * @returns {object[]} aggregated and sorted data for data join
  */
 const markData = s => {
 	const series = Array.isArray(data(s)) && data(s).every(Array.isArray)

--- a/source/marks.js
+++ b/source/marks.js
@@ -193,7 +193,7 @@ const stackEncoders = (s, dimensions) => {
  * render a single bar chart mark
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} single mark renderer
+ * @returns {function(object)} single mark renderer
  */
 const barMark = (s, dimensions) => {
 	const encoders = stackEncoders(s, dimensions)
@@ -255,7 +255,7 @@ const barMarksTransform = (s, dimensions) => {
  * render bar chart marks
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} bar renderer
+ * @returns {function(object)} bar renderer
  */
 const barMarks = (s, dimensions) => {
 	const encoders = createEncoders(s, dimensions, createAccessors(s, 'series'))
@@ -325,7 +325,7 @@ const areaEncoders = (s, dimensions) => {
  * render area marks
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} area mark renderer
+ * @returns {function(object)} area mark renderer
  */
 const areaMarks = (s, dimensions) => {
 	const encoders = areaEncoders(s, dimensions)
@@ -433,7 +433,7 @@ const pointMark = (s, dimensions) => {
  * render image marks
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} image mark renderer
+ * @returns {function(object)} image mark renderer
  */
 const imageMarks = (s, dimensions) => {
 	const encoders = createEncoders(s, dimensions, createAccessors(s))
@@ -466,7 +466,7 @@ const imageMarks = (s, dimensions) => {
  * render multiple point marks
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} points renderer
+ * @returns {function(object)} points renderer
  */
 const pointMarks = (s, dimensions) => {
 	const encoders = createEncoders(s, dimensions, createAccessors(s))
@@ -521,7 +521,7 @@ const pointMarks = (s, dimensions) => {
  * render line chart marks
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} line renderer
+ * @returns {function(object)} line renderer
  */
 const lineMarks = (s, dimensions) => {
 	const encoders = createEncoders(s, dimensions, createAccessors(s))
@@ -600,7 +600,7 @@ const radius = dimensions => Math.min(dimensions.x, dimensions.y) * 0.5
  * render arc marks for a circular pie or donut chart
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} circular chart arc renderer
+ * @returns {function(object)} circular chart arc renderer
  */
 const circularMarks = (s, dimensions) => {
 	const outerRadius = radius(dimensions)
@@ -672,7 +672,7 @@ const ruleDirection = s => {
  * render rule marks
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} rule renderer
+ * @returns {function(object)} rule renderer
  */
 const ruleMarks = (s, dimensions) => {
 	const renderer = selection => {
@@ -788,7 +788,7 @@ const textMarks = (s, dimensions) => {
  * select an appropriate mark renderer
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} mark renderer
+ * @returns {function(object)} mark renderer
  */
 const _marks = (s, dimensions) => {
 	try {

--- a/source/position.js
+++ b/source/position.js
@@ -107,7 +107,7 @@ const margin = memoize(_margin)
  * transform string for positioning charts
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} positioning function
+ * @returns {function(object)} positioning function
  */
 const position = (s, dimensions) => {
 	const yOffsetCircular =

--- a/source/scales.js
+++ b/source/scales.js
@@ -178,7 +178,7 @@ const domainBaseValues = (s, channel) => {
  * sort the domain
  * @param {object} s Vega Lite specification
  * @param {string} channel visual encoding
- * @returns {function}
+ * @returns {function(array)}
  */
 const domainSort = (s, channel) => {
 	if (!s.encoding[channel].sort || s.encoding[channel].sort === null) {

--- a/source/sort.js
+++ b/source/sort.js
@@ -112,7 +112,7 @@ const isDescending = (s, channel) => {
  * extract the values to sort and resolve repeated values
  * @param {object} s Vega Lite specification
  * @param {string} channel encoding channel
- * @returns {array} array of data values to be sorted
+ * @returns {object[]} array of data values to be sorted
  */
 const valuesToSort = (s, channel) => {
 	const getValue = encodingValue(s, channel)

--- a/source/text.js
+++ b/source/text.js
@@ -63,7 +63,7 @@ const fontStyles = node => {
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
  * @param {'x'|'y'} channel encoding channel
- * @returns {function} abbreviation function
+ * @returns {function(string)} abbreviation function
  */
 const _abbreviate = (s, dimensions, channel) => {
 	return tick => {
@@ -92,7 +92,7 @@ const abbreviate = memoize(_abbreviate)
  * format axis tick label text
  * @param {object} s Vega Lite specification
  * @param {'x'|'y'} channel encoding channel
- * @returns {function} formatting function
+ * @returns {function(string)} formatting function
  */
 const format = (s, channel) => {
 	const formatter = encodingType(s, channel) === 'temporal' ? formatAxis(s, channel) : label => label.toString()
@@ -202,7 +202,7 @@ const longestAxisTickLabelTextWidth = memoize(_longestAxisTickLabelTextWidth)
  * render axis tick text
  * @param {object} s Vega Lite specification
  * @param {'x'|'y'} channel encoding channel
- * @returns {function} text processing function
+ * @returns {function(object)} text processing function
  */
 const axisTicksLabelText = (s, channel) => {
 	let styles = {}

--- a/source/time.js
+++ b/source/time.js
@@ -52,7 +52,7 @@ const _getTimeParser = date => {
 /**
  * select a function that can parse a date format
  * @param {(string|number)} date date representation
- * @returns {function} date parsing function
+ * @returns {function(Date)} date parsing function
  */
 const getTimeParser = memoize(_getTimeParser)
 

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -156,17 +156,16 @@ const _getTooltipField = (s, type) => {
 }
 const getTooltipField = memoize(_getTooltipField)
 
+/**
+ * retrieve default fields for tooltip
+ * @param {object} s Vega Lite specification
+ * @returns {function(object)} default field content retrieval function
+ */
 const _tooltipContentDefault = s => {
 	return d => {
 		return includedChannels(s).map(channel => getTooltipField(s, channel)(d))
 	}
 }
-/**
- * retrieve default fields for tooltip
- * @param {object} s Vega Lite specification
- * @param {object} d datum
- * @returns {array} default field content
- */
 const tooltipContentDefault = memoize(_tooltipContentDefault)
 
 const _tooltipContentAll = s => {

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -21,7 +21,7 @@ const formatField = field => {
 
 /**
  * format datum description
- * @param {array} content data fields to format
+ * @param {object[]|string} content data fields to format
  * @returns {string} datum description
  */
 const formatTooltipContent = content => {
@@ -45,7 +45,7 @@ const _includedChannels = s => {
 /**
  * determine which encoding channels to include in a description
  * @param {object} s Vega Lite specification
- * @returns {array} included channels
+ * @returns {string[]} included channels
  */
 const includedChannels = memoize(_includedChannels)
 
@@ -186,7 +186,7 @@ const _tooltipContentAll = s => {
  * retrieve all datum fields for tooltip
  * @param {object} s Vega Lite specification
  * @param {object} d datum
- * @returns {array} all field content
+ * @returns {object[]} all field content
  */
 const tooltipContentAll = memoize(_tooltipContentAll)
 

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -96,7 +96,7 @@ const tooltip = (selection, s) => {
 /**
  * create a function to render all tooltips
  * @param {object} s Vega Lite specification
- * @returns {function} tooltip rendering function
+ * @returns {function(object)} tooltip rendering function
  */
 const tooltips = s => {
 	if (s.usermeta?.tooltipHandler) {
@@ -113,7 +113,7 @@ const tooltips = s => {
  * create a function to retrieve a tooltip field pair from a datum
  * @param {object} s Vega Lite specification
  * @param {string} type encoding parameter, field, or transform field
- * @returns {function} function
+ * @returns {function(object)} function
  */
 const _getTooltipField = (s, type) => {
 	let accessors
@@ -193,7 +193,7 @@ const tooltipContentAll = memoize(_tooltipContentAll)
 /**
  * create a function to retrieve tooltip content
  * @param {object} s Vega Lite specification
- * @returns {function} tooltip field data lookup function
+ * @returns {function(object)} tooltip field data lookup function
  */
 const tooltipContentData = s => {
 	return d => {

--- a/source/transform.js
+++ b/source/transform.js
@@ -7,7 +7,7 @@ import * as d3 from 'd3'
 /**
  * create a function to perform a single calculate expression
  * @param {string} str a calculate expression describing string interpolation
- * @returns {function} string interpolation function
+ * @returns {function(string)} string interpolation function
  */
 const calculate = str => expression(str)
 
@@ -36,7 +36,7 @@ const _composeCalculateTransforms = transforms => {
 /**
  * create a function to augment a datum with multiple calculate expressions
  * @param {array} transforms an array of calculate expressions
- * @returns {function} transform function
+ * @returns {function(object[])} transform function
  */
 const composeCalculateTransforms = memoize(_composeCalculateTransforms)
 

--- a/source/transform.js
+++ b/source/transform.js
@@ -35,7 +35,7 @@ const _composeCalculateTransforms = transforms => {
 
 /**
  * create a function to augment a datum with multiple calculate expressions
- * @param {array} transforms an array of calculate expressions
+ * @param {object[]} transforms an array of calculate expressions
  * @returns {function(object[])} transform function
  */
 const composeCalculateTransforms = memoize(_composeCalculateTransforms)

--- a/source/views.js
+++ b/source/views.js
@@ -287,7 +287,7 @@ const layerSpecification = (s, index) => {
  * render layers of a specification
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {function} layer renderer
+ * @returns {function(object)} layer renderer
  */
 const layerMarks = (s, dimensions) => {
 	if (!s.layer.length) {


### PR DESCRIPTION
Correct a bug in the type signature for default tooltips and specify types for arrays as well as the input arguments for functions returned from factories and higher-order functions.