### PR TITLE
refactor text descriptions

### DIFF
--- a/source/chart.js
+++ b/source/chart.js
@@ -51,8 +51,6 @@ const render = (s, _panelDimensions) => {
 
 			chartNode.call(audio(s))
 
-			chartNode.attr('aria-description', s.description || null)
-
 			initializeInteractions(chartNode.node(), s)
 
 			chartNode.call(menu(s))

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -197,7 +197,7 @@ const chartType = s => {
  * @return {string} chart description
  */
 const chartDescription = s => {
-	return [s.description, chartType(s), s.encoding && encodingDescription(s)].filter(Boolean).join(' ')
+	return [s.description, chartType(s), s.encoding && encodingDescription(s), instructions(s)].filter(Boolean).join(' ')
 }
 
 /**
@@ -225,7 +225,7 @@ const chartLabel = s => {
 	if (!s.title.text) {
 		throw new Error('specification title is required')
 	}
-	return `${[s.title.text, s.title.subtitle].filter(Boolean).join(' - ')}. ${instructions(s)}`
+	return `${[s.title.text, s.title.subtitle].filter(Boolean).join(' - ')}`
 }
 
 /**

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -24,7 +24,7 @@ import { scaleType, parseScales } from './scales.js'
 import { formatAxis } from './format.js'
 import { list } from './text.js'
 
-const delimiter = '; '
+const fieldDelimiter = '; '
 
 const quantitativeChannels = s => {
 	const result = Object.keys(s.encoding)
@@ -102,7 +102,7 @@ const _extentDescription = s => {
 			return `${endpoint.type} value of ${s.encoding[channel].field} field`
 		}).filter(Boolean)
 		if (endpoints.length) {
-			return delimiter + endpoints.join(delimiter)
+			return fieldDelimiter + endpoints.join(fieldDelimiter)
 		} else {
 			return ''
 		}
@@ -203,7 +203,7 @@ const chartType = s => {
  * @return {string} chart description
  */
 const chartDescription = s => {
-	const end = ['.', '!', '?']
+	const segmentDelimiters = ['.', '!', '?']
 	const type = chartType(s)
 	const description = s.description
 	const chart = type ? type[0].toUpperCase() + type.slice(1) + ' of ' + encodingDescription(s) : ''
@@ -213,7 +213,7 @@ const chartDescription = s => {
 		instructions(s)
 	]
 		.filter(Boolean)
-		.map(item => end.includes(item.slice(-1)) ? item : `${item}.`)
+		.map(item => segmentDelimiters.includes(item.slice(-1)) ? item : `${item}.`)
 		.join(' ')
 }
 

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -119,6 +119,9 @@ const encodingDescription = s => {
 	if (!s.encoding) {
 		return ''
 	}
+	if (extension(s, 'description')?.instructions === false) {
+		return ''
+	}
 	let segments = []
 	if (feature(s).isCircular()) {
 		segments.push(`${encodingField(s, 'theta')}`)

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -142,7 +142,7 @@ const encodingDescription = s => {
 		segments.push(`split by ${encodingField(s, 'color')}`)
 	}
 	if (segments.length) {
-		return `of ${segments.join(' ')}`
+		return `${segments.join(' ')}`
 	}
 }
 
@@ -200,7 +200,15 @@ const chartType = s => {
  * @return {string} chart description
  */
 const chartDescription = s => {
-	return [s.description, chartType(s), encodingDescription(s), instructions(s)].filter(Boolean).join(' ')
+	const type = chartType(s)
+	const description = s.description
+	const chart = type ? type[0].toUpperCase() + type.slice(1) + ' of ' + encodingDescription(s) : ''
+	const keys = instructions(s) || ''
+	return [
+		description,
+		chart ? `${chart}.` : '',
+		keys ? `${keys}.` : ''
+	].filter(Boolean).join(' ')
 }
 
 /**
@@ -214,8 +222,7 @@ const instructions = s => {
 	}
 	return [
 		'Use the arrow keys to navigate',
-		feature(s).hasLinks() ? ' and press the Enter key to open links' : '',
-		'.'
+		feature(s).hasLinks() ? ' and press the Enter key to open links' : ''
 	].join('')
 }
 

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -206,7 +206,8 @@ const chartDescription = s => {
 	const segmentDelimiters = ['.', '!', '?']
 	const type = chartType(s)
 	const description = s.description
-	const chart = type ? capitalize(type) + ' of ' + encodingDescription(s) : ''
+	const encoding = encodingDescription(s)
+	const chart = type && encoding ? `${capitalize(type)} of ${encoding}` : type || encoding
 	return [
 		description,
 		chart,

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -200,15 +200,19 @@ const chartType = s => {
  * @return {string} chart description
  */
 const chartDescription = s => {
+	const end = ['.', '!', '?']
 	const type = chartType(s)
 	const description = s.description
 	const chart = type ? type[0].toUpperCase() + type.slice(1) + ' of ' + encodingDescription(s) : ''
 	const keys = instructions(s) || ''
 	return [
 		description,
-		chart ? `${chart}.` : '',
-		keys ? `${keys}.` : ''
-	].filter(Boolean).join(' ')
+		chart,
+		keys
+	]
+		.filter(Boolean)
+		.map(item => end.includes(item.slice(-1)) ? item : `${item}.`)
+		.join(' ')
 }
 
 /**

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -207,11 +207,10 @@ const chartDescription = s => {
 	const type = chartType(s)
 	const description = s.description
 	const chart = type ? type[0].toUpperCase() + type.slice(1) + ' of ' + encodingDescription(s) : ''
-	const keys = instructions(s) || ''
 	return [
 		description,
 		chart,
-		keys
+		instructions(s)
 	]
 		.filter(Boolean)
 		.map(item => end.includes(item.slice(-1)) ? item : `${item}.`)

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -116,6 +116,9 @@ const extentDescription = memoize(_extentDescription)
  * @return {string} encoding description
  */
 const encodingDescription = s => {
+	if (!s.encoding) {
+		return ''
+	}
 	let segments = []
 	if (feature(s).isCircular()) {
 		segments.push(`${encodingField(s, 'theta')}`)
@@ -197,7 +200,7 @@ const chartType = s => {
  * @return {string} chart description
  */
 const chartDescription = s => {
-	return [s.description, chartType(s), s.encoding && encodingDescription(s), instructions(s)].filter(Boolean).join(' ')
+	return [s.description, chartType(s), encodingDescription(s), instructions(s)].filter(Boolean).join(' ')
 }
 
 /**

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -197,7 +197,7 @@ const chartType = s => {
  * @return {string} chart description
  */
 const chartDescription = s => {
-	return [chartType(s), s.encoding && encodingDescription(s)].filter(Boolean).join(' ')
+	return [s.description, chartType(s), s.encoding && encodingDescription(s)].filter(Boolean).join(' ')
 }
 
 /**
@@ -225,11 +225,7 @@ const chartLabel = s => {
 	if (!s.title.text) {
 		throw new Error('specification title is required')
 	}
-	if (s.description) {
-		return s.description
-	} else {
-		return `${[s.title.text, s.title.subtitle].filter(Boolean).join(' - ')}. ${instructions(s)}`
-	}
+	return `${[s.title.text, s.title.subtitle].filter(Boolean).join(' - ')}. ${instructions(s)}`
 }
 
 /**

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -6,7 +6,7 @@
 import './types.d.js'
 
 import * as d3 from 'd3'
-import { datum, identity, isContinuous } from './helpers.js'
+import { capitalize, datum, identity, isContinuous } from './helpers.js'
 import {
 	encodingField,
 	encodingType,
@@ -206,7 +206,7 @@ const chartDescription = s => {
 	const segmentDelimiters = ['.', '!', '?']
 	const type = chartType(s)
 	const description = s.description
-	const chart = type ? type[0].toUpperCase() + type.slice(1) + ' of ' + encodingDescription(s) : ''
+	const chart = type ? capitalize(type) + ' of ' + encodingDescription(s) : ''
 	return [
 		description,
 		chart,

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -24,6 +24,13 @@ const abbreviateNumbers = number => {
 }
 
 /**
+ * capitalize a string
+ * @param {string} string input string
+ * @return {string} capitalized string
+ */
+const capitalize = string => string[0].toUpperCase() + string.slice(1)
+
+/**
  * return the original data object if it has been nested
  * by a layout generator
  * @param {object} s Vega Lite specification
@@ -274,6 +281,7 @@ const kebabToCamel = kebab => {
 export {
 	abbreviateNumbers,
 	mark,
+	capitalize,
 	datum,
 	nested,
 	deduplicateByField,

--- a/tests/unit/description-test.js
+++ b/tests/unit/description-test.js
@@ -44,6 +44,13 @@ module('unit > description', () => {
 			const description = chartDescription(s)
 			assert.equal(description, 'Pie chart of size split by type. Use the arrow keys to navigate.')
 		})
+		test('describes how to open links with keyboard navigation', assert => {
+			const s = specification()
+			s.encoding.href = { field: 'url' }
+			const description = chartDescription(s)
+			assert.ok(description.includes('Enter key'))
+			assert.ok(description.includes('open links'))
+		})
 		test('prepends custom chart description', assert => {
 			const s = specification()
 			s.description = 'this is a chart with a custom description!'

--- a/tests/unit/description-test.js
+++ b/tests/unit/description-test.js
@@ -1,6 +1,6 @@
 import qunit from 'qunit'
 import { specificationFixture } from '../test-helpers.js'
-import { axisDescription } from '../../source/descriptions.js'
+import { axisDescription, chartDescription } from '../../source/descriptions.js'
 
 const { module, test } = qunit
 
@@ -18,6 +18,37 @@ module('unit > description', () => {
 					assert.ok(valid, `generates ${channel} axis description`)
 				})
 			})
+		})
+	})
+
+	module('chart', () => {
+		const specification = () => {
+			return {
+				mark: {
+					type: 'arc'
+				},
+				encoding: {
+					theta: {
+						field: 'size',
+						type: 'quantitative'
+					},
+					color: {
+						field: 'type',
+						type: 'nominal'
+					}
+				}
+			}
+		}
+		test('generates chart description based on encodings', assert => {
+			const s = specification()
+			const description = chartDescription(s)
+			assert.equal(description, 'pie chart of size split by type')
+		})
+		test('prepends custom chart description', assert => {
+			const s = specification()
+			s.description = 'this is a chart with a custom description! it is also a'
+			const description = chartDescription(s)
+			assert.equal(description, 'this is a chart with a custom description! it is also a pie chart of size split by type')
 		})
 	})
 })

--- a/tests/unit/description-test.js
+++ b/tests/unit/description-test.js
@@ -42,13 +42,13 @@ module('unit > description', () => {
 		test('generates chart description based on encodings', assert => {
 			const s = specification()
 			const description = chartDescription(s)
-			assert.equal(description, 'pie chart of size split by type Use the arrow keys to navigate.')
+			assert.equal(description, 'Pie chart of size split by type. Use the arrow keys to navigate.')
 		})
 		test('prepends custom chart description', assert => {
 			const s = specification()
-			s.description = 'this is a chart with a custom description! it is also a'
+			s.description = 'this is a chart with a custom description!'
 			const description = chartDescription(s)
-			assert.equal(description, 'this is a chart with a custom description! it is also a pie chart of size split by type Use the arrow keys to navigate.')
+			assert.equal(description, 'this is a chart with a custom description! Pie chart of size split by type. Use the arrow keys to navigate.')
 		})
 	})
 })

--- a/tests/unit/description-test.js
+++ b/tests/unit/description-test.js
@@ -42,13 +42,13 @@ module('unit > description', () => {
 		test('generates chart description based on encodings', assert => {
 			const s = specification()
 			const description = chartDescription(s)
-			assert.equal(description, 'pie chart of size split by type')
+			assert.equal(description, 'pie chart of size split by type Use the arrow keys to navigate.')
 		})
 		test('prepends custom chart description', assert => {
 			const s = specification()
 			s.description = 'this is a chart with a custom description! it is also a'
 			const description = chartDescription(s)
-			assert.equal(description, 'this is a chart with a custom description! it is also a pie chart of size split by type')
+			assert.equal(description, 'this is a chart with a custom description! it is also a pie chart of size split by type Use the arrow keys to navigate.')
 		})
 	})
 })


### PR DESCRIPTION
As it turns out, pull request #398 conflicted with existing functionality for chart level descriptions that already existed in `descriptions.js`, which wasn't obvious initially because it was all a bit of a mess. The text used for that `aria-description` field is now much cleaner, as is the code that generates it. Test coverage around this has also improved.

That's all internal-facing, though. The main publicly visible change is that there's now a clearer separation between `aria-label` and `aria-description` as used at the top level of the chart. The former now contains only `specification.title` and `specification.subtitle`. The latter contains `specification.description` if provided, as well as additional any text generated automatically to help improve accessibility.