### PR TITLE
fix configurable point fill

### DIFF
--- a/source/feature.js
+++ b/source/feature.js
@@ -36,7 +36,15 @@ const _feature = s => {
 		isLine: s => mark(s) === 'line',
 		isArea: s => mark(s) === 'area',
 		hasPoints: s => ['point', 'circle', 'square'].includes(mark(s)) || s.mark?.point === true || s.mark?.point === 'transparent',
-		hasPointsFilled: s => (mark(s) !== 'point') && (s.mark?.filled !== false) && s.mark?.point !== 'transparent',
+		hasMarksFilled: s => {
+			if (mark(s) === 'point') {
+				return s.mark?.filled === true && s.mark?.point !== 'transparent'
+			} else if (['line', 'rule'].includes(mark(s))) {
+				return false
+			} else {
+				return s.mark?.filled !== false
+			}
+		},
 		hasLayers: s => s.layer,
 		isCircular: s => mark(s) === 'arc',
 		hasDefs: s => !!s.mark?.color?.gradient,

--- a/source/marks.js
+++ b/source/marks.js
@@ -425,6 +425,7 @@ const pointMarkCircle = (s, dimensions) => {
 			.attr('cx', encoders.x)
 			.attr('cy', encoders.y)
 			.attr('r', radius)
+			.attr('fill', encoders.color)
 	}
 	return renderer
 }
@@ -552,13 +553,13 @@ const pointMarks = (s, dimensions) => {
 				.style('stroke-width', 1)
 			points
 				.style('fill', feature(s).isMulticolor() ? encoders.color : color)
-				.style('fill-opacity', feature(s).hasPointsFilled() ? 1 : transparent)
+				.style('fill-opacity', feature(s).hasMarksFilled() ? 1 : transparent)
 		// style the series node when point marks are on top of line marks
 		} else {
 			marks
 				.style('stroke', encoders.color)
-				.style('fill', feature(s).hasPointsFilled() ? encoders.color : null)
-				.style('fill-opacity', feature(s).hasPointsFilled() ? 1 : transparent)
+				.style('fill', feature(s).hasMarksFilled() ? encoders.color : null)
+				.style('fill-opacity', feature(s).hasMarksFilled() ? 1 : transparent)
 			if (s.mark.point === 'transparent') {
 				marks
 					.selectAll(pointMarkSelector(s))

--- a/source/marks.js
+++ b/source/marks.js
@@ -425,7 +425,7 @@ const pointMarkCircle = (s, dimensions) => {
 			.attr('cx', encoders.x)
 			.attr('cy', encoders.y)
 			.attr('r', radius)
-			.attr('fill', encoders.color)
+			.attr('fill', feature(s).hasMarksFilled() ? encoders.color : transparent)
 	}
 	return renderer
 }
@@ -447,6 +447,7 @@ const pointMarkSquare = (s, dimensions) => {
 			.attr('y', d => encoders.y(d) + offset(d))
 			.attr('height', side)
 			.attr('width', side)
+			.attr('fill', feature(s).hasMarksFilled() ? encoders.color : transparent)
 	}
 	return renderer
 }


### PR DESCRIPTION
Reworks point fill as originally implemented in pull request #207 and #211 to more accurately handle [`mark.filled: false`](https://vega.github.io/vega-lite/docs/point.html#properties) on [point](https://vega.github.io/vega-lite/docs/point.html), [circle](https://vega.github.io/vega-lite/docs/circle.html), and [square](https://vega.github.io/vega-lite/docs/square.html) marks.