### PR TITLE
container dimensions

### DIFF
--- a/source/chart.js
+++ b/source/chart.js
@@ -27,11 +27,20 @@ const render = (s, _panelDimensions) => {
 	let tooltipHandler
 	let errorHandler = console.error
 	let tableRenderer = table
-	const panelDimensions = _panelDimensions || { x: s.width, y: s.height }
 
 	const renderer = selection => {
 		try {
 			selection.html('')
+
+			let panelDimensions
+			if (_panelDimensions) {
+				panelDimensions = _panelDimensions
+			} else if (s.height && s.width) {
+				panelDimensions = {
+					x: s.width === 'container' ? selection.node().getBoundingClientRect().width : s.width,
+					y: s.height === 'container' ? selection.node().getBoundingClientRect().height : s.height
+				}
+			}
 
 			selection.call(setupNode(s, panelDimensions))
 


### PR DESCRIPTION
Instead of specifying dimensions, set `specification.height: "container"` and/or `specification.width: "container"` to [derive the size](https://vega.github.io/vega-lite/docs/size.html#specifying-responsive-width-and-height) from the parent node into which the chart is being rendered.