### PR TITLE
streamgraphs

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -158,6 +158,10 @@ const stackData = s => {
 		stacker.offset(d3.stackOffsetExpand)
 	}
 
+	if (stackOffset(s) === 'center') {
+		stacker.offset(d3.stackOffsetSilhouette)
+	}
+
 	const stacked = stacker(summed)
 	const single = stacked.length === 1
 

--- a/source/scales.js
+++ b/source/scales.js
@@ -193,7 +193,14 @@ const domainBaseValues = (s, channel) => {
 			if (channel === 'x' || channel === 'y') {
 				min = baseline(s, channel)
 			}
-			max = stackOffset(s) === 'normalize' ? 1 : d3.max(sumByCovariates(s))
+			if (stackOffset(s) === 'normalize') {
+				max = 1
+			} else if (stackOffset(s) === 'center') {
+				max = d3.max(d3.extent(sumByCovariates(s)).map(Math.abs))
+				min = max * -1
+			} else {
+				max = d3.max(sumByCovariates(s))
+			}
 		} else if (feature(s).isLine()) {
 			const byPeriod = data(s)
 				.map(item => item.values)


### PR DESCRIPTION
Allows the [`encoding.stack` property](https://vega.github.io/vega-lite/docs/stack.html#encoding) to set a [center offset](https://github.com/d3/d3-shape#stack-offsets) for use in [streamgraphs](https://vega.github.io/vega-lite/examples/stacked_area_stream.html).