### PR TITLE
gradient color encoding bug fix

### DIFF
--- a/source/marks.js
+++ b/source/marks.js
@@ -377,7 +377,7 @@ const areaMarks = (s, dimensions) => {
 
 		const layout = data(s)
 
-		const fill = (d, i) => s.mark.color?.gradient ? `url(#${gradientKey(s, i)})` : color
+		const fill = (d, i) => s.mark.color?.gradient ? `url(#${gradientKey(s, i)})` : color(d)
 
 		marks
 			.selectAll(markSelector(s))


### PR DESCRIPTION
Quick follow up to pull request #382 to solve a bug it introduced. Factoring out the `fill()` function then means that the datum argument `d` needs to be explicitly passed to the `color` encoder – otherwise there's no data point on which to look up the color.