### PR TITLE
remove redundant string from mark type

### DIFF
--- a/source/types.d.js
+++ b/source/types.d.js
@@ -21,7 +21,7 @@
  */
 
 /**
- * @typedef {('rect'|'path'|'circle'|'rect'|'line'|'image'|'text')} mark
+ * @typedef {('path'|'circle'|'rect'|'line'|'image'|'text')} mark
  */
 
 /**


### PR DESCRIPTION
Removes one instance of `"rect"` since it is listed twice in the type definition.