### PR TITLE
memoize null and undefined values

### DIFF
--- a/source/memoize.js
+++ b/source/memoize.js
@@ -5,7 +5,7 @@ const references = {
 
 const argumentKey = arg => {
 	const type = typeof arg
-	const primitive = type !== 'object' && type !== 'function'
+	const primitive = (type !== 'object' && type !== 'function') || arg === null || arg === undefined
 
 	if (primitive) {
 		return `${arg}`


### PR DESCRIPTION
Handle `null` and `undefined` as function arguments that can be memoized.