### PR TITLE
encoding titles

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -76,7 +76,7 @@ const ticks = (s, channel) => {
  */
 const axisTitle = (s, channel) => {
 	const encoding = s.encoding[channel]
-	return encoding.axis?.title || encoding.field
+	return encoding.axis?.title || encoding.title || encoding.field
 }
 
 /**

--- a/source/legend.js
+++ b/source/legend.js
@@ -38,7 +38,7 @@ function createLegendItem(config) {
  * @returns {string} legend title
  */
 const legendTitle = s => {
-	return s.encoding.color.legend?.title || encodingField(s, 'color')
+	return s.encoding.color.legend?.title || s.encoding.color.title || encodingField(s, 'color')
 }
 
 /**


### PR DESCRIPTION
Allow the `title` property at the top level of an encoding channel definition instead of requiring it to be nested under the `axis` or `legend` objects.