### PR TITLE
remove duplicate build check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,6 @@
 name: ci
 on: [push, pull_request]
 jobs:
-  check-build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: latest
-      - run: npm install && npm run build
   lint-js:
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
Contrary to the conclusion that led to restoring it recently in pull request #413, the `check-build` job _should_ be removed, albeit for a completely different reason: because it's a duplicate of the `build` job.