### PR TITLE
table links

### DIFF
--- a/source/table.js
+++ b/source/table.js
@@ -12,6 +12,8 @@ import { parseScales } from './scales.js'
 import { values } from './values.js'
 import { feature } from './feature.js'
 
+import * as d3 from 'd3'
+
 const tableSelector = '.chart > .table'
 const legendSelector = '.chart .legend'
 const graphicSelector = '.chart .graphic'
@@ -102,7 +104,11 @@ const rows = s => {
 			.append('td')
 		cell
 			.attr('class', ([_, value]) => typeof value === 'number' ? 'quantitative' : null)
-			.text(([_, value]) => value)
+			.each(function([field, value]) {
+				const href = encodingField(s, 'href') === field
+				const target = href ? d3.select(this).append('a').attr('href', value) : d3.select(this)
+				target.text(([_, value]) => value)
+			})
 		if (s.encoding.color?.field) {
 			cell.filter(([key]) => key === encodingField(s, 'color'))
 				.append('div')

--- a/source/table.js
+++ b/source/table.js
@@ -100,8 +100,9 @@ const rows = s => {
 			.data(d => columnEntries(s)(d))
 			.enter()
 			.append('td')
-			.text(([_, value]) => value)
+		cell
 			.attr('class', ([_, value]) => typeof value === 'number' ? 'quantitative' : null)
+			.text(([_, value]) => value)
 		if (s.encoding.color?.field) {
 			cell.filter(([key]) => key === encodingField(s, 'color'))
 				.append('div')

--- a/tests/integration/table-test.js
+++ b/tests/integration/table-test.js
@@ -35,4 +35,17 @@ module('integration > table', function() {
 		toggle.dispatchEvent(event())
 		assert.notOk(table.querySelector('tr'), 'table view is inactive')
 	})
+	test('renders urls as links', assert => {
+		const s = specificationFixture('circular')
+		const count = s.data.values.length
+		s.data.values = s.data.values.map((item, index) => {
+			return { ...item, url: `https://example.com/${index}` }
+		})
+		s.encoding.href = { field: 'url' }
+		const element = render(s)
+		const toggle = element.querySelector(selector)
+		const table = element.querySelector('.table')
+		toggle.dispatchEvent(event())
+		assert.equal(table.querySelectorAll('td a').length, count, `${count} links in table`)
+	})
 })


### PR DESCRIPTION
When rendering values in the [table view](https://github.com/vijithassar/bisonica/pull/189), check to see whether the current cell is expressing a field that has been mapped to the [hyperlink encoding channel](https://vega.github.io/vega-lite/docs/encoding.html#href) and if so render it as a clickable link tag instead of as text.