### PR TITLE
fit streamgraph to size

### DIFF
--- a/source/scales.js
+++ b/source/scales.js
@@ -196,7 +196,7 @@ const domainBaseValues = (s, channel) => {
 			if (stackOffset(s) === 'normalize') {
 				max = 1
 			} else if (stackOffset(s) === 'center') {
-				max = d3.max(d3.extent(sumByCovariates(s)).map(Math.abs))
+				max = d3.max(d3.extent(sumByCovariates(s)).map(Math.abs)) * 0.5
 				min = max * -1
 			} else {
 				max = d3.max(sumByCovariates(s))


### PR DESCRIPTION
Improves the readability of [streamgraphs](https://vega.github.io/vega-lite/examples/stacked_area_stream.html) by cutting the maximum value used for the domain in half, thereby increasing the rendering size to fill the available space.