### PR TITLE
normalize tooltip values

### DIFF
--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -9,6 +9,7 @@ import { memoize } from './memoize.js'
 import { noop } from './helpers.js'
 import { parseScales } from './scales.js'
 import { transformDatum } from './transform.js'
+import { values } from './values.js'
 
 /**
  * format field description
@@ -133,6 +134,19 @@ const _getTooltipField = (s, type) => {
 
 	const getValue = accessors?.[channel] ? accessors[channel] : encodingValue(s, channel)
 
+	const stack = s.encoding[channel]?.stack
+	const normalize = stack === 'normalize'
+
+	const percentage = value => {
+		let total
+		if (feature(s).isCircular()) {
+			total = d3.sum(values(s).map(encodingValue(s, channel)))
+		} else if (feature(s).isCartesian()) {
+			total = 1
+		}
+		return Math.round(value / total * 100) + '%'
+	}
+
 	return d => {
 		let value
 
@@ -149,6 +163,10 @@ const _getTooltipField = (s, type) => {
 		if (!key && !value) {
 			key = type // key may be a field, not a channel
 			value = transformDatum(s)()(d)[key]
+		}
+
+		if (normalize) {
+			value = percentage(value)
 		}
 
 		return { key, value }

--- a/tests/unit/tooltip-test.js
+++ b/tests/unit/tooltip-test.js
@@ -1,6 +1,7 @@
 import qunit from 'qunit'
 import { tooltipContent } from '../../source/tooltips.js'
 import { data } from '../../source/data.js'
+import { specificationFixture } from '../test-helpers.js'
 
 const { module, test } = qunit
 
@@ -109,6 +110,13 @@ module('unit > tooltips', () => {
 		const text = tooltipContent(transformField)(datum)
 
 		assert.equal(text, 'tooltip value is: 1')
+	})
+	test('normalizes stacked tooltip values', assert => {
+		const s = specificationFixture('circular')
+		s.encoding.theta.stack = 'normalize'
+		const datum = { data: { value: 9, group: 'a' } }
+		const text = tooltipContent(s)(datum)
+		assert.ok(text.includes('%;'), 'appends percent sign')
 	})
 	test('handles bidirectional cartesian encodings', assert => {
 		const length = { field: 'a', type: 'quantitative' }


### PR DESCRIPTION
When `encoding.stack` is [set to `"normalized"`](https://vega.github.io/vega-lite/docs/stack.html#normalized), convert the value to a percentage when supplying it to the tooltips.