### PR TITLE
custom menu items

### DIFF
--- a/source/menu.js
+++ b/source/menu.js
@@ -1,17 +1,29 @@
 import { feature } from './feature.js'
 import { extension } from './extensions.js'
+import { key } from './helpers.js'
 import { download } from './download.js'
+
+/**
+ * create a menu configuration object for a data download
+ * @param {object} s Vega Lite specification
+ * @param {'csv'|'json'} format data format
+ * @returns {object} menu item configuration object
+ */
+const item = (s, format) => {
+	return { text: format, href: download(s, format) }
+}
 
 /**
  * determine menu content
  * @param {object} s Vega Lite specification
- * @returns {string[]} menu items
+ * @returns {object[]} menu item configuration objects
  */
 const items = s => {
 	const download = feature(s).hasDownload() && extension(s, 'download')
 	return [
-		download?.csv !== false ? 'csv' : null,
-		download?.json !== false ? 'json' : null
+		download?.csv !== false ? item(s, 'csv') : null,
+		download?.json !== false ? item(s, 'json') : null,
+		...(extension(s, 'menu')?.items ? extension(s, 'menu')?.items : [])
 	].filter(Boolean)
 }
 
@@ -29,11 +41,11 @@ const menu = s => {
 			.data(items(s))
 			.enter()
 			.append('li')
-			.attr('data-menu', item => item)
+			.attr('data-menu', item => key(item.text))
 			.classed('item', true)
 			.append('a')
-			.text(item => item)
-			.attr('href', item => download(s, item))
+			.text(item => item.text)
+			.attr('href', item => item.href)
 	}
 }
 

--- a/tests/integration/menu-test.js
+++ b/tests/integration/menu-test.js
@@ -1,0 +1,11 @@
+import qunit from 'qunit'
+import { render, testSelector, specificationFixture } from '../test-helpers.js'
+
+const { module, test } = qunit
+
+module('integration > menu', function() {
+	test('renders a menu', assert => {
+		const element = render(specificationFixture('circular'))
+		assert.ok(element.querySelector(testSelector('menu-item')))
+	})
+})

--- a/tests/integration/menu-test.js
+++ b/tests/integration/menu-test.js
@@ -8,4 +8,20 @@ module('integration > menu', function() {
 		const element = render(specificationFixture('circular'))
 		assert.ok(element.querySelector(testSelector('menu-item')))
 	})
+	test('adds custom menu items', assert => {
+		const items = [
+			{ text: 'WCAG', href: 'https://www.w3.org/WAI/standards-guidelines/wcag/' },
+			{ text: 'Vega Lite', href: 'https://vega.github.io/vega-lite/' }
+		]
+		const s = specificationFixture('circular')
+		s.usermeta = {}
+		s.usermeta.menu = { items }
+		const element = render(s)
+		const labels = [...element.querySelectorAll(testSelector('menu-item'))].map(node => node.textContent)
+		items
+			.map(item => item.text)
+			.forEach(text => {
+				assert.ok(labels.includes(text))
+			})
+	})
 })


### PR DESCRIPTION
Allow the caller to add custom links to the [menu](https://github.com/vijithassar/bisonica/pull/348).

To use this, add an array of `items` to the top level [`usermeta`](https://vega.github.io/vega-lite/docs/spec.html#top-level) property of the specification, each of which is an object containing `text` and `href` properties.

```javascript
specification.usermeta = {
  menu: {
    items: [
      { text: 'Example', href: 'https://www.example.com' }
    ]
  }
}
```