### PR TITLE
change package manager in contributor documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ bisonica follows the API for [Vega Lite](https://vega.github.io/vega-lite/). Not
 
 # Documentation
 
-Internals are thoroughly documented with [JSDoc](https://jsdoc.app/). To build the documentation locally, run `yarn run documentation` and then view the generated HTML files in your web browser.
+Internals are thoroughly documented with [JSDoc](https://jsdoc.app/). To build the documentation locally, run `npm run documentation` and then view the generated HTML files in your web browser.
 
 # Architecture
 


### PR DESCRIPTION
A quick follow up to pull request #408 which changes the command for generating documentation as listed in `CONTRIBUTING.md` to match.