### PR TITLE
cast to number before summing values

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -182,7 +182,7 @@ const sumByProperty = (datum, property, valueKey) => {
 
 		const value = valueKey && valueKey.includes('.') ? nested(item, valueKey) : item[valueKey]
 
-		result[key].value += value
+		result[key].value += +value
 
 		// this should be refactored
 		const field = ['url', 'description', 'tooltip']


### PR DESCRIPTION
Cast to numbers before summing to ensure that `+` always means addition and does not mean concatenation.

This is similar to the change in pull request #283, but the same mechanism is required in both places because some chart types may never hit the code path to apply the earlier upstream version of the fix.