### PR TITLE
stricter Cartesian channel helpers

### DIFF
--- a/source/data.js
+++ b/source/data.js
@@ -111,7 +111,7 @@ const stackKeys = data => {
  */
 const sumByCovariates = s => {
 	const quantitative = encodingField(s, encodingChannelQuantitative(s))
-	const covariate = encodingField(s, encodingChannelCovariateCartesian(s))
+	const covariate = feature(s).isCartesian() ? encodingField(s, encodingChannelCovariateCartesian(s)) : null
 	const group = encodingField(s, 'color') || encodingField(s, 'detail')
 
 	const summedByGroup = groupAndSumByProperties(values(s), covariate, group, quantitative)
@@ -157,7 +157,7 @@ const stackValue = (d, key) => d[key]?.value || 0
  * @return {object[]} stacked data series
  */
 const stackData = s => {
-	const covariate = encodingField(s, encodingChannelCovariateCartesian(s))
+	const covariate = feature(s).isCartesian() ? encodingField(s, encodingChannelCovariateCartesian(s)) : null
 	const quantitative = encodingField(s, encodingChannelQuantitative(s))
 	const group = encodingField(s, 'color') || encodingField(s, 'detail')
 

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -191,10 +191,11 @@ const encodingChannelCovariate = s => {
  * determine which channel of a Cartesian specification object
  * is secondary to the quantitative channel
  * @param {object} s Vega Lite specification
- * @return {string} encoding channel
+ * @return {cartesian} encoding channel
  */
 const encodingChannelCovariateCartesian = s => {
-	const channel = ['x', 'y'].find(channel => channel !== encodingChannelQuantitative(s))
+	const test = channel => ['x', 'y'].includes(channel) && encodingType(s, channel) !== 'quantitative'
+	const channel = encodingTest(s, test)
 	if (channel) {
 		return channel
 	} else {
@@ -207,10 +208,11 @@ const encodingChannelCovariateCartesian = s => {
  * determine which channel of a Cartesian specification object
  * is the primary quantitative channel
  * @param {object} s Vega Lite specification
- * @return {string} encoding channel
+ * @return {cartesian} encoding channel
  */
 const encodingChannelQuantitativeCartesian = s => {
-	const channel = ['x', 'y'].find(channel => channel === encodingChannelQuantitative(s))
+	const test = channel => ['x', 'y'].includes(channel) && encodingType(s, channel) === 'quantitative'
+	const channel = encodingTest(s, test)
 	if (channel) {
 		return channel
 	} else {

--- a/source/marks.js
+++ b/source/marks.js
@@ -209,7 +209,7 @@ const stackEncoders = (s, dimensions) => {
 	const lane = encoders[encodingChannelCovariateCartesian(s)]
 	const start = encoders.start
 	const length = encoders.length
-	const width = () => step(s, dimensions)
+	const width = () => feature(s).isBar() ? barWidth(s, dimensions) : step(s, dimensions)
 
 	return {
 		x: vertical ? lane : start,

--- a/source/marks.js
+++ b/source/marks.js
@@ -12,6 +12,7 @@ import { createAccessors } from './accessors.js'
 import {
 	createEncoders,
 	encodingChannelCovariateCartesian,
+	encodingChannelQuantitative,
 	encodingChannelQuantitativeCartesian,
 	encodingType,
 	encodingValue
@@ -114,7 +115,21 @@ const _step = (s, dimensions) => {
 	}
 }
 const step = memoize(_step)
-const barWidth = step
+
+/**
+ * compute bar width based on input data
+ * @param {object} s Vega Lite specification
+ * @param {dimensions} dimensions chart dimensions
+ * @return {number} bar width
+ */
+const barWidth = (s, dimensions) => {
+	if (feature(s).isCartesian()) {
+		return step(s, dimensions)
+	} else {
+		const key = ['x', 'y'].find(channel => channel !== encodingChannelQuantitative(s))
+		return dimensions[key]
+	}
+}
 
 /**
  * retrieve the d3 curve factory function needed for the marks

--- a/source/marks.js
+++ b/source/marks.js
@@ -221,7 +221,7 @@ const layoutDirection = s => {
 const stackEncoders = (s, dimensions) => {
 	const encoders = createEncoders(s, dimensions, createAccessors(s))
 	const vertical = layoutDirection(s) === 'vertical'
-	const lane = encoders[encodingChannelCovariateCartesian(s)]
+	const lane = feature(s).isCartesian() ? encoders[encodingChannelCovariateCartesian(s)] : null
 	const start = encoders.start
 	const length = encoders.length
 	const width = () => feature(s).isBar() ? barWidth(s, dimensions) : step(s, dimensions)


### PR DESCRIPTION
A bit of a rabbit hole here:

- narrowing the [return types](https://github.com/vijithassar/bisonica/pull/364/) of the Cartesian channel helpers from pull requests #80 and #391 requires restructuring them a bit internally
- the resulting more restrictive and accurate checks no longer return a fallback value for the covariate encoding in the case of the [single-bar layout](https://github.com/vijithassar/bisonica/pull/33), which now _only_ (and correctly) has a encoder function for its sole quantitative channel
- as a result of the preceding, the single-bar layout breaks

This can all be salvaged with a minor refactor of the `barWidth()` function to distinguish it from the [step interval](https://github.com/vijithassar/bisonica/pull/333) and explicitly handle the single-bar case, which is certainly a more sensible approach than relying on an implicit phantom channel.