### PR TITLE
deduplicate channels

### DIFF
--- a/source/helpers.js
+++ b/source/helpers.js
@@ -61,6 +61,33 @@ const nested = function(d, key, newValue) {
 }
 
 /**
+ * create a function which ensures channels have
+ * unique fields
+ * @param {object} s Vega Lite specification
+ * @returns {function(array)} deduplication function
+ */
+const deduplicateByField = s => {
+	const fields = Object.entries(s.encoding).map(([_, definition]) => definition.field).filter(Boolean)
+	const unique = [...new Set(fields).values()]
+	return channels => {
+		const allowed = unique.reduce((accumulator, current) => {
+			accumulator[current] = true
+			return accumulator
+		}, {})
+		let result = []
+		channels
+			.forEach(channel => {
+				const field = s.encoding[channel].field
+				if (allowed[field]) {
+					result.push(channel)
+					allowed[field] = false
+				}
+			})
+		return result
+	}
+}
+
+/**
  * get the string used when there's no appropriate name for a series
  * @returns {string} series name
  */
@@ -225,6 +252,7 @@ export {
 	mark,
 	datum,
 	nested,
+	deduplicateByField,
 	missingSeries,
 	getUrl,
 	noop,

--- a/source/table.js
+++ b/source/table.js
@@ -1,5 +1,5 @@
 import { extension } from './extensions.js'
-import { noop } from './helpers.js'
+import { deduplicateByField, noop } from './helpers.js'
 import { encodingField } from './encodings.js'
 import { layerPrimary } from './views.js'
 import { markData } from './marks.js'
@@ -25,7 +25,7 @@ const setup = s => {
  * @param {object} s Vega Lite specification
  * @returns {string[]} array of column names
  */
-const channels = s => Object.keys(s.encoding)
+const channels = s => deduplicateByField(s)(Object.keys(s.encoding))
 
 /**
  * column encoding fields

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -6,7 +6,7 @@ import { encodingChannelQuantitative, encodingField, encodingType, encodingValue
 import { feature } from './feature.js'
 import { formatAxis } from './format.js'
 import { memoize } from './memoize.js'
-import { noop } from './helpers.js'
+import { deduplicateByField, noop } from './helpers.js'
 import { parseScales } from './scales.js'
 import { transformDatum } from './transform.js'
 import { values } from './values.js'
@@ -40,7 +40,10 @@ const _includedChannels = s => {
 		excluded.push('color')
 	}
 
-	return Object.keys(s.encoding).filter(channel => excluded.includes(channel) === false)
+	const included = Object.keys(s.encoding)
+		.filter(channel => excluded.includes(channel) === false)
+
+	return deduplicateByField(s)(included)
 }
 
 /**

--- a/tests/unit/helpers-test.js
+++ b/tests/unit/helpers-test.js
@@ -28,4 +28,13 @@ module('unit > helpers', () => {
 		assert.ok(selection.select('g.test').size(), 1)
 		assert.ok(selection.select('circle').size(), 1)
 	})
+	test('deduplicates channels by field', assert => {
+		const s = {
+			encoding: {
+				'x': { field: 'a' },
+				'y': { field: 'a' }
+			}
+		}
+		assert.equal(helpers.deduplicateByField(s)(Object.keys(s.encoding)).length, 1)
+	})
 })


### PR DESCRIPTION
It's possible to reuse channels for redundant encodings, such as a bar chart where every bar is a different color because color and bar position are reading from the same data field. When that is expressed via text as with a tooltip or a [table](https://github.com/vijithassar/bisonica/pull/189) or the `aria-label` attribute, however, the redundant visual mapping becomes redundant text. Cleaning this up requires deduplicating the _channels_ by making sure the associated _fields_ are never repeated.