### PR TITLE
custom type definitions

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -4,6 +4,8 @@
  * @see {@link https://vega.github.io/vega-lite/docs/axis.html|vega-lite:axis}
  */
 
+import './types.d.js'
+
 import * as d3 from 'd3'
 
 import { axisTicksLabelText, rotation, truncate } from './text.js'
@@ -119,7 +121,7 @@ const tickText = (s, channel) => {
 /**
  * y axis positions
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {object} y axis positions
  */
 const axisOffsetY = (s, dimensions) => {
@@ -147,7 +149,7 @@ const axisOffsetY = (s, dimensions) => {
 /**
  * create x axis
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} x axis creator
  */
 const createX = (s, dimensions) => {
@@ -189,7 +191,7 @@ const createX = (s, dimensions) => {
 /**
  * create y axis
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} y axis creator
  */
 const createY = (s, dimensions) => {
@@ -216,7 +218,7 @@ const createY = (s, dimensions) => {
 /**
  * render x axis title
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} x axis title renderer
  */
 const axisTitleX = (s, dimensions) => {
@@ -246,7 +248,7 @@ const axisTitleX = (s, dimensions) => {
 /**
  * render y axis title
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} y axis title renderer
  */
 const axisTitleY = (s, dimensions) => {
@@ -274,7 +276,7 @@ const axisTitleY = (s, dimensions) => {
 /**
  * extend ticks across the chart
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} y axis tick extension adjustment function
  */
 const axisTicksExtensionY = (s, dimensions) => {
@@ -294,7 +296,7 @@ const axisTicksExtensionY = (s, dimensions) => {
 /**
  * adjust y axis tick rotation based on a live DOM node
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} y axis tick rotation adjustment function
  */
 const axisTicksRotationY = (s, dimensions) => {
@@ -338,7 +340,7 @@ const axisTicksRotationX = s => {
 /**
  * adjust axis titles based on a live DOM node
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} axis title adjustment function
  */
 const axisTitles = (s, dimensions) => {
@@ -351,7 +353,7 @@ const axisTitles = (s, dimensions) => {
 /**
  * adjust axis ticks based on a live DOM node
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} axis tick adjustment function
  */
 const axisTicks = (s, dimensions) => {
@@ -407,7 +409,7 @@ const axisTicksStyles = (s, channel) => {
 /**
  * run functions that require a live DOM node
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} axis adjustment function
  */
 const postAxisRender = (s, dimensions) => {
@@ -422,7 +424,7 @@ const postAxisRender = (s, dimensions) => {
 /**
  * render chart axes
  * @param {object} _s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} renderer
  */
 const axes = (_s, dimensions) => {

--- a/source/axes.js
+++ b/source/axes.js
@@ -79,7 +79,7 @@ const ticks = (s, channel) => {
 /**
  * retrieve axis title
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {string} title
  */
 const axisTitle = (s, channel) => {
@@ -90,7 +90,7 @@ const axisTitle = (s, channel) => {
 /**
  * retrieve axis title and possibly truncate
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {string} title text, potentially truncated
  */
 const titleText = (s, channel) => {
@@ -102,7 +102,7 @@ const titleText = (s, channel) => {
 /**
  * render axis tick text content
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {function(object)} tick text renderer
  */
 const tickText = (s, channel) => {

--- a/source/chart.js
+++ b/source/chart.js
@@ -3,6 +3,8 @@
  * @module chart
  */
 
+import './types.d.js'
+
 import { WRAPPER_CLASS } from './config.js'
 import { audio } from './audio.js'
 import { axes } from './axes.js'
@@ -26,7 +28,7 @@ import { menu } from './menu.js'
  * generate chart rendering function based on
  * a Vega Lite specification
  * @param {object} s Vega Lite specification
- * @param {object} [_panelDimensions] chart dimensions
+ * @param {dimensions} [_panelDimensions] chart dimensions
  * @returns {function(object)} renderer
  */
 const render = (s, _panelDimensions) => {
@@ -130,7 +132,7 @@ const render = (s, _panelDimensions) => {
  * convert a synchronous rendering function
  * into an asynchronous rendering function
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} asynchronous rendering function
  */
 const asyncRender = (s, dimensions) => {
@@ -149,7 +151,7 @@ const asyncRender = (s, dimensions) => {
  * optionally fetch remote data, then create and run
  * a chart rendering function
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} renderer
  */
 const chart = (s, dimensions) => {

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -3,6 +3,8 @@
  * @module descriptions
  */
 
+import './types.d.js'
+
 import * as d3 from 'd3'
 import { datum, identity, isContinuous } from './helpers.js'
 import {
@@ -233,7 +235,7 @@ const chartLabel = s => {
 /**
  * text description of axis values
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {string} values description
  */
 const axisValuesText = (s, channel) => {
@@ -256,7 +258,7 @@ const scaleDescriptions = {
 /**
  * written description of a scale
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {string} scale description
  */
 const scaleDescription = (s, channel) => {
@@ -276,7 +278,7 @@ const scaleDescription = (s, channel) => {
 /**
  * written description of an axis
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {string} axis description
  */
 const axisDescription = (s, channel) => {

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -259,7 +259,7 @@ const encoder = memoize(_encoder)
 /**
  * generate a set of complex encoders
  * @param {object} s Vega Lite specification
- * @param {object} dimensions desired dimensions of the chart
+ * @param {object} dimensions chart dimensions
  * @param {object} accessors hash of data accessor functions
  * @returns {object} hash of encoder functions with complex data
  * lookup suitable for use as d3 callbacks

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -6,6 +6,8 @@
  * @see {@link https://vega.github.io/vega-lite/docs/encoding.html|vega-lite:encoding}
  */
 
+import './types.d.js'
+
 import { feature } from './feature.js'
 import { memoize } from './memoize.js'
 import { isTemporalScale, isOrdinalScale, isQuantitativeScale, parseScales } from './scales.js'
@@ -207,7 +209,7 @@ const encodingChannelCovariateCartesian = s => {
  * @param {object} s Vega Lite specification
  * @param {string} channel encoding channel
  * @param {function} accessor accessor function
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} encoder function
  */
 const _encoder = (s, channel, accessor, dimensions) => {

--- a/source/lifecycle.js
+++ b/source/lifecycle.js
@@ -15,7 +15,7 @@ import { fetchAll } from './fetch.js'
 /**
  * prepare the DOM of a specified element for rendering a chart
  * @param {object} s Vega Lite specification
- * @param {object} dimensions desired dimensions of the chart
+ * @param {object} dimensions chart dimensions
  */
 const setupNode = (s, dimensions) => {
 	const initializer = selection => {

--- a/source/marks.js
+++ b/source/marks.js
@@ -4,6 +4,8 @@
  * @see {@link https://vega.github.io/vega-lite/docs/mark.html|vega-lite:mark}
  */
 
+import './types.d.js'
+
 import * as d3 from 'd3'
 
 import { createAccessors } from './accessors.js'
@@ -67,7 +69,7 @@ const defaultSize = 30
 /**
  * partition dimensions into categorical steps
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {number} step size in pixels
  */
 const _step = (s, dimensions) => {
@@ -197,7 +199,7 @@ const layoutDirection = s => {
  * shuffle around mark encoders to
  * facilitate bidirectional layout
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {object} bar encoder methods
  */
 const stackEncoders = (s, dimensions) => {
@@ -219,7 +221,7 @@ const stackEncoders = (s, dimensions) => {
 /**
  * render a single bar chart mark
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} single mark renderer
  */
 const barMark = (s, dimensions) => {
@@ -254,7 +256,7 @@ const barMark = (s, dimensions) => {
 /**
  * lane transform for all bar marks
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {string} transform
  */
 const barMarksTransform = (s, dimensions) => {
@@ -281,7 +283,7 @@ const barMarksTransform = (s, dimensions) => {
 /**
  * render bar chart marks
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} bar renderer
  */
 const barMarks = (s, dimensions) => {
@@ -325,7 +327,7 @@ const barMarks = (s, dimensions) => {
 /**
  * assign encoders to area mark methods
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {object} area encoders
  */
 const areaEncoders = (s, dimensions) => {
@@ -351,7 +353,7 @@ const areaEncoders = (s, dimensions) => {
 /**
  * render area marks
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} area mark renderer
  */
 const areaMarks = (s, dimensions) => {
@@ -393,7 +395,7 @@ const areaMarks = (s, dimensions) => {
 /**
  * render a circular point mark
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} circular point mark rendering function
  */
 const pointMarkCircle = (s, dimensions) => {
@@ -412,7 +414,7 @@ const pointMarkCircle = (s, dimensions) => {
 /**
  * render a square point mark
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} square point mark rendering function
  */
 const pointMarkSquare = (s, dimensions) => {
@@ -433,7 +435,7 @@ const pointMarkSquare = (s, dimensions) => {
 /**
  * render a single point mark
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} point rendering function
  */
 const pointMark = (s, dimensions) => {
@@ -466,7 +468,7 @@ const pointMark = (s, dimensions) => {
 /**
  * render image marks
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} image mark renderer
  */
 const imageMarks = (s, dimensions) => {
@@ -499,7 +501,7 @@ const imageMarks = (s, dimensions) => {
 /**
  * render multiple point marks
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} points renderer
  */
 const pointMarks = (s, dimensions) => {
@@ -554,7 +556,7 @@ const pointMarks = (s, dimensions) => {
 /**
  * render line chart marks
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} line renderer
  */
 const lineMarks = (s, dimensions) => {
@@ -628,7 +630,7 @@ const lineMarks = (s, dimensions) => {
 
 /**
  * maximum viable radius for a given set of dimensions
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {number} radius
  */
 const maxRadius = dimensions => Math.min(dimensions.x, dimensions.y) * 0.5
@@ -636,7 +638,7 @@ const maxRadius = dimensions => Math.min(dimensions.x, dimensions.y) * 0.5
 /**
  * render arc marks for a circular pie or donut chart
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} circular chart arc renderer
  */
 const circularMarks = (s, dimensions) => {
@@ -721,7 +723,7 @@ const ruleDirection = s => {
 /**
  * render rule marks
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} rule renderer
  */
 const ruleMarks = (s, dimensions) => {
@@ -768,7 +770,7 @@ const ruleMarks = (s, dimensions) => {
 /**
  * render text marks
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} text mark renderer
  */
 const textMarks = (s, dimensions) => {
@@ -843,7 +845,7 @@ const textMarks = (s, dimensions) => {
 /**
  * select an appropriate mark renderer
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} mark renderer
  */
 const _marks = (s, dimensions) => {

--- a/source/position.js
+++ b/source/position.js
@@ -34,7 +34,7 @@ const marginCircular = () => {
 /**
  * compute margin for Cartesian chart axis ticks
  * @param {object} s Vega Lite specification
- * @returns {object} D3 margin convention object
+ * @returns {object} partial margin convention object
  */
 const tickMargin = s => {
 	const textLabels = longestAxisTickLabelTextWidth(s)
@@ -58,7 +58,7 @@ const tickMargin = s => {
 /**
  * compute margin for Cartesian chart axis title
  * @param {object} s Vega Lite specification
- * @returns {object} D3 margin convention object
+ * @returns {{bottom: number, left: number}} partial margin convention object
  */
 const titleMargin = s => {
 	return {

--- a/source/position.js
+++ b/source/position.js
@@ -20,7 +20,7 @@ const axes = { x: 'bottom', y: 'left' }
 
 /**
  * compute margin for a circular chart
- * @returns {object} D3 margin convention object
+ * @returns {object} margin convention object
  */
 const marginCircular = () => {
 	return {
@@ -70,7 +70,7 @@ const titleMargin = s => {
 /**
  * compute margin for Cartesian chart
  * @param {object} s Vega Lite specification
- * @returns {object} D3 margin convention object
+ * @returns {object} margin convention object
  */
 const marginCartesian = s => {
 	const defaultMargin = {
@@ -106,7 +106,7 @@ const _margin = s => {
 /**
  * compute margin values based on chart type
  * @param {object} s Vega Lite specification
- * @returns {object} D3 margin convention object
+ * @returns {object} margin convention object
  */
 const margin = memoize(_margin)
 

--- a/source/position.js
+++ b/source/position.js
@@ -3,6 +3,8 @@
  * @module position
  */
 
+import './types.d.js'
+
 import { GRID, WRAPPER_CLASS } from './config.js'
 import { feature } from './feature.js'
 import { longestAxisTickLabelTextWidth, rotation } from './text.js'
@@ -111,7 +113,7 @@ const margin = memoize(_margin)
 /**
  * transform string for positioning charts
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} positioning function
  */
 const position = (s, dimensions) => {

--- a/source/position.js
+++ b/source/position.js
@@ -20,7 +20,7 @@ const axes = { x: 'bottom', y: 'left' }
 
 /**
  * compute margin for a circular chart
- * @returns {object} margin convention object
+ * @returns {margin} margin convention object
  */
 const marginCircular = () => {
 	return {
@@ -70,7 +70,7 @@ const titleMargin = s => {
 /**
  * compute margin for Cartesian chart
  * @param {object} s Vega Lite specification
- * @returns {object} margin convention object
+ * @returns {margin} margin convention object
  */
 const marginCartesian = s => {
 	const defaultMargin = {
@@ -106,7 +106,7 @@ const _margin = s => {
 /**
  * compute margin values based on chart type
  * @param {object} s Vega Lite specification
- * @returns {object} margin convention object
+ * @returns {margin} margin convention object
  */
 const margin = memoize(_margin)
 

--- a/source/scales.js
+++ b/source/scales.js
@@ -6,6 +6,8 @@
  * @see {@link https://vega.github.io/vega-lite/docs/scale.html|vega-lite:scale}
  */
 
+import './types.d.js'
+
 import * as d3 from 'd3'
 import { data, stackOffset, sumByCovariates } from './data.js'
 import { values } from './values.js'
@@ -314,7 +316,7 @@ const cartesianRange = (s, channel) => {
 /**
  * compute scale range
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @param {string} _channel visual encoding
  * @returns {number[]} range
  */
@@ -390,7 +392,7 @@ const range = (s, dimensions, _channel) => {
  * generate scale functions described by the
  * specification's encoding section
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {object} hash of d3 scale functions
  */
 const coreScales = (s, dimensions) => {
@@ -469,7 +471,7 @@ const detectScaleExtensions = s => {
  * generate additional necessary scale functions beyond those
  * described in the s's encoding section
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @param {object} scales a hash of the core scale functions
  * @returns {object} hash of extended d3 scale functions
  */

--- a/source/scales.js
+++ b/source/scales.js
@@ -163,7 +163,7 @@ const zero = (s, channel) => {
 /**
  * baseline for an axis
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel visual encoding
+ * @param {cartesian} channel visual encoding
  * @returns {number[]}
  */
 const baseline = (s, channel) => {
@@ -285,7 +285,7 @@ const domain = (s, channel) => {
 /**
  * compute cartesian range
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {function(object)} Cartsian range
  */
 const cartesianRange = (s, channel) => {

--- a/source/text.js
+++ b/source/text.js
@@ -69,7 +69,7 @@ const fontStyles = node => {
  * abbreviate axis tick label text
  * @param {object} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {function(string)} abbreviation function
  */
 const _abbreviate = (s, dimensions, channel) => {
@@ -98,7 +98,7 @@ const abbreviate = memoize(_abbreviate)
 /**
  * format axis tick label text
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {function(string)} formatting function
  */
 const format = (s, channel) => {
@@ -150,7 +150,7 @@ const truncate = memoize(_truncate)
 /**
  * process axis tick text content
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel axis dimension
+ * @param {cartesian} channel axis dimension
  * @param {string} textContent text to process
  * @param {object} [styles] styles to incorporate when measuring text width
  * @returns {string} text processing function
@@ -209,7 +209,7 @@ const longestAxisTickLabelTextWidth = memoize(_longestAxisTickLabelTextWidth)
 /**
  * render axis tick text
  * @param {object} s Vega Lite specification
- * @param {'x'|'y'} channel encoding channel
+ * @param {cartesian} channel encoding channel
  * @returns {function(object)} text processing function
  */
 const axisTicksLabelText = (s, channel) => {

--- a/source/text.js
+++ b/source/text.js
@@ -3,6 +3,8 @@
  * @module text
  */
 
+import './types.d.js'
+
 import * as d3 from 'd3'
 import { MINIMUM_TICK_COUNT } from './config.js'
 import { encodingType } from './encodings.js'
@@ -66,7 +68,7 @@ const fontStyles = node => {
 /**
  * abbreviate axis tick label text
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @param {'x'|'y'} channel encoding channel
  * @returns {function(string)} abbreviation function
  */

--- a/source/time.js
+++ b/source/time.js
@@ -3,6 +3,8 @@
  * @module time
  */
 
+import './types.d.js'
+
 import * as d3 from 'd3'
 import { encodingChannelCovariateCartesian, encodingValue } from './encodings.js'
 import { memoize } from './memoize.js'
@@ -135,7 +137,7 @@ const timePeriod = (s, channel) => {
  * alter dimensions object to subtract the bar width
  * for a temporal bar chart
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {object} chart dimensions with bar width offset
  */
 const temporalBarDimensions = (s, dimensions) => {

--- a/source/types.d.js
+++ b/source/types.d.js
@@ -1,0 +1,6 @@
+/**
+* chart dimensions
+* @typedef dimensions
+* @prop {number} x horizontal dimension
+* @prop {number} y vertical dimension
+*/

--- a/source/types.d.js
+++ b/source/types.d.js
@@ -6,5 +6,6 @@
 */
 
 /**
+* encoding channel in cartesian space
 * @typedef {'x'|'y'} cartesian
 */

--- a/source/types.d.js
+++ b/source/types.d.js
@@ -9,3 +9,13 @@
 * encoding channel in cartesian space
 * @typedef {'x'|'y'} cartesian
 */
+
+/**
+* margin convention object
+* @typedef margin
+* @property {number} top top margin
+* @property {number} right right margin
+* @property {number} bottom bottom margin
+* @property {number} left left margin
+* @see {@link https://observablehq.com/@d3/margin-convention|margin convention}
+*/

--- a/source/types.d.js
+++ b/source/types.d.js
@@ -4,3 +4,7 @@
 * @prop {number} x horizontal dimension
 * @prop {number} y vertical dimension
 */
+
+/**
+* @typedef {'x'|'y'} cartesian
+*/

--- a/source/views.js
+++ b/source/views.js
@@ -4,6 +4,8 @@
  * @see {@link https://vega.github.io/vega-lite/docs/composition.html|vega-lite:composition}
  */
 
+import './types.d.js'
+
 import * as d3 from 'd3'
 import { feature } from './feature.js'
 
@@ -292,7 +294,7 @@ const layerSpecification = (s, index) => {
 /**
  * render layers of a specification
  * @param {object} s Vega Lite specification
- * @param {object} dimensions chart dimensions
+ * @param {dimensions} dimensions chart dimensions
  * @returns {function(object)} layer renderer
  */
 const layerMarks = (s, dimensions) => {


### PR DESCRIPTION
Up until now, [type checking](https://github.com/vijithassar/bisonica/pull/5) has relied on primitive types. For example, if the argument is an `{object}`, it's safe to infer that it is very likely a Vega Lite specification, but this based on a human stylistic preference which is not actually enforced by the type system. For the most part this works due to a combination of discipline and functional programming style which rewards the use of primitive arguments that don't need custom types at all.

This decision was mostly an aesthetic objection to the tedium of needing to `/import()` the `@typedef` every time it is referenced in every single function header, which is the standard JSDoc syntax, but it's also possible to [import once using a standard ES import](https://stackoverflow.com/questions/49836644/how-to-import-a-typedef-from-one-file-to-another-in-jsdoc-using-node-js/73232942#73232942).