### PR TITLE
legend spacing

### DIFF
--- a/source/index.css
+++ b/source/index.css
@@ -4,6 +4,11 @@
   text-align: center;
 }
 
+.legend h3 {
+  padding: 0;
+  margin: 0;
+}
+
 .graphic {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Reduces the spacing around the legend title text so there's enough room to render the legend items instead of banishing them into the popup.