### PR TITLE
remove dependency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,6 @@
 name: ci
 on: [push, pull_request]
 jobs:
-  check-dependencies:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: latest
-      - run: yarn && yarn check && yarn check --integrity && yarn check --verify-tree
   check-build:
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
This functionality doesn't exist in `npm` so the task needs to be disabled in order for CI to pass without relying on `yarn`.