### PR TITLE
range endpoint cleanup

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -306,7 +306,7 @@ const range = (s, dimensions, _channel) => {
 		range[0] = scale?.rangeMin
 	}
 	if (scale?.rangeMax && isContinuous(s, channel)) {
-		range[0] = scale?.rangeMax
+		range[1] = scale?.rangeMax
 	}
 	return range
 }

--- a/source/scales.js
+++ b/source/scales.js
@@ -302,11 +302,13 @@ const range = (s, dimensions, _channel) => {
 		range = ranges[channel]()
 	}
 
-	if (scale?.rangeMin && isContinuous(s, channel)) {
-		range[0] = scale?.rangeMin
-	}
-	if (scale?.rangeMax && isContinuous(s, channel)) {
-		range[1] = scale?.rangeMax
+	if (isContinuous(s, channel)) {
+		if (scale?.rangeMin) {
+			range[0] = scale?.rangeMin
+		}
+		if (scale?.rangeMax) {
+			range[1] = scale?.rangeMax
+		}
 	}
 	return range
 }


### PR DESCRIPTION
Fix a bug with [`rangeMax`](https://vega.github.io/vega-lite/docs/scale.html#range) and clean up the surrounding code from pull request #321.