### PR TITLE
gracefully remove downloads

### DIFF
--- a/source/feature.js
+++ b/source/feature.js
@@ -62,7 +62,7 @@ const _feature = s => {
 		hasAxisTitleY: s => s.encoding?.y?.axis?.title !== null,
 		hasStaticText: s => s.mark?.text && !s.encoding?.text,
 		hasTable: s => s.usermeta?.table !== null,
-		hasDownload: s => s.usermeta?.download !== null,
+		hasDownload: s => s.usermeta?.download !== null && !!URL,
 		isCartesian: s => (s.encoding?.x && s.encoding?.y),
 		isLinear: s => (s.encoding?.x && !s.encoding?.y) || (s.encoding?.y && !s.encoding?.x),
 		isTemporal: () => isTemporal,


### PR DESCRIPTION
Pull request #425 was a nice start, but an even more graceful failure is possible in cases where the browser won't support data downloads: the feature test can be extended to indicate that the download is possible and the link to the download should never be rendered in the first place.