### PR TITLE
fix color scheme property

### DIFF
--- a/source/color.js
+++ b/source/color.js
@@ -128,8 +128,8 @@ const colors = (s, count) => {
 	const variant = extension(s, 'color')?.variant
 	if (variant) {
 		return alternate(accessibleColors(count, variant))
-	} else if (s.encoding.color?.scheme) {
-		return scheme(count, s.encoding.color.scheme)
+	} else if (s.encoding.color?.scale?.scheme) {
+		return scheme(count, s.encoding.color.scale.scheme)
 	} else {
 		return alternate(standardColors(count))
 	}

--- a/tests/unit/color-test.js
+++ b/tests/unit/color-test.js
@@ -31,7 +31,7 @@ module('unit > color', () => {
 		const normal = specificationFixture('circular')
 		const normalRange = parseScales(normal).color.range()
 		const accent = specificationFixture('circular')
-		accent.encoding.color.scheme = 'accent'
+		accent.encoding.color.scale = { scheme: 'accent' }
 		const accentRange = parseScales(accent).color.range()
 		assert.notEqual(normalRange.join(' '), accentRange.join(' '))
 	})


### PR DESCRIPTION
The custom color schemes from pull request #338 should be controlled by the nested property `encoding.color.scale.scheme`, not a top level `encoding.color.scheme`.