### PR TITLE
add missing styles

### DIFF
--- a/source/index.css
+++ b/source/index.css
@@ -40,6 +40,7 @@ svg .wrapper text.mark:not([data-highlight]) {
 
 .axes text {
   fill: var(--medium);
+  stroke: none;
 }
 
 .axes path {

--- a/source/index.css
+++ b/source/index.css
@@ -1,3 +1,11 @@
+.chart {
+  --border: white;
+  --highlight: red;
+  --light: #ccc;
+  --medium: #888;
+  --dark: #444;
+}
+
 .legend {
   max-height: 12em;
   overflow: hidden;

--- a/source/index.css
+++ b/source/index.css
@@ -39,7 +39,7 @@ svg .wrapper text.mark:not([data-highlight]) {
 }
 
 .axes text {
-  fill: var(--light);
+  fill: var(--medium);
 }
 
 .axes path {

--- a/source/index.css
+++ b/source/index.css
@@ -210,3 +210,7 @@ table td div {
   margin-left: 0.5rem;
   display: inline-block;
 }
+
+[data-highlight] {
+  stroke: var(--highlight);
+}


### PR DESCRIPTION
A handful of styles had been hanging out in the local development environment but are worth including as part of the library, mostly to provide a better experience out of the box. It's better to render a chart that looks good, rather than rendering markup that _can be styled_ to look good.