### PR TITLE
documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-bisonica is a minimalist and accessibility-first alternative renderer for the open source [Vega Lite](https://vega.github.io/vega-lite/) standard for data visualization, a replacement for the [original `vega-lite.js` library](https://github.com/vega/vega-lite) which reads in the same JSON configuration objects and outputs charts.
+bisonica is a minimalist and accessibility-first alternative renderer for the open source [Vega Lite](https://vega.github.io/vega-lite/) standard for data visualization, a replacement for the [original `vega-lite.js` library](https://github.com/vega/vega-lite) which reads in the same [JSON configuration objects](https://vega.github.io/vega-lite/docs/) and outputs charts.
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ On the other hand, the standard `vega-lite.js` renderer is definitely still the 
 
 ## Omissions
 
-bisonica is still a work in progress and as such supports only a subset of Vega Lite functionality. The supported chart forms are listed in [`source/marks.js`](./source/marks.js).
+bisonica is still a work in progress and as such supports only a subset of Vega Lite functionality. The supported chart forms are listed in [`marks.js`](./source/marks.js).
 
 Data loading will not [parse inline strings](https://vega.github.io/vega-lite/docs/data.html#inline).
 


### PR DESCRIPTION
Link to the external documentation for the config objects and simplify the internal link to `marks.js`.