### PR TITLE
raw data download links

### DIFF
--- a/source/download.js
+++ b/source/download.js
@@ -15,25 +15,23 @@ const download = s => {
 	if (!feature(s).hasDownload()) {
 		return noop
 	}
-	const handler = event => {
-		const format = event.target.innerText
-		let file
-		if (format === 'csv') {
-			file = new Blob([csvFormat(values(s))], { type: 'text/csv' })
-		} else if (format === 'json') {
-			file = new Blob([JSON.stringify(s)], { type: 'text/json' })
-		}
-		window.open(URL.createObjectURL(file))
-	}
 	return selection => {
 		selection.append('h3').text('download')
 		formats.forEach(format => {
-			if (extension(s, 'download')?.[format] !== false) {
-				selection
-					.append('a')
-					.text(format)
-					.on('click', handler)
+			if (extension(s, 'download')?.[format] === false || !values(s)) {
+				return
 			}
+			let file
+			if (format === 'csv') {
+				file = new Blob([csvFormat(values(s))], { type: 'text/csv' })
+			} else if (format === 'json') {
+				file = new Blob([JSON.stringify(s)], { type: 'text/json' })
+			}
+			const url = URL.createObjectURL(file)
+			selection
+				.append('a')
+				.text(format)
+				.attr('href', url)
 		})
 	}
 }

--- a/source/download.js
+++ b/source/download.js
@@ -3,8 +3,26 @@ import { noop } from './helpers.js'
 import { values } from './values.js'
 import { csvFormat } from 'd3'
 import { feature } from './feature.js'
+import { memoize } from './memoize.js'
 
 const formats = ['csv', 'json']
+
+/**
+ * create a data download URL
+ * @param {object} s Vega Lite specification
+ * @param {'csv'|'json'} format data format
+ */
+const _url = (s, format) => {
+	let file
+	if (format === 'csv') {
+		file = new Blob([csvFormat(values(s))], { type: 'text/csv' })
+	} else if (format === 'json') {
+		file = new Blob([JSON.stringify(s)], { type: 'text/json' })
+	}
+	const url = URL.createObjectURL(file)
+	return url
+}
+const url = memoize(_url)
 
 /**
  * render download links
@@ -21,17 +39,10 @@ const download = s => {
 			if (extension(s, 'download')?.[format] === false || !values(s)) {
 				return
 			}
-			let file
-			if (format === 'csv') {
-				file = new Blob([csvFormat(values(s))], { type: 'text/csv' })
-			} else if (format === 'json') {
-				file = new Blob([JSON.stringify(s)], { type: 'text/json' })
-			}
-			const url = URL.createObjectURL(file)
 			selection
 				.append('a')
 				.text(format)
-				.attr('href', url)
+				.attr('href', url(s, format))
 		})
 	}
 }

--- a/tests/browser-shim.cjs
+++ b/tests/browser-shim.cjs
@@ -15,6 +15,16 @@ const svg = () => {
     getBBox();
 };
 
+const url = () => {
+    let counter = 0
+    if (!window.URL?.createObjectURL) {
+        window.URL.createObjectURL = (content) => {
+            counter++
+            return `https://test/${counter}`
+        }
+    }
+}
+
 const context = () => {
     const pixelsPerCharacter = 5;
     window.HTMLCanvasElement.prototype.getContext = () => {
@@ -39,3 +49,4 @@ const audio = () => {
 svg();
 canvas();
 audio();
+url();

--- a/tests/browser-shim.cjs
+++ b/tests/browser-shim.cjs
@@ -18,7 +18,7 @@ const svg = () => {
 const url = () => {
     let counter = 0
     if (!window.URL?.createObjectURL) {
-        window.URL.createObjectURL = (content) => {
+        window.URL.createObjectURL = () => {
             counter++
             return `https://test/${counter}`
         }


### PR DESCRIPTION
Precompute the [object URLs](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static) for [raw data downloads](https://github.com/vijithassar/bisonica/pull/298) and attach them to `href` attributes on the link anchors instead of doing it on the fly after the user clicks. This is better for navigation with assistive technologies.