### PR TITLE
detail encoding

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -240,7 +240,7 @@ const stackKeys = data => {
 const sumByCovariates = s => {
 	const quantitative = encodingField(s, encodingChannelQuantitative(s))
 	const covariate = encodingField(s, encodingChannelCovariateCartesian(s))
-	const group = encodingField(s, 'color')
+	const group = encodingField(s, 'color') || encodingField(s, 'detail')
 
 	const summedByGroup = groupAndSumByProperties(values(s), covariate, group, quantitative)
 	const keys = stackKeys(summedByGroup)
@@ -287,7 +287,7 @@ const stackValue = (d, key) => d[key]?.value || 0
 const stackData = s => {
 	const covariate = encodingField(s, encodingChannelCovariateCartesian(s))
 	const quantitative = encodingField(s, encodingChannelQuantitative(s))
-	const group = encodingField(s, 'color')
+	const group = encodingField(s, 'color') || encodingField(s, 'detail')
 
 	const summed = groupAndSumByProperties(values(s), covariate, group, quantitative)
 	const stacker = d3.stack().keys(stackKeys).value(stackValue)
@@ -350,7 +350,7 @@ const circularData = s => {
 const lineData = s => {
 	const quantitative = encodingField(s, encodingChannelQuantitative(s))
 	const covariate = encodingField(s, encodingChannelCovariateCartesian(s)) || missingSeries()
-	const color = encodingField(s, 'color')
+	const color = encodingField(s, 'color') || encodingField(s, 'detail')
 
 	const summed = groupAndSumByProperties(values(s), covariate, color, quantitative)
 	const results = stackKeys(summed).map(key => {

--- a/source/scales.js
+++ b/source/scales.js
@@ -245,13 +245,17 @@ const range = (s, dimensions, _channel) => {
 
 		return result
 	}
+
 	const ranges = {
 		x: cartesian,
 		y: cartesian,
 		color: () => {
 			return s.encoding.color?.scale?.range || colors(s, categoryCount(s, channel))
 		},
-		theta: () => [0, Math.PI * 2]
+		theta: () => [0, Math.PI * 2],
+		detail: () => {
+			return s.encoding.detail?.scale?.range || Array.from({ length: categoryCount(s, channel) }).map(() => null)
+		}
 	}
 
 	return ranges[channel]()

--- a/tests/unit/encodings-test.js
+++ b/tests/unit/encodings-test.js
@@ -54,6 +54,16 @@ module('unit > encoders', () => {
 		assert.equal(encodingField(s, 'y'), 'b')
 	})
 
+	test('detail channel groups data without visual encoding', assert => {
+		const s = specificationFixture('multiline')
+		s.encoding.detail = s.encoding.color
+		delete s.encoding.color
+
+		const layout = data(s)
+
+		assert.equal(layout.length, 10)
+	})
+
 	test('accesses nested fields with encoding value lookup', assert => {
 		const datum = {
 			a: {


### PR DESCRIPTION
Implement the [detail encoding channel](https://vega.github.io/vega-lite/docs/encoding.html#detail) for arbitrary data grouping without any further visual effects.