### PR TITLE
render undefined quantitative values as 0

### DIFF
--- a/source/encodings.js
+++ b/source/encodings.js
@@ -225,7 +225,11 @@ const _encoder = (s, channel, accessor, dimensions) => {
 		const encoded = scale(value)
 
 		if (encoded === undefined) {
-			throw new Error(`encoded value for ${channel} is undefined`)
+			if (encodingType(s, channel) === 'quantitative') {
+				return 0
+			} else {
+				throw new Error(`encoded value for ${channel} is undefined`)
+			}
 		}
 
 		if (Number.isNaN(encoded)) {


### PR DESCRIPTION
When an encoder function produces an `undefined` value, render it as `0` instead of throwing an error. This is mostly just to align with the behavior of the standard `vega-lite.js` renderer.