### PR TITLE
module headers

### DIFF
--- a/source/defs.js
+++ b/source/defs.js
@@ -1,3 +1,8 @@
+/**
+ * reusable nodes that are referenced but aren't directly rendered
+ * @module defs
+ */
+
 import { feature } from './feature.js'
 import { gradient } from './gradient.js'
 import { noop } from './helpers.js'

--- a/source/gradient.js
+++ b/source/gradient.js
@@ -1,3 +1,9 @@
+/**
+ * render gradients
+ * @module gradients
+ * @see {@link https://vega.github.io/vega-lite/docs/gradient.html|vega-lite:gradient}
+ */
+
 import { key, noop } from './helpers.js'
 
 /**


### PR DESCRIPTION
Add JSDoc `@module` tags and links to documentation with `@see` to the new `defs.js` and `gradient.js` modules introduced in pull request #382.