### PR TITLE
require commit scopes

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -9,6 +9,7 @@ const config = {
         'references-empty': [0],
         'signed-off-by': [0],
         'scope-case': [2, 'always', 'lower-case'],
+        'scope-empty': [2, 'never'],
         'scope-enum': [2, 'always', ['core', 'tooling', 'tests', 'docs']],
         'type-enum': [2, 'always', ['chore', 'fix', 'feat']]
     },


### PR DESCRIPTION
Require commit messages to always include a scope in parentheses.

For example:

`feat(core): my cool new feature`

This would fail:

`feat: my new feature.