### PR TITLE
invert scales

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -339,6 +339,11 @@ const range = (s, dimensions, _channel) => {
 				range[1] = scale?.rangeMax
 			}
 		}
+
+		if (s.encoding[channel].reverse) {
+			range.reverse()
+		}
+
 		return range
 	} catch (error) {
 		error.message = `could not determine scale range for ${channel} channel - ${error.message}`

--- a/tests/unit/scales-test.js
+++ b/tests/unit/scales-test.js
@@ -146,6 +146,15 @@ module('unit > scales', hooks => {
 		assert.equal(negativeScales.domain()[0], -100, 'overridden by negative numbers')
 	})
 
+	test('reverses scale ranges', assert => {
+		const forward = specificationFixture('circular')
+		const forwardRange = parseScales(forward).color.range()
+		const reverse = specificationFixture('circular')
+		reverse.encoding.color.reverse = true
+		const reverseRange = parseScales(reverse).color.range()
+		assert.equal(forwardRange.join(' '), reverseRange.reverse().join(' '))
+	})
+
 	test('uses custom domains', assert => {
 		const s = {
 			data: {


### PR DESCRIPTION
Allow any encoding to invert the scale range by setting `channel.reverse: true`.