### PR TITLE
add parentheses to function name in error message

### DIFF
--- a/source/helpers.js
+++ b/source/helpers.js
@@ -210,7 +210,7 @@ const detach = (fn, ...rest) => {
 			detached.call(fn, ...rest)
 			selection.append(() => detached.node())
 		} catch (error) {
-			const identifier = fn.name ? `function ${fn.name}` : 'function'
+			const identifier = fn.name ? `function ${fn.name}()` : 'function'
 			error.message = `could not run ${identifier} with detached <${tag}> node - ${error.message}`
 			throw error
 		}


### PR DESCRIPTION
Append parentheses to the [function name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name) to make the resulting error message clearer.