### PR TITLE
legend popup styling

### DIFF
--- a/source/index.css
+++ b/source/index.css
@@ -2,6 +2,7 @@
   max-height: 6em;
   overflow: hidden;
   text-align: center;
+  position: relative;
 }
 
 .legend h3 {

--- a/source/index.css
+++ b/source/index.css
@@ -1,5 +1,5 @@
 .legend {
-  max-height: 6em;
+  max-height: 12em;
   overflow: hidden;
   text-align: center;
   position: relative;


### PR DESCRIPTION
Increase the legend size so the popup mode is considerably less likely to ever be triggered, and anchor it to the legend if it is.