### PR TITLE
cast categories to strings

### DIFF
--- a/source/helpers.js
+++ b/source/helpers.js
@@ -111,11 +111,11 @@ const noop = () => {
 const identity = x => x
 
 /**
- * convert a string to machine-friendly key
- * @param {string} string input string
+ * convert an identifier to machine-friendly key
+ * @param {string|number} id identifier
  * @returns {string} kebab case string
  */
-const key = string => string?.toLowerCase().replace(/ /g, '-')
+const key = id => `${id}`.toLowerCase().replace(/ /g, '-')
 
 /**
  * convert radians to degrees


### PR DESCRIPTION
The `key()` function which produces `kebab-case` strings for use as machine readable identifiers assumes the input will be a string. This is usually true, but not always, and logically there's no reason why a pie chart can't be partitioned using numerical identifiers instead of string labels. Casting to string inside the `key()` function is usually redundant, but occasionally not when the input is a number, and in those cases that's the only way to make sure a `.toLowerCase()` method exists.