### PR TITLE
layer specification type

### DIFF
--- a/source/views.js
+++ b/source/views.js
@@ -18,6 +18,16 @@ import { temporalBarDimensions } from './time.js'
 import { values } from './values.js'
 
 /**
+ * a variant of a specification
+ * which represents a single layer
+ * among many
+ *
+ * this is only for internal use
+ * within views.js
+ * @typedef {object} layerSpecification
+ */
+
+/**
  * determine whether encoding types can be shared
  * across layers
  * @param {specification} s Vega Lite specification
@@ -135,7 +145,7 @@ const layerTest = (s, test) => {
  * which matches a predicate function return it
  * @param {specification} s Vega Lite specification
  * @param {function} test predicate function
- * @return {object} Vega Lite specification for a single layer
+ * @return {layerSpecification} Vega Lite specification for a single layer
  */
 const layerMatch = (s, test) => {
 	if (!s.layer && test(s)) {
@@ -155,7 +165,7 @@ const layerMatch = (s, test) => {
  * for global functionality like axes and margins across the
  * entire chart
  * @param {object} s Vega Lite specification
- * @return {object} layer specification
+ * @return {layerSpecification} layer specification
  */
 const _layerPrimary = s => {
 	if (!s.layer) {
@@ -224,7 +234,7 @@ const layerNode = (s, wrapper) => {
  * single layer of a multilayer specification
  * @param {specification} s Vega Lite specification
  * @param {number} index index of the target layer
- * @return {object} Vega Lite specification for a single layer
+ * @return {layerSpecification} Vega Lite specification for a single layer
  */
 const layerSpecification = (s, index) => {
 	if (index === undefined) {

--- a/source/views.js
+++ b/source/views.js
@@ -17,6 +17,8 @@ import { parseScales } from './scales.js'
 import { temporalBarDimensions } from './time.js'
 import { values } from './values.js'
 
+/* eslint-disable jsdoc/require-property */
+
 /**
  * a variant of a specification
  * which represents a single layer
@@ -26,6 +28,8 @@ import { values } from './values.js'
  * within views.js
  * @typedef {object} layerSpecification
  */
+
+/* eslint-enable jsdoc/require-property */
 
 /**
  * determine whether encoding types can be shared

--- a/source/views.js
+++ b/source/views.js
@@ -169,7 +169,7 @@ const layerMatch = (s, test) => {
  * for global functionality like axes and margins across the
  * entire chart
  * @param {object} s Vega Lite specification
- * @return {layerSpecification} layer specification
+ * @return {layerSpecification} Vega Lite specification for a single layer
  */
 const _layerPrimary = s => {
 	if (!s.layer) {


### PR DESCRIPTION
Adds a JSDoc `@typedef` for the individual `layerSpecification` objects which are peeled off from multilayer specifications for use inside `views.js`.