### PR TITLE
error message for scale ranges

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -317,23 +317,28 @@ const range = (s, dimensions, _channel) => {
 		radius: () => [0, 100]
 	}
 
-	let range
+	try {
+		let range
 
-	if (scale?.range?.field) {
-		range = [...new Set(values(s).map(item => item[scale.range.field]))]
-	} else {
-		range = ranges[channel]()
-	}
+		if (scale?.range?.field) {
+			range = [...new Set(values(s).map(item => item[scale.range.field]))]
+		} else {
+			range = ranges[channel]()
+		}
 
-	if (isContinuous(s, channel)) {
-		if (scale?.rangeMin) {
-			range[0] = scale?.rangeMin
+		if (isContinuous(s, channel)) {
+			if (scale?.rangeMin) {
+				range[0] = scale?.rangeMin
+			}
+			if (scale?.rangeMax) {
+				range[1] = scale?.rangeMax
+			}
 		}
-		if (scale?.rangeMax) {
-			range[1] = scale?.rangeMax
-		}
+		return range
+	} catch (error) {
+		error.message = `could not determine scale range for ${channel} channel - ${error.message}`
+		throw error
 	}
-	return range
 }
 
 /**


### PR DESCRIPTION
When implementing new encoding channels, the first error is often that a known static range has not been defined. Adding error handling for that case with a nicer explanation will make future development more pleasant.