### PR TITLE
predicate error messages

### DIFF
--- a/source/predicate.js
+++ b/source/predicate.js
@@ -106,10 +106,15 @@ const compose = config => {
  */
 const _predicate = config => {
 	const multiple = config.and || config.or || config.not
-	if (multiple) {
-		return compose(config)
-	} else {
-		return single(config)
+	try {
+		if (multiple) {
+			return compose(config)
+		} else {
+			return single(config)
+		}
+	} catch (error) {
+		error.message = `could not create predicate function - ${error.message}`
+		throw error
 	}
 }
 const predicate = memoize(_predicate)

--- a/source/predicate.js
+++ b/source/predicate.js
@@ -105,6 +105,9 @@ const compose = config => {
  * @returns {function(object)} predicate test function
  */
 const _predicate = config => {
+	if (typeof config === 'string') {
+		throw new Error(`cannot evaluate string expression (${config}), predicates must use structured object syntax`)
+	}
 	const multiple = config.and || config.or || config.not
 	try {
 		if (multiple) {


### PR DESCRIPTION
Currently [predicates](https://github.com/vijithassar/bisonica/pull/251) cannot evaluate arbitrary [Vega expressions](https://github.com/vega/vega-expression) which are supplied in string format, so it's helpful to emit a more descriptive error message when that condition occurs, especially since many of the charts in the [Vega Lite example gallery](https://vega.github.io/vega-lite/examples/) use the unsupported syntax.

This pull request also adds the more generic top-level `try`/`catch` style error handling.