### PR TITLE
step

### DIFF
--- a/source/config.js
+++ b/source/config.js
@@ -1,7 +1,5 @@
 const WRAPPER_CLASS = 'wrapper'
 
-const BAR_WIDTH_MINIMUM = 2
-
 const GRID = 10
 
 const MINIMUM_TICK_COUNT = 3
@@ -12,6 +10,5 @@ export {
 	WRAPPER_CLASS,
 	GRID,
 	MINIMUM_TICK_COUNT,
-	BAR_WIDTH_MINIMUM,
 	RENDER_FREQUENCY
 }

--- a/source/marks.js
+++ b/source/marks.js
@@ -1,6 +1,5 @@
 import * as d3 from 'd3'
 
-import { BAR_WIDTH_MINIMUM } from './config.js'
 import { createAccessors } from './accessors.js'
 import {
 	createEncoders,
@@ -67,7 +66,10 @@ const defaultSize = 30
  */
 const _barWidth = (s, dimensions) => {
 	const channel = encodingChannelCovariateCartesian(s)
-	const barWidthMaximum = dimensions[channel] / 3
+
+	const min = 2
+	const max = dimensions[channel] / 3
+
 	const stacked = markData(s)
 	const type = encodingType(s, channel)
 	const temporal = type === 'temporal'
@@ -94,12 +96,12 @@ const _barWidth = (s, dimensions) => {
 
 	const dynamic = (dimensions[channel] / count) * 0.5
 
-	if (dynamic > BAR_WIDTH_MINIMUM && dynamic < barWidthMaximum) {
+	if (dynamic > min && dynamic < max) {
 		return dynamic
-	} else if (dynamic < BAR_WIDTH_MINIMUM) {
-		return BAR_WIDTH_MINIMUM
-	} else if (dynamic > barWidthMaximum) {
-		return barWidthMaximum
+	} else if (dynamic < min) {
+		return min
+	} else if (dynamic > max) {
+		return max
 	}
 }
 const barWidth = memoize(_barWidth)

--- a/source/marks.js
+++ b/source/marks.js
@@ -59,12 +59,12 @@ const stroke = 3
 const defaultSize = 30
 
 /**
- * bar chart bar width
+ * partition dimensions into categorical steps
  * @param {object} s Vega Lite specification
  * @param {object} dimensions chart dimensions
- * @returns {number} bar width
+ * @returns {number} step size in pixels
  */
-const _barWidth = (s, dimensions) => {
+const _step = (s, dimensions) => {
 	const channel = encodingChannelCovariateCartesian(s)
 
 	const min = 2
@@ -104,7 +104,8 @@ const _barWidth = (s, dimensions) => {
 		return max
 	}
 }
-const barWidth = memoize(_barWidth)
+const step = memoize(_step)
+const barWidth = step
 
 /**
  * retrieve the d3 curve factory function needed for the marks
@@ -199,7 +200,7 @@ const stackEncoders = (s, dimensions) => {
 	const lane = encoders[encodingChannelCovariateCartesian(s)]
 	const start = encoders.start
 	const length = encoders.length
-	const width = () => barWidth(s, dimensions)
+	const width = () => step(s, dimensions)
 
 	return {
 		x: vertical ? lane : start,
@@ -864,4 +865,4 @@ const _marks = (s, dimensions) => {
 }
 const marks = (s, dimensions) => detach(_marks(s, dimensions))
 
-export { marks, maxRadius, barWidth, layoutDirection, markData, markSelector, markInteractionSelector, category }
+export { marks, maxRadius, step, barWidth, layoutDirection, markData, markSelector, markInteractionSelector, category }

--- a/source/scales.js
+++ b/source/scales.js
@@ -8,6 +8,7 @@ import { identity, isContinuous, isDiscrete, isTextChannel } from './helpers.js'
 import { memoize } from './memoize.js'
 import { parseTime, temporalBarDimensions } from './time.js'
 import { sorter } from './sort.js'
+import { step } from './marks.js'
 
 const defaultDimensions = { x: 0, y: 0 }
 
@@ -296,8 +297,8 @@ const range = (s, dimensions, _channel) => {
 		detail: () => {
 			return s.encoding.detail?.scale?.range || Array.from({ length: categoryCount(s, channel) }).map(() => null)
 		},
-		yOffset: () => [dimensions.y, 0],
-		xOffset: () => [0, dimensions.x],
+		yOffset: () => [step(s, dimensions).y, 0],
+		xOffset: () => [0, step(s, dimensions).x],
 		size: () => {
 			let min = 0
 			let max


### PR DESCRIPTION
The computation performed by the `barWidth()` function can be used for things other than bars, notably with band scales and ordinal scales. For this reason it's called [`step`](https://vega.github.io/vega-lite/docs/size.html#specifying-width-and-height-per-discrete-step) in the Vega Lite documentation. Time to rename it.