### PR TITLE
chart description

### DIFF
--- a/source/chart.js
+++ b/source/chart.js
@@ -51,6 +51,8 @@ const render = (s, _panelDimensions) => {
 
 			chartNode.call(audio(s))
 
+			chartNode.attr('aria-description', s.description || null)
+
 			initializeInteractions(chartNode.node(), s)
 
 			chartNode.call(menu(s))


### PR DESCRIPTION
Renders the [top level description](https://vega.github.io/vega-lite/docs/spec.html), if present, as the value of the chart node's `aria-description` attribute.