### PR TITLE
simple string expression predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Data loading will not [parse inline strings](https://vega.github.io/vega-lite/do
 
 Nested fields must be looked up using dot notation (e.g. `datum.field`), not bracket notation (e.g. `datum['field']`).
 
-[Predicates](https://vega.github.io/vega-lite/docs/predicate.html) do not support expressions.
+[Predicates](https://vega.github.io/vega-lite/docs/predicate.html) defined with string expressions only support simple comparisons (e.g. `"datum.value < 100"` or `"datum.group === 'a'"`).
 
 The [calculate transform](https://vega.github.io/vega-lite/docs/calculate.html) only supports deriving new fields with string concatenation and static functions but can't do arbitrary math. (If you need arbitrary math, do it in JavaScript and attach the results to your specification before rendering.)
 

--- a/tests/unit/predicate-test.js
+++ b/tests/unit/predicate-test.js
@@ -5,13 +5,17 @@ const { module, test } = qunit
 
 const data = () => {
 	return [
-		{ x: 1 },
-		{ x: 2 },
-		{ x: 3 },
-		{ x: 4 },
-		{ x: 5 },
-		{ x: 6 }
+		{ x: 1, _: 'apple pie' },
+		{ x: 2, _: 'banana split' },
+		{ x: 3, _: 'cherry cobbler' },
+		{ x: 4, _: 'donut' },
+		{ x: 5, _: 'eclair' },
+		{ x: 6, _: 'flan' }
 	]
+}
+
+const run = config => {
+	return data().filter(predicate(config)).map(item => item.x).join(',')
 }
 
 module('unit > predicate', () => {
@@ -50,5 +54,26 @@ module('unit > predicate', () => {
 			] }
 			assert.equal(run(config), '5,6')
 		})
+	})
+	module('string expression predicates', () => {
+		const comparisons = {
+			'==': 'equal',
+			'===': 'equal',
+			'>': 'gt',
+			'>=': 'gte',
+			'<': 'lt',
+			'<=': 'lte'
+		}
+		Object.entries(comparisons).forEach(([symbol, key]) => {
+			test(`${key} (${symbol})`, assert => {
+				const string = `datum.x ${symbol} 1`
+				const object = { field: 'x', [key]: 1 }
+				assert.equal(run(string), run(object))
+			})
+		})
+	})
+	test('equal (===) with string comparison', assert => {
+		const string = 'datum._ === "apple pie"'
+		assert.equal(run(string), 1)
 	})
 })


### PR DESCRIPTION
Add support for simpler [expressions](https://vega.github.io/vega/docs/expressions/) to use as [predicates](https://github.com/vijithassar/bisonica/pull/251).

These expression strings take the form `datum.{property} {operator} {value}`, so for example `datum.value > 100` or `datum.group === "a"`.

Requirements include:

- Property lookup must use dot notation, not bracket notation.
- Any property name can be used as long as it doesn't have spaces and thus works with dot notation.
- Supported operators include `<`, `<=`, `>`, `>=`, `===` and `==`. Both `===` and `==` resolve to [strict equality](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality).
- Any value can be used for comparison. Strings can include spaces and must be enclosed in either `'single quotes'` or `"double quotes"`.