### PR TITLE
clean up public type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-export function chart(s: object, panelDimensions?: object): Function;
+export function chart(s: object, panelDimensions?: {x: number, y: number}): Function;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-export function chart(s: object, panelDimensions: object): Function;
+export function chart(s: object, panelDimensions?: object): Function;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-export function chart(s: object, panelDimensions?: {x: number, y: number}): Function;
+export function chart(s: object, dimensions?: {x: number, y: number}): Function;

--- a/source/chart.js
+++ b/source/chart.js
@@ -151,7 +151,7 @@ const asyncRender = (s, dimensions) => {
  * optionally fetch remote data, then create and run
  * a chart rendering function
  * @param {object} s Vega Lite specification
- * @param {dimensions} dimensions chart dimensions
+ * @param {dimensions} [dimensions] chart dimensions
  * @return {function(object)} renderer
  */
 const chart = (s, dimensions) => {


### PR DESCRIPTION
A few changes to the public type declaration:

- shorter argument name for `dimensions`
- `dimensions` are optional now that [container sizing](https://github.com/vijithassar/bisonica/pull/313) has been implemented
- if a `dimensions` object is supplied, require `x` and `y` properties