### PR TITLE
generate categorical ranges from continuous color scheme

### DIFF
--- a/source/color.js
+++ b/source/color.js
@@ -98,9 +98,13 @@ const scheme = (_count, config) => {
 	const name = object ? config.name : config
 	const count = object ? config.count : _count
 	const key = name.slice(0, 1).toUpperCase() + name.slice(1)
-	const scheme = d3[`scheme${key}`]
+	const scheme = d3[`scheme${key}`] || d3[`interpolate${key}`]
 	if (!scheme) {
 		throw new Error(`unknown color scheme ${name}`)
+	}
+	const callable = typeof scheme === 'function'
+	if (callable) {
+		return Array.from({ length: count }).map((_, index) => scheme(1 / count * index))
 	}
 	const nested = Array.isArray([...scheme].pop())
 	if (!nested) {


### PR DESCRIPTION
Convert continuous color schemes into categorical ranges by mapping the color scheme functions into an array of colors, thereby extending the color scheme support from pull request #338 to also cover the [diverging](https://github.com/d3/d3-scale-chromatic#diverging), sequential [single-hue](https://github.com/d3/d3-scale-chromatic#sequential-single-hue) and [multi-hue](https://github.com/d3/d3-scale-chromatic#sequential-multi-hue), and [cyclical](https://github.com/d3/d3-scale-chromatic#cyclical) schemes provided by `d3-scale-chromatic`.