### PR TITLE
type check extension keys

### DIFF
--- a/source/extensions.js
+++ b/source/extensions.js
@@ -4,10 +4,12 @@
  * @see {@link https://vega.github.io/vega-lite/docs/spec.html|vega-lite:spec}
  */
 
+import './types.d.js'
+
 /**
  * retrieve information from usermeta
  * @param {object} s Vega Lite specification
- * @param {string} key usermeta key
+ * @param {extension} key usermeta key
  */
 const extension = (s, key) => {
 	if (s.usermeta?.[key] !== undefined) {

--- a/source/types.d.js
+++ b/source/types.d.js
@@ -23,3 +23,7 @@
 /**
  * @typedef {('rect'|'path'|'circle'|'rect'|'line'|'image'|'text')} mark
  */
+
+/**
+ * @typedef {('audio'|'color'|'description'|'download'|'id'|'menu'|'table')} extension
+ */


### PR DESCRIPTION
Enumerates the possible strings used as object properties for [extensions](https://github.com/vijithassar/bisonica/pull/64) so they can then be enforced by the type checker.