### PR TITLE
color schemes

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -291,7 +291,11 @@ const range = (s, dimensions, _channel) => {
 		x: cartesian,
 		y: cartesian,
 		color: () => {
-			return s.encoding.color?.scale?.range || colors(s, categoryCount(s, channel))
+			if (s.encoding.color?.scale?.range) {
+				return s.encoding.color.scale.range
+			} else {
+				return colors(s, categoryCount(s, channel))
+			}
 		},
 		theta: () => [0, Math.PI * 2],
 		detail: () => {

--- a/tests/unit/color-test.js
+++ b/tests/unit/color-test.js
@@ -27,4 +27,12 @@ module('unit > color', () => {
 			assert.notEqual(range(s), standard, variant)
 		})
 	})
+	test('supports named color schemes', assert => {
+		const normal = specificationFixture('circular')
+		const normalRange = parseScales(normal).color.range()
+		const accent = specificationFixture('circular')
+		accent.encoding.color.scheme = 'accent'
+		const accentRange = parseScales(accent).color.range()
+		assert.notEqual(normalRange.join(' '), accentRange.join(' '))
+	})
 })


### PR DESCRIPTION
Adds support for [named color schemes](https://vega.github.io/vega-lite/docs/scale.html#scheme) as defined by [Vega](https://vega.github.io/vega/docs/schemes/#reference) and [`d3-scale-chromatic`](https://github.com/d3/d3-scale-chromatic).