### PR TITLE
step dimensions

### DIFF
--- a/source/chart.js
+++ b/source/chart.js
@@ -7,7 +7,7 @@ import { keyboard } from './keyboard.js'
 import { layerMarks } from './views.js'
 import { legend } from './legend.js'
 import { margin, position } from './position.js'
-import { marks } from './marks.js'
+import { markData, marks } from './marks.js'
 import { testAttributes } from './markup.js'
 import { usermeta } from './extensions.js'
 import { table, tableOptions } from './table.js'
@@ -32,13 +32,33 @@ const render = (s, _panelDimensions) => {
 		try {
 			selection.html('')
 
-			let panelDimensions
+			let panelDimensions = { x: null, y: null }
 			if (_panelDimensions) {
-				panelDimensions = _panelDimensions
-			} else if (s.height && s.width) {
-				panelDimensions = {
-					x: s.width === 'container' ? selection.node().getBoundingClientRect().width : s.width,
-					y: s.height === 'container' ? selection.node().getBoundingClientRect().height : s.height
+				panelDimensions.x = _panelDimensions.x
+				panelDimensions.y = _panelDimensions.y
+			} else {
+				const marks = feature(s).isBar() ? markData(s)[0].length : 1
+				if (s.width) {
+					if (s.width === 'container') {
+						panelDimensions.x = selection.node().getBoundingClientRect().width
+					} else if (s.width.step) {
+						panelDimensions.x = s.width.step * marks
+					} else if (typeof s.width === 'number') {
+						panelDimensions.x = s.width
+					} else if (_panelDimensions.x) {
+						panelDimensions.x = _panelDimensions.x
+					}
+				}
+				if (s.height) {
+					if (s.height === 'container') {
+						panelDimensions.y = selection.node().getBoundingClientRect().height
+					} else if (s.height.step) {
+						panelDimensions.y = s.height.step * marks
+					} else if (typeof s.height === 'number') {
+						panelDimensions.y = s.height
+					} else if (_panelDimensions.y) {
+						panelDimensions.y = _panelDimensions.y
+					}
 				}
 			}
 

--- a/source/chart.js
+++ b/source/chart.js
@@ -7,7 +7,7 @@ import { keyboard } from './keyboard.js'
 import { layerMarks } from './views.js'
 import { legend } from './legend.js'
 import { margin, position } from './position.js'
-import { markData, marks } from './marks.js'
+import { marks } from './marks.js'
 import { testAttributes } from './markup.js'
 import { usermeta } from './extensions.js'
 import { table, tableOptions } from './table.js'
@@ -15,6 +15,7 @@ import { feature } from './feature.js'
 import { fetchAll } from './fetch.js'
 import { copyMethods } from './helpers.js'
 import { download } from './download.js'
+import { dimensions } from './dimensions.js'
 
 /**
  * generate chart rendering function based on
@@ -32,35 +33,7 @@ const render = (s, _panelDimensions) => {
 		try {
 			selection.html('')
 
-			let panelDimensions = { x: null, y: null }
-			if (_panelDimensions) {
-				panelDimensions.x = _panelDimensions.x
-				panelDimensions.y = _panelDimensions.y
-			} else {
-				const marks = feature(s).isBar() ? markData(s)[0].length : 1
-				if (s.width) {
-					if (s.width === 'container') {
-						panelDimensions.x = selection.node().getBoundingClientRect().width
-					} else if (s.width.step) {
-						panelDimensions.x = s.width.step * marks
-					} else if (typeof s.width === 'number') {
-						panelDimensions.x = s.width
-					} else if (_panelDimensions.x) {
-						panelDimensions.x = _panelDimensions.x
-					}
-				}
-				if (s.height) {
-					if (s.height === 'container') {
-						panelDimensions.y = selection.node().getBoundingClientRect().height
-					} else if (s.height.step) {
-						panelDimensions.y = s.height.step * marks
-					} else if (typeof s.height === 'number') {
-						panelDimensions.y = s.height
-					} else if (_panelDimensions.y) {
-						panelDimensions.y = _panelDimensions.y
-					}
-				}
-			}
+			let panelDimensions = dimensions(s, selection.node(), _panelDimensions)
 
 			selection.call(setupNode(s, panelDimensions))
 
@@ -94,12 +67,12 @@ const render = (s, _panelDimensions) => {
 			const { top, right, bottom, left } = margin(s, panelDimensions)
 
 			// subtract rendered height of legend from dimensions
-			const dimensions = {
+			const graphicDimensions = {
 				x: panelDimensions.x - left - right,
 				y: imageHeight - top - bottom
 			}
 
-			if (dimensions.y > 0) {
+			if (graphicDimensions.y > 0) {
 				const wrapper = chartNode
 					.select('.graphic')
 					.select('svg')
@@ -107,8 +80,8 @@ const render = (s, _panelDimensions) => {
 					.select(`g.${WRAPPER_CLASS}`)
 
 				wrapper
-					.call(axes(s, dimensions))
-					.call((s.layer ? layerMarks : marks)(s, dimensions))
+					.call(axes(s, graphicDimensions))
+					.call((s.layer ? layerMarks : marks)(s, graphicDimensions))
 					.call(keyboard(s))
 					.call(interactions(s))
 				selection.call(testAttributes)

--- a/source/dimensions.js
+++ b/source/dimensions.js
@@ -1,6 +1,11 @@
 import { feature } from './feature.js'
 import { markData } from './marks.js'
 
+const channels = {
+	x: 'width',
+	y: 'height'
+}
+
 /**
  * determine rendering size for chart
  * @param {object} s Vega Lite specification
@@ -10,34 +15,20 @@ import { markData } from './marks.js'
  */
 const dimensions = (s, node, explicitDimensions) => {
 	let result = { x: null, y: null }
-	if (_panelDimensions) {
-		result.x = _panelDimensions.x
-		result.y = _panelDimensions.y
-	} else {
-		const marks = feature(s).isBar() ? markData(s)[0].length : 1
-		if (s.width) {
-			if (s.width === 'container') {
-				result.x = node.getBoundingClientRect().width
-			} else if (s.width.step) {
-				result.x = s.width.step * marks
-			} else if (typeof s.width === 'number') {
-				result.x = s.width
-			} else if (_panelDimensions.x) {
-				result.x = _panelDimensions.x
+	const marks = feature(s).isBar() ? markData(s)[0].length : 1
+	Object.entries(channels).forEach(([channel, dimension]) => {
+		if (explicitDimensions?.[channel]) {
+			result[channel] = explicitDimensions[channel]
+		} else if (s[dimension]) {
+			if (s[dimension] === 'container') {
+				result[channel] = node.getBoundingClientRect()[dimension]
+			} else if (s[dimension].step) {
+				result[channel] = s[dimension].step * marks
+			} else if (typeof s[dimension] === 'number') {
+				result[channel] = s[dimension]
 			}
 		}
-		if (s.height) {
-			if (s.height === 'container') {
-				result.y = node.getBoundingClientRect().height
-			} else if (s.height.step) {
-				result.y = s.height.step * marks
-			} else if (typeof s.height === 'number') {
-				result.y = s.height
-			} else if (_panelDimensions.y) {
-				result.y = _panelDimensions.y
-			}
-		}
-	}
+	})
 	return result
 }
 

--- a/source/dimensions.js
+++ b/source/dimensions.js
@@ -5,10 +5,10 @@ import { markData } from './marks.js'
  * determine rendering size for chart
  * @param {object} s Vega Lite specification
  * @param {HTMLElement} node DOM node
- * @param {object} [_panelDimensions] chart dimensions
+ * @param {object} [explicitDimensions] chart dimensions
  * @returns {object} chart dimensions
  */
-const dimensions = (s, node, _panelDimensions) => {
+const dimensions = (s, node, explicitDimensions) => {
 	let result = { x: null, y: null }
 	if (_panelDimensions) {
 		result.x = _panelDimensions.x

--- a/source/dimensions.js
+++ b/source/dimensions.js
@@ -1,0 +1,44 @@
+import { feature } from './feature.js'
+import { markData } from './marks.js'
+
+/**
+ * determine rendering size for chart
+ * @param {object} s Vega Lite specification
+ * @param {HTMLElement} node DOM node
+ * @param {object} [_panelDimensions] chart dimensions
+ * @returns {object} chart dimensions
+ */
+const dimensions = (s, node, _panelDimensions) => {
+	let result = { x: null, y: null }
+	if (_panelDimensions) {
+		result.x = _panelDimensions.x
+		result.y = _panelDimensions.y
+	} else {
+		const marks = feature(s).isBar() ? markData(s)[0].length : 1
+		if (s.width) {
+			if (s.width === 'container') {
+				result.x = node.getBoundingClientRect().width
+			} else if (s.width.step) {
+				result.x = s.width.step * marks
+			} else if (typeof s.width === 'number') {
+				result.x = s.width
+			} else if (_panelDimensions.x) {
+				result.x = _panelDimensions.x
+			}
+		}
+		if (s.height) {
+			if (s.height === 'container') {
+				result.y = node.getBoundingClientRect().height
+			} else if (s.height.step) {
+				result.y = s.height.step * marks
+			} else if (typeof s.height === 'number') {
+				result.y = s.height
+			} else if (_panelDimensions.y) {
+				result.y = _panelDimensions.y
+			}
+		}
+	}
+	return result
+}
+
+export { dimensions }

--- a/tests/integration/chart-test.js
+++ b/tests/integration/chart-test.js
@@ -25,4 +25,14 @@ module('unit > chart', () => {
 		const marks = selection.selectAll(testSelector('mark'))
 		assert.equal(marks.size(), s.data.values.length)
 	})
+	test('creates a chart function with step dimension in specification', assert => {
+		const s = specificationFixture('categoricalBar')
+		s.width = { step: 50 }
+		s.height = dimensions.y
+		const selection = d3.create('svg:svg').append('svg:g')
+		const renderer = chart(s)
+		selection.call(renderer)
+		const marks = selection.selectAll(testSelector('mark'))
+		assert.equal(marks.size(), s.data.values.length)
+	})
 })

--- a/tests/integration/dimensions-test.js
+++ b/tests/integration/dimensions-test.js
@@ -5,9 +5,9 @@ import * as d3 from 'd3'
 
 const { module, test } = qunit
 
-module('unit > chart', () => {
+module('unit > dimensions', () => {
 	const dimensions = { x: 500, y: 500 }
-	test('creates a chart function with separate dimensions object', assert => {
+	test('renders a chart with separate dimensions object', assert => {
 		const s = specificationFixture('circular')
 		const selection = d3.create('svg:svg').append('svg:g')
 		const renderer = chart(s, dimensions)
@@ -15,7 +15,7 @@ module('unit > chart', () => {
 		const marks = selection.selectAll(testSelector('mark'))
 		assert.equal(marks.size(), s.data.values.length)
 	})
-	test('creates a chart function with dimensions in specification', assert => {
+	test('renders a chart with dimensions in specification', assert => {
 		const s = specificationFixture('circular')
 		s.width = dimensions.x
 		s.height = dimensions.y
@@ -25,7 +25,7 @@ module('unit > chart', () => {
 		const marks = selection.selectAll(testSelector('mark'))
 		assert.equal(marks.size(), s.data.values.length)
 	})
-	test('creates a chart function with step dimension in specification', assert => {
+	test('renders a chart with step dimension in specification', assert => {
 		const s = specificationFixture('categoricalBar')
 		s.width = { step: 50 }
 		s.height = dimensions.y


### PR DESCRIPTION
Instead of always requiring a `dimensions` object `{ x, y }` at the top level as an input to the `chart()` function, the `specification` can [include dimensions](https://vega.github.io/vega-lite/docs/size.html) under the `height` and `width` properties. This was previously implemented for integers in pull request #308 and for the string value `"container"` in pull request #313, which provides dynamic sizing.

This pull request now further extends that functionality to support [objects with `step` properties](https://vega.github.io/vega-lite/docs/size.html#specifying-width-and-height-per-discrete-step) as valid values for the dimensions. In those cases, the `step` value is multiplied by the number of marks to determine the desired total size.

It also moves the whole thing out from the `chart()` function and into a dedicated `dimensions.js` module.

This implementation is still a bit odd in two ways:

1. It doesn't quite align with `step` as defined in pull request #333, though it probably should; they're very similar concepts, but the integer values don't actually match.
2. Step sizing is only used for bar marks for now.