### PR TITLE
Cartesian quantitative helper

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -6,7 +6,7 @@
  */
 
 import { layoutDirection } from './marks.js'
-import { encodingChannelCovariateCartesian, encodingChannelQuantitative, encodingType, encodingValue } from './encodings.js'
+import { encodingChannelCovariateCartesian, encodingChannelQuantitativeCartesian, encodingType, encodingValue } from './encodings.js'
 import { feature } from './feature.js'
 import { mark } from './helpers.js'
 import { memoize } from './memoize.js'
@@ -85,7 +85,7 @@ const _createAccessors = (s, type = null) => {
 	}
 
 	if (key === 'line') {
-		const quantitative = encodingChannelQuantitative(s)
+		const quantitative = encodingChannelQuantitativeCartesian(s)
 		const covariate = encodingChannelCovariateCartesian(s)
 
 		accessors[quantitative] = d => d.value

--- a/source/data.js
+++ b/source/data.js
@@ -11,6 +11,7 @@ import * as d3 from 'd3'
 
 import {
 	encodingChannelQuantitative,
+	encodingChannelQuantitativeCartesian,
 	encodingChannelCovariate,
 	encodingChannelCovariateCartesian,
 	encodingField,
@@ -232,7 +233,7 @@ const circularData = s => {
  * @return {object[]} summed values for line chart
  */
 const lineData = s => {
-	const quantitative = encodingField(s, encodingChannelQuantitative(s))
+	const quantitative = encodingField(s, encodingChannelQuantitativeCartesian(s))
 	const covariate = encodingField(s, encodingChannelCovariateCartesian(s)) || missingSeries()
 	const color = encodingField(s, 'color') || encodingField(s, 'detail')
 

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -204,6 +204,22 @@ const encodingChannelCovariateCartesian = s => {
 }
 
 /**
+ * determine which channel of a Cartesian specification object
+ * is the primary quantitative channel
+ * @param {object} s Vega Lite specification
+ * @return {string} visual encoding channel
+ */
+const encodingChannelQuantitativeCartesian = s => {
+	const channel = ['x', 'y'].find(channel => channel === encodingChannelQuantitative(s))
+	if (channel) {
+		return channel
+	} else {
+		const message = feature(s).isCartesian() ? 'could not determine Cartesian quantitative encoding' : 'specification is not Cartesian'
+		throw new Error(message)
+	}
+}
+
+/**
  * bundle together an accessor and an encoder function
  * into an encoder function
  * @param {object} s Vega Lite specification
@@ -280,6 +296,7 @@ export {
 	encodingValue,
 	encodingType,
 	encodingChannelQuantitative,
+	encodingChannelQuantitativeCartesian,
 	encodingChannelCovariate,
 	encodingChannelCovariateCartesian,
 	createEncoders,

--- a/source/marks.js
+++ b/source/marks.js
@@ -12,7 +12,7 @@ import { createAccessors } from './accessors.js'
 import {
 	createEncoders,
 	encodingChannelCovariateCartesian,
-	encodingChannelQuantitative,
+	encodingChannelQuantitativeCartesian,
 	encodingType,
 	encodingValue
 } from './encodings.js'
@@ -338,11 +338,11 @@ const areaEncoders = (s, dimensions) => {
 		x0: x,
 		x1: d => x(d) + width(d)
 	}
-	if (encodingChannelQuantitative(s) === 'x') {
+	if (encodingChannelQuantitativeCartesian(s) === 'x') {
 		return {
 			...base
 		}
-	} else if (encodingChannelQuantitative(s) === 'y') {
+	} else if (encodingChannelQuantitativeCartesian(s) === 'y') {
 		return {
 			x0: x,
 			y0: y,

--- a/source/scales.js
+++ b/source/scales.js
@@ -12,7 +12,7 @@ import * as d3 from 'd3'
 import { data, stackOffset, sumByCovariates } from './data.js'
 import { values } from './values.js'
 import { colors } from './color.js'
-import { encodingChannelQuantitative, encodingType, encodingValue } from './encodings.js'
+import { encodingChannelQuantitativeCartesian, encodingType, encodingValue } from './encodings.js'
 import { feature } from './feature.js'
 import { identity, isContinuous, isDiscrete, isTextChannel } from './helpers.js'
 import { memoize } from './memoize.js'
@@ -481,7 +481,7 @@ const extendScales = (s, dimensions, scales) => {
 
 	if (extensions.includes('length')) {
 		extendedScales.length = d => {
-			const channel = encodingChannelQuantitative(s)
+			const channel = encodingChannelQuantitativeCartesian(s)
 			if (extendedScales[channel].domain().every(endpoint => endpoint === 0)) {
 				return 0
 			}
@@ -507,7 +507,7 @@ const extendScales = (s, dimensions, scales) => {
 
 	if (extensions.includes('start')) {
 		extendedScales.start = d => {
-			const channel = encodingChannelQuantitative(s)
+			const channel = encodingChannelQuantitativeCartesian(s)
 			if (feature(s).isStacked()) {
 				if (channel === 'y') {
 					return extendedScales[channel](d[0]) - extendedScales.length(d[1] - d[0])

--- a/tests/unit/views-test.js
+++ b/tests/unit/views-test.js
@@ -163,11 +163,11 @@ module('unit > views', () => {
 								type: 'line'
 							},
 							encoding: {
-								theta: {
+								y: {
 									field: 'value',
 									type: 'quantitative'
 								},
-								color: {
+								x: {
 									field: 'date',
 									type: 'temporal'
 								}


### PR DESCRIPTION
Pull request #80 introduced `encodingChannelCovariateCartesian()`, which was logically equivalent to `encodingChannelCovariate()` from pull request #30 but additionally restricted the output to either `"x"` or `"y"`, which helps quickly rule out other irrelevant channels when the goal is to solve spatial questions about layout. This pull request now introduces `encodingChannelQuantitativeCartesian()`, the equivalent counterpart for identifying quantitative encodings which matter for layout in Cartesian space.