### PR TITLE
specification type

### DIFF
--- a/source/accessors.js
+++ b/source/accessors.js
@@ -15,7 +15,7 @@ import { parseTime } from './time.js'
 /**
  * generate accessor methods which can look up
  * data points for a particular chart type
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {mark} [type] mark type
  * @return {object} accessor methods
  */

--- a/source/audio.js
+++ b/source/audio.js
@@ -23,28 +23,28 @@ const defaults = {
 
 /**
  * root note for the musical scale
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {number} root frequency
  */
 const root = s => extension(s, 'audio')?.root || defaults.root
 
 /**
  * octaves spread which repeats the musical scale
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {number} number of octaves
  */
 const octaves = s => extension(s, 'audio')?.octaves || defaults.octaves
 
 /**
  * tempo
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {number} tempo in beats per minute
  */
 const tempo = s => extension(s, 'audio')?.tempo || defaults.tempo
 
 /**
  * note duration
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {number} note duration
  */
 const duration = s => 60 / tempo(s) / 2
@@ -89,7 +89,7 @@ const minorExponential = root => {
 
 /**
  * play a note
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {number} frequency audio frequency
  * @param {number} start start time
  */
@@ -115,7 +115,7 @@ const note = (s, frequency, start) => {
 
 /**
  * repeat a scale across octaves in linear data space
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {number} min minimum value
  * @param {number} max maximum value
  * @return {number[]} multiple octave data scale
@@ -137,7 +137,7 @@ const repeatLinear = (s, min, max) => {
 
 /**
  * repeat a scale across octaves in audio space
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {number} min minimum value
  * @param {number} max maximum value
  * @return {number[]} multiple octave audio scale
@@ -160,7 +160,7 @@ const repeatExponential = (s, min, max) => {
  * handle playback of musical notes
  * @param {object[]} values data values
  * @param {object} dispatcher interaction dispatcher
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  */
 const notes = (values, dispatcher, s) => {
 	const [min, max] = d3.extent(values, d => d.value)
@@ -180,7 +180,7 @@ const notes = (values, dispatcher, s) => {
 
 /**
  * audio sonification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} audio sonification function
  */
 const audio = s => {

--- a/source/axes.js
+++ b/source/axes.js
@@ -22,7 +22,7 @@ import { axisDescription } from './descriptions.js'
 
 /**
  * tick count specifier
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {number|function} tick count
  */
@@ -78,7 +78,7 @@ const ticks = (s, channel) => {
 
 /**
  * retrieve axis title
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel encoding channel
  * @return {string} title
  */
@@ -89,7 +89,7 @@ const axisTitle = (s, channel) => {
 
 /**
  * retrieve axis title and possibly truncate
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel encoding channel
  * @return {string} title text, potentially truncated
  */
@@ -101,7 +101,7 @@ const titleText = (s, channel) => {
 
 /**
  * render axis tick text content
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel encoding channel
  * @return {function(object)} tick text renderer
  */
@@ -120,7 +120,7 @@ const tickText = (s, channel) => {
 
 /**
  * axis positions
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function('x'|'y')} y axis positions
  */
@@ -153,7 +153,7 @@ const axisOffset = (s, dimensions) => {
 
 /**
  * create x axis
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} x axis creator
  */
@@ -199,7 +199,7 @@ const createX = (s, dimensions) => {
 
 /**
  * create y axis
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} y axis creator
  */
@@ -238,7 +238,7 @@ const createY = (s, dimensions) => {
 
 /**
  * render x axis title
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} x axis title renderer
  */
@@ -267,7 +267,7 @@ const axisTitleX = (s, dimensions) => {
 
 /**
  * render y axis title
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} y axis title renderer
  */
@@ -297,7 +297,7 @@ const axisTitleY = (s, dimensions) => {
  * determine whether a given axis should have axis
  * ticks that extend across the full data rectangle
  * to serve as grid lines
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel visual encoding channel
  */
 const hasGridLines = (s, channel) => {
@@ -311,7 +311,7 @@ const hasGridLines = (s, channel) => {
 
 /**
  * extend ticks across the chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} y axis tick extension adjustment function
  */
@@ -332,7 +332,7 @@ const axisTicksExtensionY = (s, dimensions) => {
 
 /**
  * extend ticks across the chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} x axis tick extension adjustment function
  */
@@ -355,7 +355,7 @@ const axisTicksExtensionX = (s, dimensions) => {
 
 /**
  * adjust y axis tick rotation based on a live DOM node
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} y axis tick rotation adjustment function
  */
@@ -376,7 +376,7 @@ const axisTicksRotationY = (s, dimensions) => {
 
 /**
  * adjust y axis tick rotation based on a live DOM node
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} x axis tick rotation adjustment function
  */
 const axisTicksRotationX = s => {
@@ -399,7 +399,7 @@ const axisTicksRotationX = s => {
 
 /**
  * adjust axis titles based on a live DOM node
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} axis title adjustment function
  */
@@ -412,7 +412,7 @@ const axisTitles = (s, dimensions) => {
 
 /**
  * adjust axis ticks based on a live DOM node
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} axis tick adjustment function
  */
@@ -441,7 +441,7 @@ const titleStyles = {
 
 /**
  * render style instructions for an axis title
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function(object)} title style rendering function
  */
@@ -455,7 +455,7 @@ const tickStyles = {
 
 /**
  * render style instructions for axis ticks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function(object)} tick style rendering function
  */
@@ -469,7 +469,7 @@ const axisTicksStyles = (s, channel) => {
 
 /**
  * run functions that require a live DOM node
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} axis adjustment function
  */

--- a/source/chart.js
+++ b/source/chart.js
@@ -29,7 +29,7 @@ import { select } from 'd3'
 /**
  * generate chart rendering function based on
  * a Vega Lite specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} [_panelDimensions] chart dimensions
  * @return {function(object)} renderer
  */
@@ -135,7 +135,7 @@ const render = (s, _panelDimensions) => {
 /**
  * convert a synchronous rendering function
  * into an asynchronous rendering function
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} asynchronous rendering function
  */
@@ -154,7 +154,7 @@ const asyncRender = (s, dimensions) => {
 /**
  * optionally fetch remote data, then create and run
  * a chart rendering function
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} [dimensions] chart dimensions
  * @return {function(object)} renderer
  */

--- a/source/color.js
+++ b/source/color.js
@@ -127,7 +127,7 @@ const scheme = (_count, config) => {
 
 /**
  * generate a categorical color scale
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {number} count number of colors
  */
 const colors = (s, count) => {

--- a/source/data.js
+++ b/source/data.js
@@ -26,7 +26,7 @@ import { values } from './values.js'
 
 /**
  * stack offset configuration
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} stack command
  */
 const stackOffset = s => s.encoding[encodingChannelQuantitative(s)].stack
@@ -106,7 +106,7 @@ const stackKeys = data => {
 
 /**
  * sum values across the time period specified on the x axis
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} values summed across time period
  */
 const sumByCovariates = s => {
@@ -153,7 +153,7 @@ const stackValue = (d, key) => d[key]?.value || 0
 /**
  * reorganize data from specification into array
  * of values used to render a stacked bar chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} stacked data series
  */
 const stackData = s => {
@@ -202,7 +202,7 @@ const stackData = s => {
 /**
  * reorganize data from specification into totals
  * used to render a circular chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} totals by group
  */
 const circularData = s => {
@@ -229,7 +229,7 @@ const circularData = s => {
 /**
  * reorganize data from a specification into
  * array of values used to render a line chart.
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} summed values for line chart
  */
 const lineData = s => {
@@ -262,21 +262,21 @@ const lineData = s => {
 
 /**
  * retrieve data points used for point marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} data points for point marks
  */
 const pointData = values
 
 /**
  * retrieve data points used for generic marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} data points for generic marks
  */
 const genericData = values
 
 /**
  * wrapper function around chart-specific data preprocessing functionality
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} sorted and aggregated data
  */
 const chartData = s => {
@@ -293,7 +293,7 @@ const chartData = s => {
 
 /**
  * wrapper function around data preprocessing functionality
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} sorted and aggregated data
  */
 const _data = s => {

--- a/source/defs.js
+++ b/source/defs.js
@@ -10,7 +10,7 @@ import { memoize } from './memoize.js'
 
 /**
  * create a defs node
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} defs rendering function
  */
 const _defs = s => {

--- a/source/descriptions.js
+++ b/source/descriptions.js
@@ -35,7 +35,7 @@ const quantitativeChannels = s => {
 /**
  * calculate minimum and maximum value for
  * each quantitative channel
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object} extents
  */
 const calculateExtents = s => {
@@ -83,7 +83,7 @@ const empty = () => ''
 /**
  * render descriptive text highlighting the minimum
  * and maximum values in the data set
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} extent description
  */
 const _extentDescription = s => {
@@ -112,7 +112,7 @@ const extentDescription = memoize(_extentDescription)
 
 /**
  * written description of the encodings of a chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} encoding description
  */
 const encodingDescription = s => {
@@ -151,7 +151,7 @@ const encodingDescription = s => {
 
 /**
  * render a description into the DOM
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} mark description renderer
  */
 const _markDescription = s => {
@@ -170,7 +170,7 @@ const markDescription = memoize(_markDescription)
 
 /**
  * chart type
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string|null} chart type
  */
 const chartType = s => {
@@ -199,7 +199,7 @@ const chartType = s => {
 
 /**
  * chart description
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} chart description
  */
 const chartDescription = s => {
@@ -220,7 +220,7 @@ const chartDescription = s => {
 
 /**
  * generate a string describing the keyboard navigation
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} instructions
  */
 const instructions = s => {
@@ -235,7 +235,7 @@ const instructions = s => {
 
 /**
  * chart name which includes title and subtitle
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} chart title
  */
 const chartLabel = s => {
@@ -250,7 +250,7 @@ const chartLabel = s => {
 
 /**
  * text description of axis values
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel encoding channel
  * @return {string} values description
  */
@@ -273,7 +273,7 @@ const scaleDescriptions = {
 
 /**
  * written description of a scale
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel encoding channel
  * @return {string} scale description
  */
@@ -293,7 +293,7 @@ const scaleDescription = (s, channel) => {
 
 /**
  * written description of an axis
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel encoding channel
  * @return {string} axis description
  */

--- a/source/dimensions.js
+++ b/source/dimensions.js
@@ -17,7 +17,7 @@ const channels = {
 
 /**
  * determine rendering size for chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {HTMLElement} node DOM node
  * @param {object} [explicitDimensions] chart dimensions
  * @return {dimensions} chart dimensions

--- a/source/download.js
+++ b/source/download.js
@@ -12,7 +12,7 @@ import { feature } from './feature.js'
 
 /**
  * render download links
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {'csv'|'json'} format data format
  * @return {string} download url
  */

--- a/source/encodings.js
+++ b/source/encodings.js
@@ -17,7 +17,7 @@ import { isTextChannel, nested } from './helpers.js'
 
 /**
  * look up the field used for a visual encoding
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string} encoding field
  */
@@ -28,7 +28,7 @@ const encodingField = (s, channel) => {
 /**
  * look up the data type used for an encoding in the s
  * (these are types of data sets, not JavaScript primitive types)
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {('nominal'|'ordinal'|'quantitative'|'temporal')} encoding type
  */
@@ -39,7 +39,7 @@ const encodingType = (s, channel) => {
 /**
  * create a function which looks up the data value used for
  * a visual encoding
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function(object)}
  */
@@ -61,7 +61,7 @@ const encodingValue = (s, channel) => {
 
 /**
  * determine which channel is used for quantitative encoding
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} encoding channel
  */
 const encodingChannelQuantitative = s => {
@@ -73,7 +73,7 @@ const encodingChannelQuantitative = s => {
 /**
  * create a function which looks up the data value used for
  * the quantitative visual encoding
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)}
  */
 const encodingValueQuantitative = s => {
@@ -82,7 +82,7 @@ const encodingValueQuantitative = s => {
 
 /**
  * default encoding types
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string} default encoding type
  */
@@ -131,7 +131,7 @@ const encodingTypeDefault = memoize(_encodingTypeDefault)
 
 /**
  * determine which channel matches a predicate function
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {function} test test
  * @return {string} encoding channel
  */
@@ -165,7 +165,7 @@ const encodingTest = memoize(_encodingTest)
 
 /**
  * determine which channel is used for the independent variable
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} encoding channel
  */
 const encodingChannelCovariate = s => {
@@ -190,7 +190,7 @@ const encodingChannelCovariate = s => {
 /**
  * determine which channel of a Cartesian specification object
  * is secondary to the quantitative channel
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {cartesian} encoding channel
  */
 const encodingChannelCovariateCartesian = s => {
@@ -207,7 +207,7 @@ const encodingChannelCovariateCartesian = s => {
 /**
  * determine which channel of a Cartesian specification object
  * is the primary quantitative channel
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {cartesian} encoding channel
  */
 const encodingChannelQuantitativeCartesian = s => {
@@ -224,7 +224,7 @@ const encodingChannelQuantitativeCartesian = s => {
 /**
  * bundle together an accessor and an encoder function
  * into an encoder function
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @param {function} accessor accessor function
  * @param {dimensions} dimensions chart dimensions
@@ -278,7 +278,7 @@ const encoder = memoize(_encoder)
 
 /**
  * generate a set of complex encoders
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} dimensions chart dimensions
  * @param {object} accessors hash of data accessor functions
  * @return {object} hash of encoder functions with complex data

--- a/source/extensions.js
+++ b/source/extensions.js
@@ -8,7 +8,7 @@ import './types.d.js'
 
 /**
  * retrieve information from usermeta
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {extension} key usermeta key
  */
 const extension = (s, key) => {
@@ -20,7 +20,7 @@ const extension = (s, key) => {
 /**
  * initialize usermeta object if it doesn't
  * already exist
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  */
 const usermeta = s => {
 	if (typeof s.usermeta !== 'object') {

--- a/source/feature.js
+++ b/source/feature.js
@@ -98,7 +98,7 @@ const _feature = s => {
 
 /**
  * use simple heuristics to determine features the chart type
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object} methods for boolean feature tests
  */
 const feature = memoize(_feature)

--- a/source/fetch.js
+++ b/source/fetch.js
@@ -39,7 +39,7 @@ const fetch = data => {
 
 /**
  * fetch and cache all remote resources for a specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  */
 const fetchAll = s => {
 	const resources = [

--- a/source/format.js
+++ b/source/format.js
@@ -75,7 +75,7 @@ const format = memoize(_format)
  *
  * this is only valid for text and tooltip channels; most of
  * the time the right choice is formatAxis
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {'text'|'tooltip'} channel encoding channel
  */
 const formatChannel = (s, channel) => {
@@ -88,7 +88,7 @@ const formatChannel = (s, channel) => {
  * this doesn't mean you're necessarily formatting axis ticks;
  * rather, it means the formatting instruction is taken from
  * the axis object, which is the most common scenario
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  */
 const formatAxis = (s, channel) => {

--- a/source/gradient.js
+++ b/source/gradient.js
@@ -8,7 +8,7 @@ import { key, noop } from './helpers.js'
 
 /**
  * assemble a string key for a gradient
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {number} [index] gradient index
  * @return {string} gradient id
  */
@@ -19,7 +19,7 @@ const gradientKey = (s, index = 0) => {
 
 /**
  * create a gradient
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} gradient definition rendering function
  */
 const gradient = s => {

--- a/source/helpers.js
+++ b/source/helpers.js
@@ -34,7 +34,7 @@ const capitalize = string => string[0].toUpperCase() + string.slice(1)
 /**
  * return the original data object if it has been nested
  * by a layout generator
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} d datum, which may or may not be nested
  * @return {object} datum
  */
@@ -78,7 +78,7 @@ const nested = function(d, key, newValue) {
 /**
  * create a function which ensures channels have
  * unique fields
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(array)} deduplication function
  */
 const deduplicateByField = s => {
@@ -110,7 +110,7 @@ const missingSeries = () => '_'
 
 /**
  * look up the URL attached to a datum
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} d datum, which may or may not be nested
  * @return {string} url
  */
@@ -128,7 +128,7 @@ const getUrl = (s, d) => {
 /**
  * look up the mark name from either a simple string
  * or the type property of a mark specification object
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} mark name
  */
 const mark = s => {
@@ -183,7 +183,7 @@ const degrees = radians => (radians * 180) / Math.PI
 
 /**
  * test whether a channel is continuous
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {boolean}
  */
@@ -193,7 +193,7 @@ const isContinuous = (s, channel) => {
 
 /**
  * test whether a channel is discrete
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {boolean}
  */

--- a/source/interactions.js
+++ b/source/interactions.js
@@ -20,7 +20,7 @@ const charts = d3.local()
 
 /**
  * events to listen for
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string[]} list of event names
  */
 const events = s => {
@@ -49,7 +49,7 @@ const events = s => {
 /**
  * events to listen for
  * @param {object} node parent node
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  */
 const initializeInteractions = (node, s) => {
 	const dispatcher = d3.dispatch(...(events(s) || []))
@@ -61,7 +61,7 @@ const initializeInteractions = (node, s) => {
 
 /**
  * select nodes to manipulate with interactions
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} wrapper chart wrapper selection
  * @param {object} node current mark node
  * @return {object} nodes
@@ -83,7 +83,7 @@ const interactionTargets = (s, wrapper, node) => {
 
 /**
  * determine selectors to which interactions are attached
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} selector
  */
 const markMouseoverSelector = s => {
@@ -102,7 +102,7 @@ const handleUrl = url => {
 
 /**
  * attach event listeners to a layer
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} user interactions
  */
 const _interactions = s => {

--- a/source/keyboard.js
+++ b/source/keyboard.js
@@ -51,7 +51,7 @@ const x = {
 
 /**
  * generate a listener for an arrow key
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {('up'|'right'|'down'|'left')} direction arrow direction
  * @return {function(object)} key listener
  */

--- a/source/legend.js
+++ b/source/legend.js
@@ -43,7 +43,7 @@ function createLegendItem(config) {
 
 /**
  * look up the title of the legend
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} legend title
  */
 const legendTitle = s => {
@@ -52,7 +52,7 @@ const legendTitle = s => {
 
 /**
  * a string for identifiying the legend in the DOM
- * @param {object} s specification
+ * @param {specification} s specification
  * @return {string|null} legend title identifier string
  */
 const legendIdentifier = s => {
@@ -65,7 +65,7 @@ const legendIdentifier = s => {
 
 /**
  * generate a written description for the legend
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string} legend description
  */
 const legendDescription = s => {
@@ -98,14 +98,14 @@ const legendStyles = {
 
 /**
  * style the legend based on the specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} legend style renderer
  */
 const legendStyle = s => renderStyles(legendStyles, s.encoding?.color?.legend)
 
 /**
  * legend item configuration
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {number} index item in legend
  * @return {object} object describing the legend item
  */
@@ -122,7 +122,7 @@ const itemConfig = (s, index) => {
 
 /**
  * items to plot in swatch legend
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string[]} domain for legend
  */
 const swatches = s => {
@@ -134,7 +134,7 @@ const swatches = s => {
 
 /**
  * discrete swatch legend
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} renderer
  */
 const swatch = s => {

--- a/source/lifecycle.js
+++ b/source/lifecycle.js
@@ -14,7 +14,7 @@ import { fetchAll } from './fetch.js'
 
 /**
  * prepare the DOM of a specified element for rendering a chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} dimensions chart dimensions
  */
 const setupNode = (s, dimensions) => {

--- a/source/marks.js
+++ b/source/marks.js
@@ -35,7 +35,7 @@ const transparent = 0.001
 
 /**
  * aggregate and sort mark data
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} aggregated and sorted data for data join
  */
 const markData = s => {
@@ -71,7 +71,7 @@ const defaultSize = 30
 
 /**
  * partition dimensions into categorical steps
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {number} step size in pixels
  */
@@ -119,7 +119,7 @@ const step = memoize(_step)
 
 /**
  * compute bar width based on input data
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {number} bar width
  */
@@ -135,7 +135,7 @@ const barWidth = (s, dimensions) => {
 /**
  * retrieve the d3 curve factory function needed for the marks
  * in a specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  */
 const curve = s => {
 	const { interpolate } = s.mark
@@ -150,7 +150,7 @@ const curve = s => {
 
 /**
  * point mark tagName
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {'circle'|'rect'} point mark tag name
  */
 const pointMarkSelector = s => {
@@ -166,7 +166,7 @@ const pointMarkSelector = s => {
 
 /**
  * mark tagName
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {mark} tagName to use in DOM for mark
  */
 const markSelector = s => {
@@ -202,7 +202,7 @@ const markInteractionSelector = _s => {
 
 /**
  * determine which way marks are oriented
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  */
 const layoutDirection = s => {
 	if (encodingType(s, 'x') === 'quantitative') {
@@ -215,7 +215,7 @@ const layoutDirection = s => {
 /**
  * shuffle around mark encoders to
  * facilitate bidirectional layout
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {object} bar encoder methods
  */
@@ -237,7 +237,7 @@ const stackEncoders = (s, dimensions) => {
 
 /**
  * render a single bar chart mark
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} single mark renderer
  */
@@ -272,7 +272,7 @@ const barMark = (s, dimensions) => {
 
 /**
  * lane transform for all bar marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {string} transform
  */
@@ -299,7 +299,7 @@ const barMarksTransform = (s, dimensions) => {
 
 /**
  * render bar chart marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} bar renderer
  */
@@ -343,7 +343,7 @@ const barMarks = (s, dimensions) => {
 
 /**
  * assign encoders to area mark methods
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {object} area encoders
  */
@@ -369,7 +369,7 @@ const areaEncoders = (s, dimensions) => {
 
 /**
  * render area marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} area mark renderer
  */
@@ -413,7 +413,7 @@ const areaMarks = (s, dimensions) => {
 
 /**
  * render a circular point mark
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} circular point mark rendering function
  */
@@ -433,7 +433,7 @@ const pointMarkCircle = (s, dimensions) => {
 
 /**
  * render a square point mark
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} square point mark rendering function
  */
@@ -455,7 +455,7 @@ const pointMarkSquare = (s, dimensions) => {
 
 /**
  * render a single point mark
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} point rendering function
  */
@@ -488,7 +488,7 @@ const pointMark = (s, dimensions) => {
 
 /**
  * render image marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} image mark renderer
  */
@@ -521,7 +521,7 @@ const imageMarks = (s, dimensions) => {
 
 /**
  * render multiple point marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} points renderer
  */
@@ -576,7 +576,7 @@ const pointMarks = (s, dimensions) => {
 
 /**
  * render line chart marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} line renderer
  */
@@ -658,7 +658,7 @@ const maxRadius = dimensions => Math.min(dimensions.x, dimensions.y) * 0.5
 
 /**
  * render arc marks for a circular pie or donut chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} circular chart arc renderer
  */
@@ -714,7 +714,7 @@ const circularMarks = (s, dimensions) => {
 
 /**
  * determine orientation of rule marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {('diagonal'|'horizontal'|'vertical')} rule orientation
  */
 const ruleDirection = s => {
@@ -743,7 +743,7 @@ const ruleDirection = s => {
 
 /**
  * render rule marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} rule renderer
  */
@@ -790,7 +790,7 @@ const ruleMarks = (s, dimensions) => {
 
 /**
  * render text marks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} text mark renderer
  */
@@ -865,7 +865,7 @@ const textMarks = (s, dimensions) => {
 
 /**
  * select an appropriate mark renderer
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} mark renderer
  */

--- a/source/menu.js
+++ b/source/menu.js
@@ -12,7 +12,7 @@ import { download } from './download.js'
 
 /**
  * create a menu configuration object for a data download
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {'csv'|'json'} format data format
  * @return {object} menu item configuration object
  */
@@ -22,7 +22,7 @@ const item = (s, format) => {
 
 /**
  * determine menu content
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} menu item configuration objects
  */
 const items = s => {
@@ -37,7 +37,7 @@ const items = s => {
 
 /**
  * render menu
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} menu renderer
  */
 const menu = s => {

--- a/source/metadata.js
+++ b/source/metadata.js
@@ -13,7 +13,7 @@ const metadataChannels = ['description', 'tooltip', 'href']
 
 /**
  * test whether a specification has metadata
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {boolean}
  */
 const hasMetadata = s => {
@@ -34,7 +34,7 @@ const matchingFields = (a, b, fields) => {
 /**
  * create a function for looking up core encoding channels
  * and returning them as a string key suitable for indexing
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} convert datum to string key
  */
 const createKeyBuilder = s => {
@@ -47,7 +47,7 @@ const createKeyBuilder = s => {
 
 /**
  * determine which fields contain metadata
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  */
 const metadataFields = s => {
 	return metadataChannels
@@ -74,7 +74,7 @@ const pick = (object, fields) => {
 /**
  * determine which core encoding channels are
  * represented in a Vega Lite specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string[]} encoding channels
  */
 const coreEncodingChannels = s => {
@@ -91,7 +91,7 @@ const coreEncodingChannels = s => {
 /**
  * fields used to represent core
  * encoding channels
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string[]} encoding fields
  */
 const coreEncodingFields = s => {
@@ -100,7 +100,7 @@ const coreEncodingFields = s => {
 
 /**
  * count the metadata fields in a data set and look for conflicts
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object[]} data data set to count fields in
  * @param {function} createKey function to create a unique key per datum
  * @return {object} metadata fields indexed by core field values
@@ -131,7 +131,7 @@ const countFields = (s, data, createKey) => {
  * restructure a data point from aggregate data
  * for a circular chart to make it easier to find
  * the data fields of interest for comparison
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} item datum
  * @return {object} object with lookup fields at the top level
  */
@@ -157,7 +157,7 @@ const lookupCircular = (s, item) => {
  * looked up once externally and then passed into
  * this restructuring function as arguments instead
  * of being kept entirely inside this scope
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} series series key
  * @param {string} covariate covariate
  * @param {object} item datum
@@ -183,7 +183,7 @@ const lookupStack = (s, series, covariate, item) => {
  * looked up once externally and then passed into
  * this restructuring function as arguments instead
  * of being kept entirely inside this scope
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} series series key
  * @param {string} covariate covariate
  * @param {object} item datum
@@ -202,7 +202,7 @@ const lookupLine = (s, series, covariate, item) => {
 /**
  * move properties from an array of source
  * values to an aggregate
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object[]} aggregated aggregated data points
  * @param {object[]} raw individual data points
  * @return {object[]} aggregated data points with transplanted field attached
@@ -243,7 +243,7 @@ const transplantFields = (s, aggregated, raw) => {
 
 /**
  * transfer metadata from raw data points to aggregated data
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object[]} data aggregated data for data join
  * @return {object[]} aggregated data with metadata
  */

--- a/source/position.js
+++ b/source/position.js
@@ -33,7 +33,7 @@ const marginCircular = () => {
 
 /**
  * compute margin for Cartesian chart axis ticks
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object} partial margin convention object
  */
 const tickMargin = s => {
@@ -57,7 +57,7 @@ const tickMargin = s => {
 
 /**
  * compute margin for Cartesian chart axis title
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {{bottom: number, left: number}} partial margin convention object
  */
 const titleMargin = s => {
@@ -69,7 +69,7 @@ const titleMargin = s => {
 
 /**
  * compute margin for Cartesian chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {margin} margin convention object
  */
 const marginCartesian = s => {
@@ -105,14 +105,14 @@ const _margin = s => {
 
 /**
  * compute margin values based on chart type
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {margin} margin convention object
  */
 const margin = memoize(_margin)
 
 /**
  * transform string for positioning charts
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} positioning function
  */

--- a/source/scales.js
+++ b/source/scales.js
@@ -38,7 +38,7 @@ const syntheticScale = (scale, domain, range) => {
 
 /**
  * parse scale types which have been explicitly specified
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string|null}
  */
@@ -56,7 +56,7 @@ const explicitScale = (s, channel) => {
 
 /**
  * scale type lookup
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string} scale type
  */
@@ -67,7 +67,7 @@ const scaleType = (s, channel) => {
 /**
  * determine the d3 method name of the scale function to
  * generate for a given dimension of visual encoding
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string|null} d3 scale type
  */
@@ -104,7 +104,7 @@ const scaleMethod = (s, channel) => {
 
 /**
  * get the specified domain from a specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {array} domain
  */
@@ -122,7 +122,7 @@ const customDomain = (s, channel) => {
 
 /**
  * sanitize channel name
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {number} number of data categories
  */
@@ -148,7 +148,7 @@ const channelRoot = channel => {
 
 /**
  * determine whether a scale starts at zero
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {boolean} whether to start the scale at zero
  */
@@ -164,7 +164,7 @@ const zero = (s, channel) => {
 
 /**
  * baseline for an axis
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel visual encoding
  * @return {number[]}
  */
@@ -174,7 +174,7 @@ const baseline = (s, channel) => {
 
 /**
  * compute raw values for scale domain
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {number[]|string[]} domain
  */
@@ -241,7 +241,7 @@ const domainBaseValues = (s, channel) => {
 /**
  * adjust a domain by substituting explicit values
  * if they are included in the specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function(array)} domain adjustment function
  */
@@ -263,7 +263,7 @@ const adjustDomain = (s, channel) => {
 
 /**
  * sort the domain
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function(array)}
  */
@@ -277,7 +277,7 @@ const domainSort = (s, channel) => {
 
 /**
  * compute domain
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  */
 const domain = (s, channel) => {
@@ -286,7 +286,7 @@ const domain = (s, channel) => {
 
 /**
  * compute cartesian range
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel encoding channel
  * @return {function(object)} function which computes Cartesian range
  */
@@ -317,7 +317,7 @@ const cartesianRange = (s, channel) => {
 
 /**
  * compute scale range
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @param {string} _channel visual encoding
  * @return {number[]} range
@@ -392,7 +392,7 @@ const range = (s, dimensions, _channel) => {
 /**
  * generate scale functions described by the
  * specification's encoding section
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {object} hash of d3 scale functions
  */
@@ -449,7 +449,7 @@ const coreScales = (s, dimensions) => {
  * determine whether a specification describes a chart that
  * will require scale functions beyond the ones listed directly
  * in the s's encoding section
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string[]} additional scale functions required
  */
 const detectScaleExtensions = s => {
@@ -470,7 +470,7 @@ const detectScaleExtensions = s => {
 /**
  * generate additional necessary scale functions beyond those
  * described in the s's encoding section
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @param {object} scales a hash of the core scale functions
  * @return {object} hash of extended d3 scale functions
@@ -544,7 +544,7 @@ const _parseScales = (s, dimensions = defaultDimensions) => {
 
 /**
  * determine whether an encoding uses a time scale
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {boolean}
  */
@@ -554,7 +554,7 @@ const isTemporalScale = (s, channel) => {
 
 /**
  * determine whether an encoding uses an ordinal scale
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {boolean}
  */
@@ -564,7 +564,7 @@ const isOrdinalScale = (s, channel) => {
 
 /**
  * determine whether an encoding uses an ordinal scale
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {boolean}
  */
@@ -574,7 +574,7 @@ const isQuantitativeScale = (s, channel) => {
 
 /**
  * generate all scale functions necessary to render a s
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} [dimensions] chart dimensions
  * @return {object} hash of all necessary d3 scale functions
  */

--- a/source/sort.js
+++ b/source/sort.js
@@ -26,7 +26,7 @@ const isInverted = sort => {
 
 /**
  * look up sorting field
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string} encoding parameter
  */
@@ -57,7 +57,7 @@ const sortField = memoize(_sortField)
 
 /**
  * look up sorting direction
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string|null} sorting direction
  */
@@ -86,7 +86,7 @@ const sortOrder = memoize(_sortOrder)
 
 /**
  * look up the channel used for sorting
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string} encoding channel used for sorting
  */
@@ -97,7 +97,7 @@ const sortChannel = memoize(_sortChannel)
 
 /**
  * determine whether sort is ascending
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {boolean} sorting direction is ascending
  */
@@ -107,7 +107,7 @@ const isAscending = (s, channel) => {
 
 /**
  * determine whether sort is descending
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {boolean} sorting direction is descending
  */
@@ -117,7 +117,7 @@ const isDescending = (s, channel) => {
 
 /**
  * extract the values to sort and resolve repeated values
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {object[]} array of data values to be sorted
  */
@@ -174,7 +174,7 @@ const valuesToSort = (s, channel) => {
 
 /**
  * sort aggregated data for mark rendering
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function} sort comparator function
  */
 const _sortMarkData = s => {
@@ -198,7 +198,7 @@ const sortMarkData = memoize(_sortMarkData)
 
 /**
  * select sort comparator function
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string} sort comparator type
  */
@@ -225,7 +225,7 @@ const selectSorter = (s, channel) => {
 /**
  * select a simple comparator function to as part
  * of more elaborate sort functions
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function} sort comparator function
  */
@@ -241,7 +241,7 @@ const selectComparator = (s, channel) => {
 
 /**
  * wrapper for natural sort comparator
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function} natural sort comparator function
  */
@@ -255,7 +255,7 @@ const sortNatural = (s, channel) => {
 
 /**
  * field sort comparator
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function} field sort comparator function
  */
@@ -275,7 +275,7 @@ const sortByField = (s, channel) => {
 
 /**
  * encoding channel sort comparator
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function} encoding channel sort comparator function
  */
@@ -305,7 +305,7 @@ const sortByChannel = (s, channel) => {
 
 /**
  * array sort comparator
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function} array sort comparator function
  */
@@ -331,7 +331,7 @@ const sortNone = () => () => 0
 
 /**
  * create sort comparator function
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {function} sort comparator
  */

--- a/source/table.js
+++ b/source/table.js
@@ -21,7 +21,7 @@ const toggleSelector = '.menu [data-menu="table"] button'
 
 /**
  * create the outer DOM for the table
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} table setup function
  */
 const setup = s => {
@@ -35,14 +35,14 @@ const setup = s => {
 
 /**
  * column headers
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string[]} array of column names
  */
 const channels = s => deduplicateByField(s)(Object.keys(s.encoding))
 
 /**
  * column encoding fields
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string[]} array of column encoding fields
  */
 const fields = s => {
@@ -54,7 +54,7 @@ const fields = s => {
 
 /**
  * create an ordered datum for data binding
- * @param {object} s datum
+ * @param {specification} s datum
  * @return {function(object)} function to convert a datum into key/value pairs
  */
 const columnEntries = s => {
@@ -64,7 +64,7 @@ const columnEntries = s => {
 
 /**
  * render table header
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} header renderer
  */
 const header = s => {
@@ -85,7 +85,7 @@ const header = s => {
 
 /**
  * render table rows
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} rows renderer
  */
 const rows = s => {
@@ -119,7 +119,7 @@ const rows = s => {
 
 /**
  * compile options to pass to an external table renderer
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object} options for table rendering
  */
 const tableOptions = s => {
@@ -147,7 +147,7 @@ const table = (_s, options) => { // eslint-disable-line no-unused-vars
 
 /**
  * toggle the content from a graphic to a table
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {function} renderer custom table rendering function
  * @return {function(object)} table toggle interaction function
  */

--- a/source/text.js
+++ b/source/text.js
@@ -67,7 +67,7 @@ const fontStyles = node => {
 
 /**
  * abbreviate axis tick label text
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @param {cartesian} channel encoding channel
  * @return {function(string)} abbreviation function
@@ -97,7 +97,7 @@ const abbreviate = memoize(_abbreviate)
 
 /**
  * format axis tick label text
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel encoding channel
  * @return {function(string)} formatting function
  */
@@ -109,7 +109,7 @@ const format = (s, channel) => {
 
 /**
  * rotate axis tick label text
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {number} axis tick text rotation
  */
@@ -148,7 +148,7 @@ const truncate = memoize(_truncate)
 
 /**
  * process axis tick text content
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel axis dimension
  * @param {string} textContent text to process
  * @param {object} [styles] styles to incorporate when measuring text width
@@ -171,7 +171,7 @@ const axisTicksLabelTextContent = memoize(_axisTicksLabelTextContent)
 
 /**
  * compute margin values based on chart type
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object} longest axis tick label text length in pixels
  */
 const _longestAxisTickLabelTextWidth = s => {
@@ -207,7 +207,7 @@ const longestAxisTickLabelTextWidth = memoize(_longestAxisTickLabelTextWidth)
 
 /**
  * render axis tick text
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {cartesian} channel encoding channel
  * @return {function(object)} text processing function
  */

--- a/source/time.js
+++ b/source/time.js
@@ -108,7 +108,7 @@ const timeMethod = specifier => {
 
 /**
  * string key for controlling date functionality
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel temporal encoding channel
  */
 const timePeriod = (s, channel) => {
@@ -136,7 +136,7 @@ const timePeriod = (s, channel) => {
 /**
  * alter dimensions object to subtract the bar width
  * for a temporal bar chart
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {dimensions} chart dimensions with bar width offset
  */

--- a/source/tooltips.js
+++ b/source/tooltips.js
@@ -56,14 +56,14 @@ const _includedChannels = s => {
 
 /**
  * determine which encoding channels to include in a description
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {string[]} included channels
  */
 const includedChannels = memoize(_includedChannels)
 
 /**
  * dispatch a CustomEvent with a data point
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {SVGElement} node mark DOM node
  * @param {object} interaction event
  */
@@ -95,7 +95,7 @@ function tooltipEvent(s, node, interaction) {
 /**
  * render a tooltip
  * @param {object} selection D3 selection with a mark
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  */
 const tooltip = (selection, s) => {
 	if (!s.mark.tooltip || s.encoding.tooltip === null) {
@@ -107,7 +107,7 @@ const tooltip = (selection, s) => {
 
 /**
  * create a function to render all tooltips
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} tooltip rendering function
  */
 const tooltips = s => {
@@ -123,7 +123,7 @@ const tooltips = s => {
 
 /**
  * create a function to retrieve a tooltip field pair from a datum
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} type encoding parameter, field, or transform field
  * @return {function(object)} function
  */
@@ -187,7 +187,7 @@ const getTooltipField = memoize(_getTooltipField)
 
 /**
  * retrieve default fields for tooltip
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} default field content retrieval function
  */
 const _tooltipContentDefault = s => {
@@ -212,7 +212,7 @@ const _tooltipContentAll = s => {
 }
 /**
  * retrieve all datum fields for tooltip
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} d datum
  * @return {object[]} all field content
  */
@@ -220,7 +220,7 @@ const tooltipContentAll = memoize(_tooltipContentAll)
 
 /**
  * create a function to retrieve tooltip content
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} tooltip field data lookup function
  */
 const tooltipContentData = s => {
@@ -255,7 +255,7 @@ const tooltipContentData = s => {
 
 /**
  * create a function to render tooltip content
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function} tooltip content renderer
  */
 const _tooltipContent = s => {

--- a/source/transform.js
+++ b/source/transform.js
@@ -51,7 +51,7 @@ const composeCalculateTransforms = memoize(_composeCalculateTransforms)
 
 /**
  * create a function to run transforms on a single datum
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} transform function for a single datum
  */
 const transformDatum = s => {
@@ -74,7 +74,7 @@ const sample = n => {
 
 /**
  * run a filter transform
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} config transform configuration
  * @return {function(object[])} filter transform function
  */
@@ -127,7 +127,7 @@ const flatten = config => {
 
 /**
  * apply a single transform
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {object} config transform configuration
  * @param {object[]} data data set
  * @return {object[]} transformed data set
@@ -146,7 +146,7 @@ const applyTransform = (s, config, data) => {
 
 /**
  * create a function to run transforms on a data set
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object[])} transform function for a data set
  */
 const _transformValues = s => {

--- a/source/types.d.js
+++ b/source/types.d.js
@@ -1,4 +1,19 @@
 /**
+ * Vega Lite specification
+ * @typedef specification
+ * @property {object} title title
+ * @property {object} [description] description
+ * @property {object} data data
+ * @property {object} [datasets] datasets
+ * @property {object} encoding encoding parameters for chart graphics
+ * @property {object|string} mark mark for rendering chart
+ * @property {object} [transform] transforms
+ * @property {object} [usermeta] arbitrary extensions
+ * @property {object} [layer] layers
+ * @property {object} [facet] facets
+ */
+
+/**
  * chart dimensions
  * @typedef dimensions
  * @property {number} x horizontal dimension

--- a/source/values.js
+++ b/source/values.js
@@ -16,21 +16,21 @@ import { memoize } from './memoize.js'
 
 /**
  * get values from values property
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]|object}
  */
 const valuesInline = s => s.data.values || s.data
 
 /**
  * get values from datasets property based on name
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]}
  */
 const valuesTopLevel = s => s.datasets[s.data.name]
 
 /**
  * generate a data set
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} data
  */
 const valuesSequence = s => {
@@ -44,7 +44,7 @@ const valuesSequence = s => {
 
 /**
  * look up data values attached to specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]|object}
  */
 const valuesStatic = s => {
@@ -79,7 +79,7 @@ const wrap = arr => {
 /**
  * look up data from a nested object based on
  * a string of properties
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)}
  */
 const lookup = s => {
@@ -93,7 +93,7 @@ const lookup = s => {
 
 /**
  * get remote data from the cache
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} data set
  */
 const valuesCached = s => cached(s.data)
@@ -107,7 +107,7 @@ const parsers = {
 
 /**
  * convert field types in an input datum object
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object)} datum field parsing function
  */
 const parseFields = s => {
@@ -127,7 +127,7 @@ const parseFields = s => {
 /**
  * run all data transformation and utility functions
  * on an input data set
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {function(object[])} data processing function
  */
 const dataUtilities = s => {
@@ -138,7 +138,7 @@ const dataUtilities = s => {
 
 /**
  * look up data values
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @return {object[]} data set
  */
 const _values = s => {

--- a/source/views.js
+++ b/source/views.js
@@ -20,7 +20,7 @@ import { values } from './values.js'
 /**
  * determine whether encoding types can be shared
  * across layers
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {string} encoding type
  */
@@ -47,7 +47,7 @@ const emptyData = data => {
 
 /**
  * compute a unified set of scale values across all layers
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @param {'domain'|'range'} valueType value type
  * @return {array} unified set of scale values
@@ -100,7 +100,7 @@ const unionScaleValues = (s, channel, valueType) => {
 
 /**
  * compute a unified data domain across all layers
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {array} unified domain
  */
@@ -108,7 +108,7 @@ const unionDomains = (s, channel) => unionScaleValues(s, channel, 'domain')
 
 /**
  * compute a unified data range across all layers
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {string} channel encoding channel
  * @return {array} unified range
  */
@@ -116,7 +116,7 @@ const unionRanges = (s, channel) => unionScaleValues(s, channel, 'range')
 
 /**
  * test all layers with a predicate function
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {function} test predicate function
  * @return {boolean} recursive test result
  */
@@ -133,7 +133,7 @@ const layerTest = (s, test) => {
 /**
  * find the first root level or layer level specification
  * which matches a predicate function return it
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {function} test predicate function
  * @return {object} Vega Lite specification for a single layer
  */
@@ -222,7 +222,7 @@ const layerNode = (s, wrapper) => {
 /**
  * construct a specification equivalent to a
  * single layer of a multilayer specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {number} index index of the target layer
  * @return {object} Vega Lite specification for a single layer
  */
@@ -294,7 +294,7 @@ const layerSpecification = (s, index) => {
 
 /**
  * render layers of a specification
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {dimensions} dimensions chart dimensions
  * @return {function(object)} layer renderer
  */
@@ -324,7 +324,7 @@ const layerMarks = (s, dimensions) => {
 /**
  * recursively test a predicate function on root
  * level specification and any layers it contains
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {function} test predicate function
  * @return {boolean} recursive test result
  */
@@ -334,7 +334,7 @@ const layerTestRecursive = (s, test) => {
 
 /**
  * run a function with selection.call() across multiple layers
- * @param {object} s Vega Lite specification
+ * @param {specification} s Vega Lite specification
  * @param {function} fn function
  * @return {function(object)}
  */


### PR DESCRIPTION
Adds a [JSDoc `@typedef`](https://jsdoc.app/tags-typedef) for [Vega Lite specification objects](https://vega.github.io/vega-lite/docs/spec.html).