### PR TITLE
disambiguate secondary channels in encoding test predicates

### DIFF
--- a/source/encodings.js
+++ b/source/encodings.js
@@ -134,6 +134,13 @@ const _encodingTest = (s, test) => {
 		return encodings[0][0]
 	}
 
+	if (encodings.length === 2) {
+		const baseEncodings = new Set([0, 1].map(index => encodings[index][0].slice(0, 1)))
+		if (baseEncodings.size === 1) {
+			return [...baseEncodings.values()][0]
+		}
+	}
+
 	if (encodings.length === 0) {
 		throw new Error('no channels match test function')
 	}

--- a/tests/unit/encodings-test.js
+++ b/tests/unit/encodings-test.js
@@ -166,6 +166,12 @@ module('unit > encoders', () => {
 		assert.equal(encodingChannelQuantitative(s), 'y')
 	})
 
+	test('identifies quantitative encoding base channels', assert => {
+		const s = { encoding: { x: { type: 'nominal' }, y: { type: 'quantitative' }, y2: { type: 'quantitative' } } }
+
+		assert.equal(encodingChannelQuantitative(s), 'y')
+	})
+
 	test('detects encoding types', assert => {
 		const s = { encoding: { x: { type: 'nominal' } } }
 


### PR DESCRIPTION
When a predicate test function passed into `encodingTest()` matches two channels instead of one, return a useful result if the channels are two complementary versions of the same encoding. For example, a test function that matches `y` and `y2` would previously have thrown an error, but now it will return `y` and the rest of the chart can continue to render.