### PR TITLE
set range with field

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -227,6 +227,7 @@ const domain = (s, channel) => {
  */
 const range = (s, dimensions, _channel) => {
 	const channel = channelRoot(s, _channel)
+	const scale = s.encoding[channel].scale
 	const cartesian = () => {
 		let result
 
@@ -281,11 +282,11 @@ const range = (s, dimensions, _channel) => {
 	}
 
 	const range = ranges[channel]()
-	if (s.encoding[channel].scale?.rangeMin && isContinuous(s, channel)) {
-		range[0] = s.encoding[channel].scale?.rangeMin
+	if (scale?.rangeMin && isContinuous(s, channel)) {
+		range[0] = scale?.rangeMin
 	}
-	if (s.encoding[channel].scale?.rangeMax && isContinuous(s, channel)) {
-		range[0] = s.encoding[channel].scale?.rangeMax
+	if (scale?.rangeMax && isContinuous(s, channel)) {
+		range[0] = scale?.rangeMax
 	}
 	return range
 }

--- a/source/scales.js
+++ b/source/scales.js
@@ -281,7 +281,14 @@ const range = (s, dimensions, _channel) => {
 		}
 	}
 
-	const range = ranges[channel]()
+	let range
+
+	if (scale?.range?.field) {
+		range = [...new Set(values(s).map(item => item[scale.range.field]))]
+	} else {
+		range = ranges[channel]()
+	}
+
 	if (scale?.rangeMin && isContinuous(s, channel)) {
 		range[0] = scale?.rangeMin
 	}

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -358,6 +358,33 @@ module('unit > scales', hooks => {
 		)
 	})
 
+	test('sets scale range based on field', assert => {
+		const s = {
+			data: { values: [
+				{ a: 1, b: '-' },
+				{ a: 2, b: '+' },
+				{ a: 3, b: '•' },
+				{ a: 4, b: '.' },
+				{ a: 4, b: '_' }
+			] },
+			mark: { type: 'arc' },
+			encoding: {
+				color: {
+					scale: {
+						range: {
+							field: 'b'
+						}
+					},
+					type: 'nominal'
+				}
+			}
+		}
+
+		const { color } = parseScales(s, { x: 100, y: 100 })
+
+		assert.equal(color.range().join(''), '-+•._')
+	})
+
 	module('explicit scales', () => {
 		const scales = [
 			'sqrt',


### PR DESCRIPTION
Set the scale range to an [accompanying field](https://vega.github.io/vega-lite/docs/scale.html#range).

[example](https://vega.github.io/vega-lite/docs/scale.html#example-setting-color-range-based-on-a-field).