### PR TITLE
gradients

### DIFF
--- a/source/chart.js
+++ b/source/chart.js
@@ -21,6 +21,7 @@ import { table, tableToggle } from './table.js'
 import { feature } from './feature.js'
 import { fetchAll } from './fetch.js'
 import { copyMethods } from './helpers.js'
+import { defs } from './defs.js'
 import { dimensions } from './dimensions.js'
 import { menu } from './menu.js'
 
@@ -66,6 +67,8 @@ const render = (s, _panelDimensions) => {
 			const imageHeight = panelDimensions.y - legendHeight
 
 			svg.attr('height', Math.max(imageHeight, 0))
+
+			svg.call(defs(s))
 
 			const { top, right, bottom, left } = margin(s, panelDimensions)
 

--- a/source/defs.js
+++ b/source/defs.js
@@ -1,0 +1,22 @@
+import { feature } from './feature.js'
+import { gradient } from './gradient.js'
+import { noop } from './helpers.js'
+
+const defs = s => {
+	if (!feature(s).hasDefs()) {
+		return noop
+	}
+	const renderer = selection => {
+		if (selection.node().tagName !== 'svg') {
+			throw new Error('defs must be rendered at the top level of the SVG node')
+		}
+		const defs = selection.append('defs')
+		const fns = [gradient(s)]
+		fns.forEach(fn => {
+			defs.call(fn)
+		})
+	}
+	return renderer
+}
+
+export { defs }

--- a/source/feature.js
+++ b/source/feature.js
@@ -39,6 +39,7 @@ const _feature = s => {
 		hasPointsFilled: s => (mark(s) !== 'point') && (s.mark?.filled !== false) && s.mark?.point !== 'transparent',
 		hasLayers: s => s.layer,
 		isCircular: s => mark(s) === 'arc',
+		hasDefs: s => !!s.mark?.color?.gradient,
 		isRule: s => mark(s) === 'rule',
 		isText: s => mark(s) === 'text',
 		isImage: s => mark(s) === 'image',

--- a/source/gradient.js
+++ b/source/gradient.js
@@ -1,0 +1,58 @@
+import { key, noop } from './helpers.js'
+
+/**
+ * assemble a string key for a gradient
+ * @param {object} s Vega Lite specification
+ * @param {number} [index] gradient index
+ * @return {string} gradient id
+ */
+const gradientKey = (s, index = 0) => {
+	const n = index + 1
+	return `${key(s.title.text)}-gradient-${n}`
+}
+
+/**
+ * create a gradient
+ * @param {object} s Vega Lite specification
+ * @return {function(object)} gradient definition rendering function
+ */
+const gradient = s => {
+	if (!s.mark?.color?.gradient) {
+		return noop
+	}
+	const renderer = selection => {
+		if (selection.node().tagName !== 'defs') {
+			throw new Error('gradients can only be rendered into a <defs> node')
+		}
+		const colors = [
+			s.mark.color,
+			s.layer?.map(item => item.mark.color)
+		]
+			.filter(Boolean)
+			.filter(item => item.gradient)
+		colors.forEach((color, index) => {
+			const type = `${color.gradient}Gradient`
+			const gradient = selection.append(type)
+			gradient
+				.attr('id', gradientKey(s, index))
+				.attr('x1', color.x1)
+				.attr('x2', color.x2)
+				.attr('y1', color.y1)
+				.attr('y2', color.y2)
+			if (type === 'radialGradient') {
+				gradient.attr('r1', color.r1)
+				gradient.attr('r2', color.r2)
+			}
+			gradient
+				.selectAll('stop')
+				.data(color.stops)
+				.enter()
+				.append('stop')
+				.attr('offset', d => d.offset)
+				.attr('stop-color', d => d.color)
+		})
+	}
+	return renderer
+}
+
+export { gradient, gradientKey }

--- a/source/marks.js
+++ b/source/marks.js
@@ -21,6 +21,7 @@ import { values } from './values.js'
 import { markDescription } from './descriptions.js'
 import { detach, datum, isDiscrete, kebabToCamel, key, mark, missingSeries } from './helpers.js'
 import { feature } from './feature.js'
+import { gradientKey } from './gradient.js'
 import { memoize } from './memoize.js'
 import { parseScales } from './scales.js'
 import { parseTime, timePeriod } from './time.js'
@@ -376,6 +377,8 @@ const areaMarks = (s, dimensions) => {
 
 		const layout = data(s)
 
+		const fill = (d, i) => s.mark.color?.gradient ? `url(#${gradientKey(s, i)})` : color
+
 		marks
 			.selectAll(markSelector(s))
 			.data(layout)
@@ -385,7 +388,7 @@ const areaMarks = (s, dimensions) => {
 			.attr('role', 'region')
 			.attr('aria-roledescription', 'data series')
 			.attr('tabindex', -1)
-			.attr('fill', color)
+			.attr('fill', fill)
 			.attr('class', 'area mark')
 			.attr('aria-label', d => d.key)
 	}


### PR DESCRIPTION
Implements [gradients](https://vega.github.io/vega-lite/docs/gradient.html) for mark fill. For now this is only attached to [area charts](https://vega.github.io/vega-lite/examples/area_gradient.html) but that can be expanded to other mark types in the future.