### PR TITLE
size encoding

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -69,7 +69,7 @@ const _createAccessors = (s, type = null) => {
 	}
 
 	if (['point', 'square', 'circle'].includes(key)) {
-		standard('x', 'y', 'color')
+		standard('x', 'y', 'color', 'size')
 	}
 
 	if (key === 'line') {
@@ -82,7 +82,7 @@ const _createAccessors = (s, type = null) => {
 	}
 
 	if (key === 'text') {
-		standard('x', 'y', 'color', 'text')
+		standard('x', 'y', 'color', 'text', 'size')
 	}
 
 	if (key === 'image') {

--- a/source/marks.js
+++ b/source/marks.js
@@ -388,8 +388,8 @@ const areaMarks = (s, dimensions) => {
  */
 const pointMarkCircle = (s, dimensions) => {
 	const size = s.mark.size || defaultSize
-	const radius = Math.sqrt(size / Math.PI)
 	const encoders = createEncoders(s, dimensions, createAccessors(s))
+	const radius = d => encoders.size ? encoders.size(d) : Math.sqrt(size / Math.PI)
 	const renderer = selection => {
 		selection
 			.attr('cx', encoders.x)
@@ -406,13 +406,13 @@ const pointMarkCircle = (s, dimensions) => {
  */
 const pointMarkSquare = (s, dimensions) => {
 	const size = s.mark.size || defaultSize
-	const side = Math.sqrt(size)
-	const offset = side * 0.5 * -1
 	const encoders = createEncoders(s, dimensions, createAccessors(s))
+	const side = d => encoders.size ? encoders.size(d) : Math.sqrt(size)
+	const offset = d => side(d) * 0.5 * -1
 	const renderer = selection => {
 		selection
-			.attr('x', d => encoders.x(d) + offset)
-			.attr('y', d => encoders.y(d) + offset)
+			.attr('x', d => encoders.x(d) + offset(d))
+			.attr('y', d => encoders.y(d) + offset(d))
 			.attr('height', side)
 			.attr('width', side)
 	}
@@ -762,7 +762,7 @@ const textMarks = (s, dimensions) => {
 		}
 
 		// default font size
-		text.style('font-size', defaultFontSize)
+		text.style('font-size', encoders.size ? encoders.size : defaultFontSize)
 
 		// text content
 		if (s.mark.text) {

--- a/source/scales.js
+++ b/source/scales.js
@@ -33,6 +33,9 @@ const explicitScale = (s, channel) => {
 	if (s.encoding[channel]?.scale === null) {
 		return null
 	} else {
+		if (channel === 'size') {
+			return 'scaleSqrt'
+		}
 		const type = scaleType(s, channel)
 		return `scale${type.slice(0, 1).toUpperCase() + type.slice(1)}`
 	}
@@ -258,7 +261,23 @@ const range = (s, dimensions, _channel) => {
 			return s.encoding.detail?.scale?.range || Array.from({ length: categoryCount(s, channel) }).map(() => null)
 		},
 		yOffset: () => [dimensions.y, 0],
-		xOffset: () => [0, dimensions.x]
+		xOffset: () => [0, dimensions.x],
+		size: () => {
+			let min = 0
+			let max
+			if (feature(s).isBar()) {
+				if (isDiscrete(s, channel)) {
+					max = 2
+				} else {
+					max = 5
+				}
+			} else if (feature(s).isText()) {
+				max = 11
+			} else {
+				max = 30
+			}
+			return [min, max]
+		}
 	}
 
 	return ranges[channel]()

--- a/tests/integration/size-test.js
+++ b/tests/integration/size-test.js
@@ -1,0 +1,30 @@
+import qunit from 'qunit'
+import { render, testSelector, specificationFixture } from '../test-helpers.js'
+
+const { module, test } = qunit
+
+const markSizes = element => {
+	const marks = [...element.querySelectorAll(testSelector('marks-mark-point'))]
+	const radii = marks.map(mark => mark.getAttribute('r'))
+	return new Set(radii).size
+}
+
+module('integration > size', function() {
+	test('renders a scatter plot with consistent mark size', assert => {
+		const s = specificationFixture('scatterPlot')
+		const element = render(s)
+		assert.equal(markSizes(element), 1, 'marks have consistent size')
+	})
+	test('renders a bubble plot with variable mark size', assert => {
+		const s = specificationFixture('scatterPlot')
+		s.data.values = s.data.values.map(item => {
+			return {
+				...item,
+				_: Math.random()
+			}
+		})
+		s.encoding.size = { field: '_', type: 'quantitative' }
+		const element = render(s)
+		assert.ok(markSizes(element) > 1, 'marks have variable size')
+	})
+})


### PR DESCRIPTION
Adds `size` encoding for use with [point](https://vega.github.io/vega-lite/docs/point.html), [circle](https://vega.github.io/vega-lite/docs/circle.html), [square](https://vega.github.io/vega-lite/docs/square.html), and [text marks](https://vega.github.io/vega-lite/docs/text.html). The [bubble plot example](https://vega.github.io/vega-lite/examples/point_bubble.html) now works as expected.