### PR TITLE
error handling helper function

### DIFF
--- a/source/error.js
+++ b/source/error.js
@@ -1,0 +1,6 @@
+const extendError = (error, addition) => {
+	error.message = `${addition} - ${error.message}`
+	throw error
+}
+
+export { extendError }

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -4,6 +4,7 @@
  */
 
 import * as d3 from 'd3'
+import { extendError } from './error.js'
 
 import { encodingField, encodingType, encodingValue } from './encodings.js'
 import { feature } from './feature.js'
@@ -241,8 +242,7 @@ const detach = (fn, ...rest) => {
 			selection.append(() => detached.node())
 		} catch (error) {
 			const identifier = fn.name ? `function ${fn.name}()` : 'function'
-			error.message = `could not run ${identifier} with detached <${tag}> node - ${error.message}`
-			throw error
+			extendError(error, `could not run ${identifier} with detached <${tag}> node`)
 		}
 	}
 }

--- a/source/legend.js
+++ b/source/legend.js
@@ -6,6 +6,7 @@
  */
 
 import * as d3 from 'd3'
+import { extendError } from './error.js'
 
 import { dispatchers } from './interactions.js'
 import { encodingField } from './encodings.js'
@@ -209,8 +210,7 @@ const swatch = s => {
 				dispatcher.on('removeLegendHighlight', removeLegendHighlight)
 			}
 		} catch (error) {
-			error.message = `could not render legend - ${error.message}`
-			throw error
+			extendError(error, 'could not render legend')
 		}
 	}
 

--- a/source/marks.js
+++ b/source/marks.js
@@ -7,6 +7,7 @@
 import './types.d.js'
 
 import * as d3 from 'd3'
+import { extendError } from './error.js'
 
 import { createAccessors } from './accessors.js'
 import {
@@ -890,8 +891,7 @@ const _marks = (s, dimensions) => {
 			throw new Error('could not determine mark rendering function')
 		}
 	} catch (error) {
-		error.message = `could not render marks - ${error.message}`
-		throw error
+		extendError(error, 'could not render marks')
 	}
 }
 const marks = (s, dimensions) => detach(_marks(s, dimensions))

--- a/source/predicate.js
+++ b/source/predicate.js
@@ -5,6 +5,8 @@
  * @see {@link https://vega.github.io/vega-lite/docs/predicate.html|vega-lite:predicate}
  */
 
+import { extendError } from './error.js'
+
 import { identity } from './helpers.js'
 import { memoize } from './memoize.js'
 import { expressionStringParse } from './expression.js'
@@ -124,8 +126,7 @@ const _predicate = config => {
 			return single(config)
 		}
 	} catch (error) {
-		error.message = `could not create predicate function - ${error.message}`
-		throw error
+		extendError(error, 'could not create predicate function')
 	}
 }
 const predicate = memoize(_predicate)

--- a/source/scales.js
+++ b/source/scales.js
@@ -9,6 +9,8 @@
 import './types.d.js'
 
 import * as d3 from 'd3'
+import { extendError } from './error.js'
+
 import { data, stackOffset, sumByCovariates } from './data.js'
 import { values } from './values.js'
 import { colors } from './color.js'
@@ -383,8 +385,7 @@ const range = (s, dimensions, _channel) => {
 
 		return range
 	} catch (error) {
-		error.message = `could not determine scale range for ${channel} channel - ${error.message}`
-		throw error
+		extendError(`could not determine scale range for ${channel} channel`)
 	}
 }
 
@@ -433,8 +434,7 @@ const coreScales = (s, dimensions) => {
 					scales[channel] = scale
 				}
 			} catch (error) {
-				error.message = `could not generate ${channel} scale - ${error.message}`
-				throw error
+				extendError(error, `could not generate ${channel} scale`)
 			}
 		})
 

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -6,6 +6,7 @@
  */
 
 import * as d3 from 'd3'
+import { extendError } from './error.js'
 
 import { category } from './marks.js'
 import { createAccessors } from './accessors.js'
@@ -87,8 +88,7 @@ function tooltipEvent(s, node, interaction) {
 
 		node.dispatchEvent(customEvent)
 	} catch (error) {
-		error.message = `could not emit tooltip event - ${error.message}`
-		throw error
+		extendError(error, 'could not emit tooltip event')
 	}
 }
 

--- a/source/values.js
+++ b/source/values.js
@@ -7,6 +7,8 @@
  */
 
 import * as d3 from 'd3'
+import { extendError } from './error.js'
+
 import { cached } from './fetch.js'
 import { identity, nested } from './helpers.js'
 import { transformValues } from './transform.js'
@@ -69,8 +71,7 @@ const wrap = arr => {
 				return { data: item }
 			})
 		} catch (error) {
-			error.message = `could not convert primitives to objects - ${error.message}`
-			throw error
+			extendError(error, 'could not convert primitives to objects')
 		}
 	}
 }

--- a/source/views.js
+++ b/source/views.js
@@ -7,8 +7,9 @@
 import './types.d.js'
 
 import * as d3 from 'd3'
-import { feature } from './feature.js'
+import { extendError } from './error.js'
 
+import { feature } from './feature.js'
 import { mark, noop } from './helpers.js'
 import { markSelector, marks } from './marks.js'
 import { memoize } from './memoize.js'
@@ -314,9 +315,7 @@ const layerMarks = (s, dimensions) => {
 					.call(marks(layer, changeDimensions ? temporalBarDimensions(barLayer, dimensions) : dimensions))
 			} catch (error) {
 				const markName = mark(layerSpecification(s, index))
-
-				error.message = `could not render ${markName} mark layer at index ${index} - ${error.message}`
-				throw error
+				extendError(error, `could not render ${markName} mark layer at index ${index}`)
 			}
 		})
 	}
@@ -349,8 +348,7 @@ const layerCall = (s, fn) => {
 			try {
 				selection.call(fn(layer))
 			} catch (error) {
-				error.message = `function ${fn.name} does not return a function for layer ${index} - ${error.message}`
-				throw error
+				extendError(error, `function ${fn.name} does not return a function for layer ${index}`)
 			}
 		})
 	}

--- a/tests/unit/error-test.js
+++ b/tests/unit/error-test.js
@@ -1,4 +1,5 @@
 import { chart } from '../../source/chart.js'
+import { extendError } from '../../source/error.js'
 import * as d3 from 'd3'
 import qunit from 'qunit'
 
@@ -24,6 +25,14 @@ module('unit > error handling', () => {
 		const renderer = chart(specification, dimensions).error(handler)
 		d3.create('div').call(renderer)
 		assert.ok(x instanceof Error)
+	})
+	test('extends errors', assert => {
+		const error = new Error('a')
+		try {
+			extendError(error, 'b')
+		} catch (error) {
+			assert.equal(error.message, 'b - a')
+		}
 	})
 	test('disables error handling', assert => {
 		const renderer = chart(specification).error(null)


### PR DESCRIPTION
So far the pattern of mutating error strings to append new information using multiple layers of error handling has made for a delightful debugging experience in which the library strives to explain what went wrong more precisely than the runtime error alone. However, up until now it has not been DRY, and instead the same handful of lines of error handling are rewritten several times across the library, anywhere an error might occur. This is fraught and error prone. We'll be better off with a reusable function.