### PR TITLE
factor out reusable parts of internals testing

### DIFF
--- a/benchmarks/benchmarks.js
+++ b/benchmarks/benchmarks.js
@@ -1,5 +1,5 @@
 import bench from 'nanobench'
-import { specificationFixture, render } from '../tests/test-helpers.js'
+import { render } from '../tests/test-helpers.js'
 import { charts } from '../tests/unit/support.js'
 
 const count = 100
@@ -11,12 +11,11 @@ const bar = time => {
 	return bar
 }
 
-charts.forEach(chart => {
-	const specification = specificationFixture(chart)
-	bench(`${chart} × ${count}`, b => {
+Object.entries(charts).forEach(([name, s]) => {
+	bench(`${name} × ${count}`, b => {
 		b.start()
 		for (let i = 0; i < count; i++) {
-			render(specification)
+			render(s)
 		}
 		b.log(bar(b.elapsed()))
 		b.end()

--- a/tests/unit/internals-test.js
+++ b/tests/unit/internals-test.js
@@ -1,14 +1,10 @@
-import { dimensions, charts } from './support.js'
+import { dimensions, charts, internals } from './support.js'
 import qunit from 'qunit'
-import { createAccessors } from '../../source/accessors.js'
-import { parseScales } from '../../source/scales.js'
-import { createEncoders } from '../../source/encodings.js'
-import { data } from '../../source/data.js'
-import { feature } from '../../source/feature.js'
-import { marks } from '../../source/marks.js'
 import { specificationFixture } from '../test-helpers.js'
 
 const { module, test } = qunit
+
+const { feature, data, createAccessors, parseScales, createEncoders, marks } = internals
 
 module('unit > internals', () => {
 	test('feature()', assert => {

--- a/tests/unit/internals-test.js
+++ b/tests/unit/internals-test.js
@@ -1,4 +1,4 @@
-import { dimensions } from './support.js'
+import { dimensions, charts } from './support.js'
 import qunit from 'qunit'
 import { createAccessors } from '../../source/accessors.js'
 import { parseScales } from '../../source/scales.js'
@@ -9,19 +9,6 @@ import { marks } from '../../source/marks.js'
 import { specificationFixture } from '../test-helpers.js'
 
 const { module, test } = qunit
-
-const charts = [
-	'categoricalBar',
-	'circular',
-	'dotPlot',
-	'line',
-	'multiline',
-	'rules',
-	'scatterPlot',
-	'singleBar',
-	'stackedArea',
-	'temporalBar'
-]
 
 module('unit > internals', () => {
 	test('feature()', assert => {

--- a/tests/unit/internals-test.js
+++ b/tests/unit/internals-test.js
@@ -1,6 +1,5 @@
 import { dimensions, charts, internals } from './support.js'
 import qunit from 'qunit'
-import { specificationFixture } from '../test-helpers.js'
 
 const { module, test } = qunit
 
@@ -8,23 +7,23 @@ const { feature, data, createAccessors, parseScales, createEncoders, marks } = i
 
 module('unit > internals', () => {
 	test('feature()', assert => {
-		charts.forEach(chart => assert.equal(typeof feature(specificationFixture(chart)), 'object', chart))
+		Object.entries(charts).forEach(([chart, s]) => assert.equal(typeof feature(s), 'object', chart))
 	})
 	test('data()', assert => {
-		charts.forEach(chart => assert.ok(Array.isArray(data(specificationFixture(chart))), chart))
+		Object.entries(charts).forEach(([chart, s]) => assert.ok(Array.isArray(data(s)), chart))
 	})
 	test('createAccessors()', assert => {
-		charts.forEach(chart => assert.equal(typeof createAccessors(specificationFixture(chart)), 'object', chart))
+		Object.entries(charts).forEach(([chart, s]) => assert.equal(typeof createAccessors(s), 'object', chart))
 	})
 	test('parseScales()', assert => {
-		charts.forEach(chart => assert.equal(typeof parseScales(specificationFixture(chart)), 'object', chart))
+		Object.entries(charts).forEach(([chart, s]) => assert.equal(typeof parseScales(s), 'object', chart))
 	})
 	test('createEncoders()', assert => {
-		charts.forEach(chart => {
-			assert.equal(typeof createEncoders(specificationFixture(chart), dimensions, createAccessors(specificationFixture(chart))), 'object', chart)
+		Object.entries(charts).forEach(([chart, s]) => {
+			assert.equal(typeof createEncoders(s, dimensions, createAccessors(s)), 'object', chart)
 		})
 	})
 	test('marks()', assert => {
-		charts.forEach(chart => assert.equal(typeof marks(specificationFixture(chart), dimensions), 'function', chart))
+		Object.entries(charts).forEach(([chart, s]) => assert.equal(typeof marks(s, dimensions), 'function', chart))
 	})
 })

--- a/tests/unit/support.js
+++ b/tests/unit/support.js
@@ -4,8 +4,9 @@ import { createEncoders } from '../../source/encodings.js'
 import { data } from '../../source/data.js'
 import { feature } from '../../source/feature.js'
 import { marks } from '../../source/marks.js'
+import { specificationFixture } from '../test-helpers.js'
 
-const charts = [
+const chartNames = [
 	'categoricalBar',
 	'circular',
 	'dotPlot',
@@ -17,6 +18,10 @@ const charts = [
 	'stackedArea',
 	'temporalBar'
 ]
+
+const fixtures = chartNames.map(name => [name, specificationFixture(name)])
+
+const charts = Object.fromEntries(fixtures)
 
 const internals = {
 	createAccessors,

--- a/tests/unit/support.js
+++ b/tests/unit/support.js
@@ -1,4 +1,31 @@
-// import { timeFormat } from '../source/time.js';
+import { createAccessors } from '../../source/accessors.js'
+import { parseScales } from '../../source/scales.js'
+import { createEncoders } from '../../source/encodings.js'
+import { data } from '../../source/data.js'
+import { feature } from '../../source/feature.js'
+import { marks } from '../../source/marks.js'
+
+const charts = [
+	'categoricalBar',
+	'circular',
+	'dotPlot',
+	'line',
+	'multiline',
+	'rules',
+	'scatterPlot',
+	'singleBar',
+	'stackedArea',
+	'temporalBar'
+]
+
+const internals = {
+	createAccessors,
+	parseScales,
+	createEncoders,
+	data,
+	feature,
+	marks
+}
 
 const timeFormat = () => null
 
@@ -12,10 +39,10 @@ const datum = () => {
 	return { label: date, value: Math.random(), group: group() }
 }
 
-const generate_data = () => {
+const generateData = () => {
 	return Array.from({ length: 100 }).map(datum)
 }
 
 const dimensions = { x: 100, y: 100 }
 
-export { dimensions, groups, charts }
+export { generateData as data, dimensions, groups, charts, internals }

--- a/tests/unit/support.js
+++ b/tests/unit/support.js
@@ -12,10 +12,10 @@ const datum = () => {
 	return { label: date, value: Math.random(), group: group() }
 }
 
-const data = () => {
+const generate_data = () => {
 	return Array.from({ length: 100 }).map(datum)
 }
 
 const dimensions = { x: 100, y: 100 }
 
-export { data, dimensions, groups }
+export { dimensions, groups, charts }


### PR DESCRIPTION
From the internals tests, the chart names, corresponding specifications, and the list of internal functions are all potentially reusable, so it's better for them to be exports from the test support file instead of restricted to the file containing the tests.