### PR TITLE
radius encoding

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -62,6 +62,11 @@ const _createAccessors = (s, type = null) => {
 	if (key === 'arc') {
 		accessors.theta = d => d.data.value
 		accessors.color = d => d.data.key
+		if (feature(s).hasRadius()) {
+			accessors.radius = d => {
+				return encodingValue(s, 'radius')(d.data)
+			}
+		}
 	}
 
 	if (key === 'rule') {

--- a/source/data.js
+++ b/source/data.js
@@ -197,7 +197,16 @@ const circularData = s => {
 	)
 
 	const summed = grouped.map(({ key, values }) => {
-		return { key, value: d3.sum(values, encodingValue(s, 'theta')) }
+		const result = { key }
+		const channels = ['theta', 'radius']
+		channels
+			.forEach(channel => {
+				const key = channel === 'theta' ? 'value' : encodingField(s, channel)
+				if (key) {
+					result[key] = d3.sum(values, encodingValue(s, channel))
+				}
+			})
+		return result
 	})
 
 	return summed

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -111,7 +111,10 @@ const extentDescription = memoize(_extentDescription)
 const encodingDescription = s => {
 	let segments = []
 	if (feature(s).isCircular()) {
-		segments.push(`${encodingField(s, encodingChannelQuantitative(s))}`)
+		segments.push(`${encodingField(s, 'theta')}`)
+		if (feature(s).hasRadius()) {
+			segments.push(`and ${encodingField(s, 'radius')}`)
+		}
 	} else if (feature(s).isCartesian()) {
 		const quantitative = quantitativeChannels(s).length
 		if (quantitative === 1) {
@@ -163,6 +166,9 @@ const chartType = s => {
 	} else if (feature(s).isBar()) {
 		return 'bar chart'
 	} else if (feature(s).isCircular()) {
+		if (feature(s).hasRadius()) {
+			return 'radial plot'
+		}
 		if (s.mark && s.mark.innerRadius) {
 			return 'donut chart'
 		} else {

--- a/source/feature.js
+++ b/source/feature.js
@@ -61,6 +61,7 @@ const _feature = s => {
 		hasEncodingX: s => s.encoding?.x,
 		hasEncodingY: s => s.encoding?.y,
 		hasEncodingColor: s => s.encoding?.color,
+		hasRadius: s => s.encoding?.radius,
 		isStacked: s => {
 			return mark(s) === 'bar' &&
 				s.encoding?.y?.stack !== null &&

--- a/source/feature.js
+++ b/source/feature.js
@@ -55,7 +55,6 @@ const _feature = s => {
 		hasDownload: s => s.usermeta?.download !== null,
 		isCartesian: s => (s.encoding?.x && s.encoding?.y),
 		isLinear: s => (s.encoding?.x && !s.encoding?.y) || (s.encoding?.y && !s.encoding?.x),
-		isRadial: s => s.encoding?.theta,
 		isTemporal: () => isTemporal,
 		isMulticolor: () => isMulticolor,
 		hasEncodingX: s => s.encoding?.x,

--- a/source/marks.js
+++ b/source/marks.js
@@ -619,7 +619,7 @@ const lineMarks = (s, dimensions) => {
  * @param {object} dimensions chart dimensions
  * @returns {number} radius
  */
-const radius = dimensions => Math.min(dimensions.x, dimensions.y) * 0.5
+const maxRadius = dimensions => Math.min(dimensions.x, dimensions.y) * 0.5
 
 /**
  * render arc marks for a circular pie or donut chart
@@ -628,7 +628,7 @@ const radius = dimensions => Math.min(dimensions.x, dimensions.y) * 0.5
  * @returns {function(object)} circular chart arc renderer
  */
 const circularMarks = (s, dimensions) => {
-	const outerRadius = radius(dimensions)
+	const outerRadius = maxRadius(dimensions)
 	const innerRadiusRatio = s.mark?.innerRadius ? s.mark.innerRadius / 100 : 0
 	const innerRadius = outerRadius * innerRadiusRatio
 	const { color } = parseScales(s)
@@ -849,4 +849,4 @@ const _marks = (s, dimensions) => {
 }
 const marks = (s, dimensions) => detach(_marks(s, dimensions))
 
-export { marks, radius, barWidth, layoutDirection, markData, markSelector, markInteractionSelector, category }
+export { marks, maxRadius, barWidth, layoutDirection, markData, markSelector, markInteractionSelector, category }

--- a/source/marks.js
+++ b/source/marks.js
@@ -628,14 +628,27 @@ const maxRadius = dimensions => Math.min(dimensions.x, dimensions.y) * 0.5
  * @returns {function(object)} circular chart arc renderer
  */
 const circularMarks = (s, dimensions) => {
-	const outerRadius = maxRadius(dimensions)
+	const encoders = createEncoders(s, dimensions, createAccessors(s))
+	const { radius } = encoders
 	const innerRadiusRatio = s.mark?.innerRadius ? s.mark.innerRadius / 100 : 0
-	const innerRadius = maxRadius(dimensions) * innerRadiusRatio
 	const { color } = parseScales(s)
+	const outerRadius = d => {
+		if (radius) {
+			return radius(d)
+		} else {
+			return maxRadius(dimensions)
+		}
+	}
+	const innerRadius = () => {
+		if (radius) {
+			return innerRadiusRatio * 100
+		} else {
+			return maxRadius(dimensions) * innerRadiusRatio
+		}
+	}
 	const sort = (a, b) => color.domain().indexOf(a.group) - color.domain().indexOf(b.group)
 	const value = d => d.value
 	const layout = d3.pie().value(value).sort(sort)
-	const encoders = createEncoders(s, dimensions, createAccessors(s))
 	const renderer = selection => {
 		const marks = selection.append('g').attr('class', 'marks')
 		const mark = marks

--- a/source/marks.js
+++ b/source/marks.js
@@ -630,7 +630,7 @@ const maxRadius = dimensions => Math.min(dimensions.x, dimensions.y) * 0.5
 const circularMarks = (s, dimensions) => {
 	const outerRadius = maxRadius(dimensions)
 	const innerRadiusRatio = s.mark?.innerRadius ? s.mark.innerRadius / 100 : 0
-	const innerRadius = outerRadius * innerRadiusRatio
+	const innerRadius = maxRadius(dimensions) * innerRadiusRatio
 	const { color } = parseScales(s)
 	const sort = (a, b) => color.domain().indexOf(a.group) - color.domain().indexOf(b.group)
 	const value = d => d.value

--- a/source/position.js
+++ b/source/position.js
@@ -3,7 +3,7 @@ import { feature } from './feature.js'
 import { longestAxisTickLabelTextWidth, rotation } from './text.js'
 import { memoize } from './memoize.js'
 import { polarToCartesian } from './helpers.js'
-import { radius } from './marks.js'
+import { maxRadius } from './marks.js'
 import { layerPrimary } from './views.js'
 
 const TITLE_MARGIN = GRID * 5
@@ -111,7 +111,7 @@ const margin = memoize(_margin)
  */
 const position = (s, dimensions) => {
 	const yOffsetCircular =
-    dimensions.x > dimensions.y ? (dimensions.y - radius(dimensions) * 2) * 0.5 : 0
+    dimensions.x > dimensions.y ? (dimensions.y - maxRadius(dimensions) * 2) * 0.5 : 0
 	const middle = {
 		x: dimensions.x * 0.5,
 		y: dimensions.y * 0.5 + yOffsetCircular

--- a/source/scales.js
+++ b/source/scales.js
@@ -290,7 +290,8 @@ const range = (s, dimensions, _channel) => {
 				max = 30
 			}
 			return [min, max]
-		}
+		},
+		radius: () => [0, 100]
 	}
 
 	let range

--- a/tests/unit/data-test.js
+++ b/tests/unit/data-test.js
@@ -101,6 +101,25 @@ module('unit > data', () => {
 			assert.ok(values, 'every segment has a value')
 		})
 
+		test('computes radial chart data', assert => {
+			const s = specificationFixture('circular')
+			s.data.values = s.data.values.map(item => {
+				return {
+					...item,
+					_: item.value
+				}
+			})
+			s.encoding.radius = { field: '_', type: 'quantitative' }
+			const segments = data(s)
+			const keys = segments.every(item => typeof item.key === 'string')
+
+			assert.ok(keys, 'every segment has a key')
+
+			assert.ok(segments.every(item => typeof item._ === 'number'), 'every segment has a radius value')
+
+			assert.ok(segments.every(item => typeof item.value === 'number'), 'every segment has a theta value')
+		})
+
 		test('compiles line chart data', assert => {
 			const spec = specificationFixture('multiline')
 			const dailyTotals = data(spec, encodingField(spec, 'x'))


### PR DESCRIPTION
Implements radius encoding for [arc marks](https://vega.github.io/vega-lite/docs/arc.html#properties) to use in construction of [radial plots](https://vega.github.io/vega-lite/examples/arc_radial.html).