### PR TITLE
read dimensions from input specification

### DIFF
--- a/source/chart.js
+++ b/source/chart.js
@@ -20,13 +20,14 @@ import { download } from './download.js'
  * generate chart rendering function based on
  * a Vega Lite specification
  * @param {object} s Vega Lite specification
- * @param {object} panelDimensions chart dimensions
+ * @param {object} [_panelDimensions] chart dimensions
  * @returns {function(object)} renderer
  */
-const render = (s, panelDimensions) => {
+const render = (s, _panelDimensions) => {
 	let tooltipHandler
 	let errorHandler = console.error
 	let tableRenderer = table
+	const panelDimensions = _panelDimensions || { x: s.width, y: s.height }
 
 	const renderer = selection => {
 		try {

--- a/tests/integration/chart-test.js
+++ b/tests/integration/chart-test.js
@@ -1,0 +1,28 @@
+import qunit from 'qunit'
+import { chart } from '../../source/chart.js'
+import { testSelector, specificationFixture } from '../test-helpers.js'
+import * as d3 from 'd3'
+
+const { module, test } = qunit
+
+module('unit > chart', () => {
+	const dimensions = { x: 500, y: 500 }
+	test('creates a chart function with separate dimensions object', assert => {
+		const s = specificationFixture('circular')
+		const selection = d3.create('svg:svg').append('svg:g')
+		const renderer = chart(s, dimensions)
+		selection.call(renderer)
+		const marks = selection.selectAll(testSelector('mark'))
+		assert.equal(marks.size(), s.data.values.length)
+	})
+	test('creates a chart function with dimensions in specification', assert => {
+		const s = specificationFixture('circular')
+		s.width = dimensions.x
+		s.height = dimensions.y
+		const selection = d3.create('svg:svg').append('svg:g')
+		const renderer = chart(s)
+		selection.call(renderer)
+		const marks = selection.selectAll(testSelector('mark'))
+		assert.equal(marks.size(), s.data.values.length)
+	})
+})


### PR DESCRIPTION
When creating the rendering function with `chart()`, check for `specification.height` and `specification.width` [at the top level](https://vega.github.io/vega-lite/docs/size.html#specifying-fixed-width-and-height) and fall back to them if the `dimensions` argument is omitted.