### PR TITLE
axis title tweaks

### DIFF
--- a/source/axes.js
+++ b/source/axes.js
@@ -243,26 +243,27 @@ const createY = (s, dimensions) => {
  * @return {function(object)} x axis title renderer
  */
 const axisTitleX = (s, dimensions) => {
+	if (!feature(s).hasEncodingX() || !feature(s).hasAxisTitleX()) {
+		return noop
+	}
 	return selection => {
-		if (feature(s).hasEncodingX() && feature(s).hasAxisTitleX()) {
-			const xTitle = selection.append('text').attr('class', 'title')
-			const bar = feature(s).isBar() ? barWidth(s, dimensions) : 0
+		const xTitle = selection.append('text').attr('class', 'title')
+		const bar = feature(s).isBar() ? barWidth(s, dimensions) : 0
 
-			xTitle
-				.attr('x', () => {
-					return (dimensions.x - margin(s, dimensions).left + bar) * 0.5
-				})
-				.attr('y', () => {
-					const axisHeight = selection.node().getBBox().height * 2
-					const tickHeight = tickMargin(s).bottom
-					const yPosition = axisHeight + tickHeight
+		xTitle
+			.attr('x', () => {
+				return (dimensions.x - margin(s, dimensions).left + bar) * 0.5
+			})
+			.attr('y', () => {
+				const axisHeight = selection.node().getBBox().height * 2
+				const tickHeight = tickMargin(s).bottom
+				const yPosition = axisHeight + tickHeight
 
-					return yPosition
-				})
-				.attr('transform', `translate(0,${axisOffset(s, dimensions)('y').y})`)
-				.text(titleText(s, 'x'))
-				.call(axisTitleStyles(s, 'x'))
-		}
+				return yPosition
+			})
+			.attr('transform', `translate(0,${axisOffset(s, dimensions)('y').y})`)
+			.text(titleText(s, 'x'))
+			.call(axisTitleStyles(s, 'x'))
 	}
 }
 

--- a/source/axes.js
+++ b/source/axes.js
@@ -119,31 +119,36 @@ const tickText = (s, channel) => {
 }
 
 /**
- * y axis positions
+ * axis positions
  * @param {object} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
- * @return {{x: number, y: number}} y axis positions
+ * @return {function('x'|'y')} y axis positions
  */
-const axisOffsetY = (s, dimensions) => {
-	const shift = feature(s).isBar() && encodingType(s, 'x') === 'temporal'
-	const bar = feature(s).isBar() ? barWidth(s, dimensions) : 0
-	const x = shift ? bar * 0.5 : 0
-
-	let y
-	const scales = parseScales(s, dimensions)
-	const temporalBarOffsetY = feature(s).isTemporalBar() && encodingChannelCovariate(s) === 'y' ? barWidth(s, dimensions) : 0
-	if (scales.y) {
-		y = isDiscrete(s, 'y') || encodingType(s, 'y') === 'temporal' ? scales.y.range().pop() : scales.y.range()[0]
-		y += temporalBarOffsetY
-	} else {
-		if (feature(s).isBar() && !feature(s).hasEncodingY()) {
-			y = barWidth(s, dimensions)
-		} else {
-			y = 0
+const axisOffset = (s, dimensions) => {
+	return channel => {
+		if (channel !== 'y') {
+			throw new Error(`cannot compute axis offset for channel ${channel}`)
 		}
-	}
+		const shift = feature(s).isBar() && encodingType(s, 'x') === 'temporal'
+		const bar = feature(s).isBar() ? barWidth(s, dimensions) : 0
+		const x = shift ? bar * 0.5 : 0
 
-	return { x, y }
+		let y
+		const scales = parseScales(s, dimensions)
+		const temporalBarOffsetY = feature(s).isTemporalBar() && encodingChannelCovariate(s) === 'y' ? barWidth(s, dimensions) : 0
+		if (scales.y) {
+			y = isDiscrete(s, 'y') || encodingType(s, 'y') === 'temporal' ? scales.y.range().pop() : scales.y.range()[0]
+			y += temporalBarOffsetY
+		} else {
+			if (feature(s).isBar() && !feature(s).hasEncodingY()) {
+				y = barWidth(s, dimensions)
+			} else {
+				y = 0
+			}
+		}
+
+		return { x, y }
+	}
 }
 
 /**
@@ -184,7 +189,7 @@ const createX = (s, dimensions) => {
 		selection.call(tickText(s, 'x'))
 
 		selection.attr('transform', () => {
-			const { x, y } = axisOffsetY(s, dimensions)
+			const { x, y } = axisOffset(s, dimensions)('y')
 			return `translate(${x},${y})`
 		})
 
@@ -254,7 +259,7 @@ const axisTitleX = (s, dimensions) => {
 
 					return yPosition
 				})
-				.attr('transform', `translate(0,${axisOffsetY(s, dimensions).y})`)
+				.attr('transform', `translate(0,${axisOffset(s, dimensions)('y').y})`)
 				.text(titleText(s, 'x'))
 				.call(axisTitleStyles(s, 'x'))
 		}

--- a/source/axes.js
+++ b/source/axes.js
@@ -16,7 +16,7 @@ import { feature } from './feature.js'
 import { layerMatch } from './views.js'
 import { parseScales } from './scales.js'
 import { renderStyles } from './styles.js'
-import { margin, tickMargin } from './position.js'
+import { tickMargin } from './position.js'
 import { timeMethod, timePeriod } from './time.js'
 import { axisDescription } from './descriptions.js'
 
@@ -248,11 +248,9 @@ const axisTitleX = (s, dimensions) => {
 	}
 	return selection => {
 		const xTitle = selection.append('text').attr('class', 'title')
-		const bar = feature(s).isBar() ? barWidth(s, dimensions) : 0
-
 		xTitle
 			.attr('x', () => {
-				return (dimensions.x - margin(s, dimensions).left + bar) * 0.5
+				return dimensions.x * 0.5
 			})
 			.attr('y', () => {
 				const axisHeight = selection.node().getBBox().height * 2


### PR DESCRIPTION
Cleans up the logic around axis title positioning. The notable visible difference is a change in the positioning logic for x axis titles, which will now appear more cleanly centered relative to the mark content such that in a bar chart with three bars the text will be aligned with the middle bar.