### PR TITLE
type definition for marks

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -150,7 +150,7 @@ const pointMarkSelector = s => {
 /**
  * mark tagName
  * @param {object} s Vega Lite specification
- * @return {('rect'|'path'|'circle'|'rect'|'line'|'image'|'text')} tagName to use in DOM for mark
+ * @return {mark} tagName to use in DOM for mark
  */
 const markSelector = s => {
 	if (feature(s).isBar()) {

--- a/source/types.d.js
+++ b/source/types.d.js
@@ -19,3 +19,7 @@
  * @property {number} left left margin
  * @see {@link https://observablehq.com/@d3/margin-convention|margin convention}
  */
+
+/**
+ * @typedef {('rect'|'path'|'circle'|'rect'|'line'|'image'|'text')} mark
+ */


### PR DESCRIPTION
Adds a `@typedef` containing the valid strings that can be used to represent different mark types.