### PR TITLE
cast quantitative domain endpoints to numbers

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -150,7 +150,7 @@ const domainBaseValues = (s, channel) => {
 				.map(item => item.values)
 				.flat()
 			const nonzero = s.encoding.y.scale?.zero === false
-			const accessor = d => d.value
+			const accessor = d => +d.value
 			const periodMin = d3.min(byPeriod, accessor)
 			const positive = typeof periodMin === 'number' && periodMin > 0
 


### PR DESCRIPTION
Explicitly convert quantitative domain endpoints to numbers. In practice this is mostly to handle the edge case of CSV data resulting in a string, but it's okay to apply it broadly because logically quantitative scales always require quantitative values.