### PR TITLE
stricter types

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -122,7 +122,7 @@ const tickText = (s, channel) => {
  * y axis positions
  * @param {object} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
- * @return {object} y axis positions
+ * @return {{x: number, y: number}} y axis positions
  */
 const axisOffsetY = (s, dimensions) => {
 	const shift = feature(s).isBar() && encodingType(s, 'x') === 'temporal'

--- a/source/dimensions.js
+++ b/source/dimensions.js
@@ -8,6 +8,8 @@ import { feature } from './feature.js'
 import { isContinuous } from './helpers.js'
 import { markData } from './marks.js'
 
+import './types.d.js'
+
 const channels = {
 	x: 'width',
 	y: 'height'
@@ -18,7 +20,7 @@ const channels = {
  * @param {object} s Vega Lite specification
  * @param {HTMLElement} node DOM node
  * @param {object} [explicitDimensions] chart dimensions
- * @return {object} chart dimensions
+ * @return {dimensions} chart dimensions
  */
 const dimensions = (s, node, explicitDimensions) => {
 	let result = { x: null, y: null }

--- a/source/text.js
+++ b/source/text.js
@@ -46,7 +46,7 @@ const measureText = memoize(_measureText)
 /**
  * extract font styles relevant to string width
  * from a DOM node
- * @param {object} node DOM node
+ * @param {SVGElement} node DOM node
  * @return {object} hashmap of styles
  */
 const fontStyles = node => {

--- a/source/time.js
+++ b/source/time.js
@@ -138,7 +138,7 @@ const timePeriod = (s, channel) => {
  * for a temporal bar chart
  * @param {object} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
- * @return {object} chart dimensions with bar width offset
+ * @return {dimensions} chart dimensions with bar width offset
  */
 const temporalBarDimensions = (s, dimensions) => {
 	const offset = feature(s).isTemporalBar() ? barWidth(s, dimensions) : 0

--- a/source/time.js
+++ b/source/time.js
@@ -17,21 +17,21 @@ const TIME = 'time'
 /**
  * convert date string in YYYY-MM-DD format to date object
  * @param {string} dateString string in YYYY-MM-DD format
- * @return {object} date object
+ * @return {Date} date object
  */
 const timeParseYYYYMMDD = d3.utcParse('%Y-%m-%d')
 
 /**
  * convert date string in ISO8601 format to date object
  * @param {string} dateString string in ISO8601 format
- * @return {object} date object
+ * @return {Date} date object
  */
 const timeParseIso = d3.isoParse
 
 /**
  * convert date in milliseconds to date object
  * @param {number} date number of milliseconds
- * @return {object} date object
+ * @return {Date} date object
  */
 const timeParseMilliseconds = date => new Date(date)
 

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -63,7 +63,7 @@ const includedChannels = memoize(_includedChannels)
 /**
  * dispatch a CustomEvent with a data point
  * @param {object} s Vega Lite specification
- * @param {object} node mark DOM node
+ * @param {SVGElement} node mark DOM node
  * @param {object} interaction event
  */
 function tooltipEvent(s, node, interaction) {

--- a/source/views.js
+++ b/source/views.js
@@ -202,7 +202,7 @@ const layerPrimary = memoize(_layerPrimary)
  * find the DOM element corresponding to a layer
  * specification
  * @param {object} s Vega Lite layer specification
- * @param {object} wrapper chart wrapper node
+ * @param {HTMLElement} wrapper chart wrapper node
  * @return {object} DOM element
  */
 const layerNode = (s, wrapper) => {


### PR DESCRIPTION
Replaces generic `{object}` types in the JSDoc headers with more specific alternatives that specify the shape of the object.