### PR TITLE
explicit zero

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -186,17 +186,13 @@ const domainBaseValues = (s, channel) => {
 			const byPeriod = data(s)
 				.map(item => item.values)
 				.flat()
-			const nonzero = s.encoding.y.scale?.zero === false
 			const accessor = d => +d.value
 			const periodMin = d3.min(byPeriod, accessor)
-			const positive = typeof periodMin === 'number' && periodMin > 0
 
-			if (nonzero && positive) {
-				min = periodMin
-			} else if (!positive) {
-				min = periodMin
-			} else {
+			if (zero(s, channel)) {
 				min = 0
+			} else {
+				min = periodMin
 			}
 
 			max = d3.max(byPeriod, accessor)

--- a/source/scales.js
+++ b/source/scales.js
@@ -135,6 +135,22 @@ const channelRoot = (s, channel) => {
 }
 
 /**
+ * determine whether a scale starts at zero
+ * @param {object} s Vega Lite specification
+ * @param {string} channel encoding parameter
+ * @returns {boolean} whether to start the scale at zero
+ */
+const zero = (s, channel) => {
+	if (encodingType(s, channel) === 'temporal' || scaleType(s, channel) === 'log') {
+		return false
+	}
+	if (s.encoding[channel]?.scale?.zero) {
+		return !!s.encoding[channel].scale.zero
+	}
+	return ['x', 'y'].includes(channel) && !!customDomain(s, channel)
+}
+
+/**
  * compute raw values for scale domain
  * @param {object} s Vega Lite specification
  * @param {string} channel encoding parameter

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -119,15 +119,9 @@ module('unit > scales', hooks => {
 			}
 		}
 
-		const startAtZero = spec()
-		const values = startAtZero.data.values.map(d => d.value)
-		const min = Math.min.apply(null, values)
-
-		const defaultBehavior = parseScales(startAtZero, dimensions).y
-
-		assert.equal(defaultBehavior.domain()[0], 0, 'start at zero by default')
-
 		const nonzero = spec()
+		const values = nonzero.data.values.map(d => d.value)
+		const min = Math.min.apply(null, values)
 
 		nonzero.encoding.y.scale.zero = false
 

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -341,18 +341,20 @@ module('unit > scales', hooks => {
 				y: {
 					field: 'value',
 					type: 'quantitative',
-					scale: { type: 'symlog' }
+					scale: { type: 'symlog', domain: [0, 10000] }
 				}
 			}
 		}
 
+		const { y } = parseScales(spec, dimensions)
+
 		assert.strictEqual(
-			parseScales(spec, dimensions).y(100).toFixed(4),
-			'50.5953',
-			'should generate symmetric log scales'
+			Math.round(y(100)),
+			50,
+			'generates symmetric log scale'
 		)
 		assert.strictEqual(
-			parseScales(spec, dimensions).y(0).toFixed(4),
+			y(0).toFixed(4),
 			'100.0000',
 			'symmetric log scales should handle zero'
 		)


### PR DESCRIPTION
Cleanup the logic around [`encoding.scale.zero`](https://vega.github.io/vega-lite/docs/scale.html#continuous-scales), and change a few tests to match the new behavior.