### PR TITLE
disable stacking

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -154,7 +154,7 @@ const stackData = s => {
 	const summed = groupAndSumByProperties(values(s), covariate, group, quantitative)
 	const stacker = d3.stack().keys(stackKeys).value(stackValue)
 
-	if (stackOffset(s)) {
+	if (stackOffset(s) === 'normalize') {
 		stacker.offset(d3.stackOffsetExpand)
 	}
 

--- a/source/feature.js
+++ b/source/feature.js
@@ -60,7 +60,13 @@ const _feature = s => {
 		isMulticolor: () => isMulticolor,
 		hasEncodingX: s => s.encoding?.x,
 		hasEncodingY: s => s.encoding?.y,
-		hasEncodingColor: s => s.encoding?.color
+		hasEncodingColor: s => s.encoding?.color,
+		isStacked: s => {
+			return mark(s) === 'bar' &&
+				s.encoding?.y?.stack !== null &&
+				s.encoding?.x?.stack !== null &&
+				isMulticolor
+		}
 	}
 
 	tests.hasAxis = s => tests.hasEncodingX(s) || tests.hasEncodingY(s)

--- a/source/scales.js
+++ b/source/scales.js
@@ -370,10 +370,18 @@ const extendScales = (s, dimensions, scales) => {
 		}
 
 		extendedScales.start = d => {
-			if (channel === 'y') {
-				return extendedScales[channel](d[0]) - extendedScales.length(d[1] - d[0])
-			} else if (channel === 'x') {
-				return extendedScales[channel](d[0])
+			if (feature(s).isStacked()) {
+				if (channel === 'y') {
+					return extendedScales[channel](d[0]) - extendedScales.length(d[1] - d[0])
+				} else if (channel === 'x') {
+					return extendedScales[channel](d[0])
+				}
+			} else {
+				if (channel === 'y') {
+					return dimensions.y - extendedScales.length(d[1] - d[0])
+				} else if (channel === 'x') {
+					return 0
+				}
 			}
 		}
 	}

--- a/tests/unit/stack-test.js
+++ b/tests/unit/stack-test.js
@@ -1,25 +1,36 @@
 import { markData } from '../../source/marks.js'
 import qunit from 'qunit'
-import { specificationFixture } from '../test-helpers.js'
+import { render, testSelector, specificationFixture } from '../test-helpers.js'
 
 const { module, test } = qunit
 
 module('unit > stack', () => {
+	const precision = 15
+	const zero = ([start, _]) => start === 0
+	const one = ([_, end]) => +end.toFixed(precision) === 1
 	test('stacks', assert => {
 		const s = specificationFixture('stackedBar')
 		const layout = markData(s)
 		assert.ok(layout[0].every(segment => segment[0] === 0), 'first series uses a zero baseline for all segments')
 	})
 	test('normalizes stacking', assert => {
-		const precision = 15
 		const s = specificationFixture('stackedBar')
 		s.encoding.y.stack = 'normalize'
 		const layout = markData(s)
 		const first = layout[0]
 		const last = layout[layout.length - 1]
-		const zero = ([start, _]) => start === 0
-		const one = ([_, end]) => +end.toFixed(precision) === 1
 		assert.ok(first.every(zero), 'first series uses a zero baseline for all segments')
 		assert.ok(last.every(one), 'final series extends all segments to maximum value')
+	})
+	test('disables stacking', assert => {
+		const s = specificationFixture('stackedBar')
+		s.encoding.y.stack = null
+		// testing disabled stacking requires rendered DOM because it's
+		// handled with control flow and is not visible in the layout
+		// returned from d3.stack() and markData()
+		const element = render(s)
+		const baseline = mark => +mark.getAttribute('y') + +mark.getAttribute('height')
+		const baselines = new Set([...element.querySelectorAll(testSelector('mark'))].map(baseline))
+		assert.equal(baselines.size, 1, 'all marks have the same baseline')
 	})
 })


### PR DESCRIPTION
Set `specification.encoding.y.stack: null` or similar to ignore the stack layout when rendering and [layer bars](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) on top of one another.