### PR TITLE
normalize stacks

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -153,6 +153,13 @@ const _values = s => {
 const values = memoize(_values)
 
 /**
+ * stack offset configuration
+ * @param {object} s Vega Lite specification
+ * @returns {string} stack command
+ */
+const stackOffset = s => s.encoding[encodingChannelQuantitative(s)].stack
+
+/**
  * nest data points in a hierarchy according to property name
  * @param {object[]} data individual data points
  * @param {string} property property name under which to nest
@@ -284,6 +291,11 @@ const stackData = s => {
 
 	const summed = groupAndSumByProperties(values(s), covariate, group, quantitative)
 	const stacker = d3.stack().keys(stackKeys).value(stackValue)
+
+	if (stackOffset(s)) {
+		stacker.offset(d3.stackOffsetExpand)
+	}
+
 	const stacked = stacker(summed)
 	const single = stacked.length === 1
 
@@ -404,4 +416,4 @@ const _data = s => {
 }
 const data = memoize(_data)
 
-export { data, values, pointData, sumByCovariates }
+export { data, values, pointData, stackOffset, sumByCovariates }

--- a/source/scales.js
+++ b/source/scales.js
@@ -1,5 +1,5 @@
 import * as d3 from 'd3'
-import { data, sumByCovariates, values } from './data.js'
+import { data, stackOffset, sumByCovariates, values } from './data.js'
 import { colors } from './color.js'
 import { encodingChannelQuantitative, encodingType, encodingValue } from './encodings.js'
 import { feature } from './feature.js'
@@ -161,7 +161,7 @@ const domainBaseValues = (s, channel) => {
 
 		if (feature(s).isBar() || feature(s).isArea()) {
 			min = 0
-			max = d3.max(sumByCovariates(s))
+			max = stackOffset(s) === 'normalize' ? 1 : d3.max(sumByCovariates(s))
 		} else if (feature(s).isLine()) {
 			const byPeriod = data(s)
 				.map(item => item.values)


### PR DESCRIPTION
Normalize stacks for [area charts](https://vega.github.io/vega-lite/examples/stacked_area_normalize.html) and [bar charts](https://vega.github.io/editor/#/examples/vega-lite/stacked_bar_normalize) so they display relative changes across the entire available plotting area.