### PR TITLE
correct grid line length for negative data values

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -11,7 +11,7 @@ import * as d3 from 'd3'
 import { axisTicksLabelText, rotation, truncate } from './text.js'
 import { barWidth } from './marks.js'
 import { degrees, detach, isContinuous, isDiscrete, noop } from './helpers.js'
-import { encodingChannelCovariate, encodingChannelCovariateCartesian, encodingType } from './encodings.js'
+import { encodingChannelCovariate, encodingType } from './encodings.js'
 import { feature } from './feature.js'
 import { layerMatch } from './views.js'
 import { parseScales } from './scales.js'
@@ -339,8 +339,7 @@ const axisTicksExtensionX = (s, dimensions) => {
 		}
 		if (isContinuous(s, 'x') && feature(s).hasEncodingY()) {
 			const offset = feature(s).isTemporalBar() && encodingType(s, 'y') === 'temporal' ? barWidth(s, dimensions) : 0
-			const index = feature(s).isLine() && encodingChannelCovariateCartesian(s) === 'y' ? 1 : 0
-			const tickLength = parseScales(s, dimensions).y.range()[index] + offset
+			const tickLength = d3.sum(parseScales(s, dimensions).y.range().map(Math.abs)) + offset
 			const tickEnd = tickLength * -1
 			selection
 				.select('line')


### PR DESCRIPTION
Selecting the largest integer value from the scale range can lead to incorrect grid line length in cases where the scale includes negative values. That logic holds when one of the range endpoints is `0`, but when negative values are present they need to be accounted for by computing the total spread between the highest and lowest point in the scale.