### PR TITLE
return numbers from tick count helper

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -55,7 +55,7 @@ const ticks = (s, channel) => {
 	const scales = parseScales(s)
 
 	if (isDiscrete(s, channel)) {
-		return scales[channel].range()
+		return scales[channel].range().length
 	}
 
 	const hasSingleValue = scales[channel].domain()[0] === scales[channel].domain()[1]


### PR DESCRIPTION
The `ticks()` helper function should return either an integer or a time interval function from [`d3-time`](https://github.com/d3/d3-time) to be used by [`axis.ticks()`](https://github.com/d3/d3-axis#axis_ticks). Discrete scales need to return the number of ticks, not an array with the tick strings as was previously the case here.