### PR TITLE
disable stacking with false

### DIFF
--- a/source/feature.js
+++ b/source/feature.js
@@ -64,7 +64,9 @@ const _feature = s => {
 		isStacked: s => {
 			return mark(s) === 'bar' &&
 				s.encoding?.y?.stack !== null &&
+				s.encoding?.y?.stack !== false &&
 				s.encoding?.x?.stack !== null &&
+				s.encoding?.x?.stack !== false &&
 				isMulticolor
 		}
 	}


### PR DESCRIPTION
A very slight update to the functionality introduced in pull request #310 – [per the documentation](https://vega.github.io/vega-lite/docs/stack.html#encoding), stacking can be disabled with _either_ `null` or `false`.